### PR TITLE
fix: nil-store crash when domReady beats startup with a large mailbox

### DIFF
--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -26,8 +26,13 @@ type App struct {
 	log *slog.Logger
 
 	store *storage.DB
-	index *search.Index
-	sync  *configsync.Manager
+	// storeReady closes once startup has finished assigning (or failing to
+	// assign) store, giving domReady a happens-before edge before it reads
+	// store on its own goroutine - without it, the read is a data race even
+	// though a nil check keeps it from crashing.
+	storeReady chan struct{}
+	index      *search.Index
+	sync       *configsync.Manager
 	// defaultStateDir is the device's normal per-OS app-support directory,
 	// independent of an active configsync in-place folder. It is where the
 	// configsync markers live so they are discoverable regardless of which
@@ -48,8 +53,9 @@ type App struct {
 // events on.
 func newApp(version string) *App {
 	return &App{
-		log:     slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		version: version,
+		log:        slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		version:    version,
+		storeReady: make(chan struct{}),
 	}
 }
 
@@ -63,10 +69,12 @@ func (a *App) startup(ctx context.Context) {
 	store, dataDir, err := openStore(ctx)
 	if err != nil {
 		a.log.Error("open store", "err", err)
+		close(a.storeReady)
 		return
 	}
 	a.store = store
 	a.queue = outbox.NewQueue(store)
+	close(a.storeReady)
 
 	if defaultPath, pathErr := storage.DefaultPath(); pathErr == nil {
 		a.defaultStateDir = filepath.Dir(defaultPath)
@@ -103,8 +111,11 @@ func (a *App) startup(ctx context.Context) {
 
 // domReady is the wails OnDomReady hook. Native window calls (like the theme
 // setter) need the webview up first, so the initial theme is applied here
-// rather than in startup.
+// rather than in startup. It can run concurrently with startup (a large
+// mailbox can still be opening when the webview signals dom-ready), so it
+// waits for storeReady first to avoid racing on store.
 func (a *App) domReady(ctx context.Context) {
+	<-a.storeReady
 	a.applyNativeTheme(a.stringSetting(storage.SettingTheme, defaultTheme))
 }
 

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -293,9 +293,14 @@ type SettingResult struct {
 	Found bool   `json:"found"`
 }
 
-// stringSetting reads a string setting, returning def when unset or on error so
-// startup never fails on a missing preference.
+// stringSetting reads a string setting, returning def when unset, on error, or
+// if the store hasn't opened yet (domReady can fire before startup finishes
+// opening a large store, see app.go) so startup never fails on a missing
+// preference.
 func (a *App) stringSetting(key, def string) string {
+	if a.store == nil {
+		return def
+	}
 	value, err := a.store.Get(a.ctx, key)
 	if err != nil || value == "" {
 		return def
@@ -303,8 +308,12 @@ func (a *App) stringSetting(key, def string) string {
 	return value
 }
 
-// boolSetting reads a bool setting, returning def when unset or unparsable.
+// boolSetting reads a bool setting, returning def when unset, unparsable, or
+// if the store hasn't opened yet.
 func (a *App) boolSetting(key string, def bool) bool {
+	if a.store == nil {
+		return def
+	}
 	value, err := a.store.GetBool(a.ctx, key)
 	if err != nil {
 		return def
@@ -312,8 +321,12 @@ func (a *App) boolSetting(key string, def bool) bool {
 	return value
 }
 
-// intSetting reads an int setting, returning def when unset or unparsable.
+// intSetting reads an int setting, returning def when unset, unparsable, or if
+// the store hasn't opened yet.
 func (a *App) intSetting(key string, def int) int {
+	if a.store == nil {
+		return def
+	}
 	value, err := a.store.GetInt(a.ctx, key)
 	if err != nil {
 		return def


### PR DESCRIPTION
## Summary
- `domReady` calls `stringSetting` to apply the saved theme, which dereferences `a.store` without checking it's been set yet.
- `startup()` opens the store asynchronously; with a small/empty dev database this always finishes before Wails fires the dom-ready callback, but with a large real mailbox (tens of MB, plus a configsync full-restore copy) the callback can win the race, crashing the app on launch with a nil pointer dereference.
- Guards `stringSetting`/`boolSetting`/`intSetting` against a nil store, returning the default the same way they already do for a missing setting or a read error.

## Test plan
- [x] `go build ./...`, `go vet ./internal/desktop/...`
- [x] Reproduced the crash against a real (non-`PELTON_DEV`) profile with a large mailbox, confirmed the fix resolves it
- [ ] Manual smoke test of theme application on a fresh/empty profile (unaffected code path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed a Pelton startup crash by guarding preference readers against a nil/unopened store when `domReady` fires before `startup()` finishes initializing storage. `stringSetting`, `boolSetting`, and `intSetting` now immediately return their provided default when `a.store` is nil, matching the existing fallback behavior for unset/unreadable settings. Added a `storeReady` synchronization channel to coordinate startup and the Wails `domReady` hook, preventing the race entirely.

AI usage: Probably — the changes follow a clear, systematic “guard + readiness channel” pattern, but no explicit AI/CodeRabbit/agentic emoji or marker strings were found in the touched files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->