### PR TITLE
fix: date/time picker and send-later menu positioning under ui zoom

### DIFF
--- a/frontend/src/components/common/ContextMenu.svelte
+++ b/frontend/src/components/common/ContextMenu.svelte
@@ -7,6 +7,7 @@
   import { IconX } from '@tabler/icons-svelte'
   import { contextMenu, closeContextMenu, type MenuItem } from '../../stores/contextmenu'
   import { flagColors } from '../../theme/flagcolors'
+  import { currentUIScale } from '../../theme/theme'
   import { t } from '../../lib/i18n'
 
   let menuEl: HTMLDivElement
@@ -23,14 +24,8 @@
   // positioned in the zoomed layout space, so the raw coordinates land the menu
   // in the wrong place. convert cursor and viewport into layout space by dividing
   // by the scale (a no-op at 100%). offsetWidth/Height are already layout-space.
-  function uiScale(): number {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
-    const n = parseFloat(raw)
-    return n > 0 ? n : 1
-  }
-
   async function place(x: number, y: number): Promise<void> {
-    const scale = uiScale()
+    const scale = currentUIScale()
     const mx = x / scale
     const my = y / scale
     left = mx

--- a/frontend/src/components/common/DateTimePicker.svelte
+++ b/frontend/src/components/common/DateTimePicker.svelte
@@ -7,6 +7,7 @@
   // parsing/formatting untouched.
   import { tick } from 'svelte'
   import { IconCalendar, IconChevronLeft, IconChevronRight } from '@tabler/icons-svelte'
+  import { currentUIScale } from '../../theme/theme'
   import { t } from '../../lib/i18n'
 
   // the bound value: 'YYYY-MM-DD' in date mode, 'YYYY-MM-DDTHH:mm' in
@@ -20,6 +21,9 @@
 
   let open = false
   let triggerEl: HTMLButtonElement
+  let panelEl: HTMLDivElement
+  let panelLeft = 0
+  let panelTop = 0
   // 'days' is the normal month grid; 'years' is a scrollable year list opened
   // by clicking the month/year label, for jumping far without repeated
   // prev/next clicks (e.g. birthdays, old date ranges).
@@ -135,13 +139,48 @@
 
   async function openYearView(): Promise<void> {
     view = 'years'
-    await tick()
+    await positionPanel()
     yearListEl?.querySelector('.year.current')?.scrollIntoView({ block: 'center' })
   }
 
   function selectYear(y: number): void {
     viewYear = y
     view = 'days'
+    void positionPanel()
+  }
+
+  // positionPanel computes the panel's on-screen position from the trigger's
+  // and panel's own (already-rendered) rects, clamped to the viewport. the
+  // panel is `position: fixed` and placed by explicit coordinates rather than
+  // css anchoring so an ancestor with `overflow: hidden`/`auto` (settings
+  // pages, dropdown menus) never clips it - the same fix already used for the
+  // compose window's send-later menu.
+  //
+  // the app applies an interface zoom via css `zoom` on <html> (see
+  // ContextMenu.svelte). under zoom, getBoundingClientRect position (like
+  // pointer clientX/Y) stays in unscaled screen pixels while a `position:
+  // fixed` element is placed in the zoomed layout space, so raw rect values
+  // land the panel in the wrong place - dividing by the scale converts them
+  // (a no-op at 100%). offsetWidth/Height are already layout-space and must
+  // not be divided.
+  async function positionPanel(): Promise<void> {
+    await tick()
+    if (!triggerEl || !panelEl) {
+      return
+    }
+    const scale = currentUIScale()
+    const margin = 8
+    const triggerRect = triggerEl.getBoundingClientRect()
+    const triggerLeft = triggerRect.left / scale
+    const triggerBottom = triggerRect.bottom / scale
+    const panelW = panelEl.offsetWidth
+    const panelH = panelEl.offsetHeight
+    const vw = window.innerWidth / scale
+    const vh = window.innerHeight / scale
+    const maxLeft = vw - panelW - margin
+    const maxTop = vh - panelH - margin
+    panelLeft = Math.min(Math.max(triggerLeft, margin), Math.max(margin, maxLeft))
+    panelTop = Math.min(Math.max(triggerBottom + 4, margin), Math.max(margin, maxTop))
   }
 
   // weekday header letters, monday-first; the reference week (2023-01-02 was
@@ -266,6 +305,7 @@
     } else {
       open = true
       view = 'days'
+      void positionPanel()
     }
   }
 
@@ -294,7 +334,7 @@
   {#if open}
     <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
     <div class="scrim" on:click={close}></div>
-    <div class="panel">
+    <div class="panel" bind:this={panelEl} style={`left:${panelLeft}px; top:${panelTop}px`}>
       <div class="nav">
         <button
           type="button"
@@ -448,9 +488,7 @@
   }
 
   .panel {
-    position: absolute;
-    top: calc(100% + var(--space-1));
-    left: 0;
+    position: fixed;
     z-index: 301;
     width: 240px;
     padding: var(--space-3);

--- a/frontend/src/components/common/DateTimePicker.svelte
+++ b/frontend/src/components/common/DateTimePicker.svelte
@@ -5,10 +5,12 @@
   // datetime mode). all date math here is local wall-clock time, matching
   // what the native inputs produced, so callers keep their existing
   // parsing/formatting untouched.
-  import { tick } from 'svelte'
+  import { tick, createEventDispatcher } from 'svelte'
   import { IconCalendar, IconChevronLeft, IconChevronRight } from '@tabler/icons-svelte'
   import { currentUIScale } from '../../theme/theme'
   import { t } from '../../lib/i18n'
+
+  const dispatch = createEventDispatcher<{ confirm: void }>()
 
   // the bound value: 'YYYY-MM-DD' in date mode, 'YYYY-MM-DDTHH:mm' in
   // datetime mode (empty string means unset), same shape the native inputs
@@ -18,6 +20,11 @@
   export let mode: 'date' | 'datetime' = 'date'
   // forwarded to the trigger button so an external <label for=...> still works.
   export let id: string | undefined = undefined
+  // when set, a primary confirm button (e.g. "Schedule") is shown inside the
+  // panel; clicking it commits the value, closes the panel and dispatches
+  // `confirm`. only the compose send-later menu passes this, so the plain
+  // date/settings pickers keep their simple footer.
+  export let confirmLabel: string | undefined = undefined
 
   let open = false
   let triggerEl: HTMLButtonElement
@@ -313,6 +320,12 @@
     open = false
     triggerEl?.focus()
   }
+
+  function confirm(): void {
+    commit()
+    open = false
+    dispatch('confirm')
+  }
 </script>
 
 <div class="picker">
@@ -436,6 +449,12 @@
         <button type="button" class="link-btn" on:click={clear}>{$t('common.datePicker.clear')}</button>
         <button type="button" class="link-btn" on:click={pickToday}>{$t('common.datePicker.today')}</button>
       </div>
+
+      {#if confirmLabel}
+        <button type="button" class="confirm-btn" disabled={!selected} on:click={confirm}>
+          {confirmLabel}
+        </button>
+      {/if}
     </div>
   {/if}
 </div>
@@ -676,5 +695,22 @@
 
   .link-btn:hover {
     background: var(--surface-hover);
+  }
+
+  .confirm-btn {
+    width: 100%;
+    padding: var(--space-2);
+    border: none;
+    border-radius: var(--radius-control);
+    background: var(--accent);
+    color: var(--accent-fg);
+    font-size: var(--fz-label);
+    font-weight: var(--fw-medium);
+    cursor: pointer;
+  }
+
+  .confirm-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
   }
 </style>

--- a/frontend/src/components/compose/Compose.svelte
+++ b/frontend/src/components/compose/Compose.svelte
@@ -539,14 +539,13 @@
     {/each}
     <div class="send-custom">
       <label for={`send-custom-${session.id}`}>{$t('compose.sendLater.customLabel')}</label>
-      <div class="send-custom-row">
-        <div class="send-custom-picker">
-          <DateTimePicker id={`send-custom-${session.id}`} mode="datetime" bind:value={customSendValue} />
-        </div>
-        <button type="button" class="send-custom-go" disabled={!customSendValue} on:click={confirmCustomSend}>
-          {$t('compose.sendLater.schedule')}
-        </button>
-      </div>
+      <DateTimePicker
+        id={`send-custom-${session.id}`}
+        mode="datetime"
+        bind:value={customSendValue}
+        confirmLabel={$t('compose.sendLater.schedule')}
+        on:confirm={confirmCustomSend}
+      />
     </div>
   </div>
 {/if}
@@ -808,11 +807,16 @@
     position: fixed;
     inset: 0;
     z-index: 140;
+    /* the enclosing .compose-layer sets pointer-events: none and only restores
+       it on .compose; these siblings must opt back in or clicks fall through to
+       the compose controls behind them. */
+    pointer-events: auto;
   }
 
   .send-menu {
     position: fixed;
     z-index: 141;
+    pointer-events: auto;
     width: 260px;
     max-height: min(360px, calc(100vh - 2 * var(--space-5)));
     overflow-y: auto;
@@ -871,32 +875,6 @@
   .send-custom label {
     font-size: var(--fz-meta);
     color: var(--text-secondary);
-  }
-
-  .send-custom-row {
-    display: flex;
-    gap: var(--space-2);
-  }
-
-  .send-custom-picker {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .send-custom-go {
-    padding: var(--space-1) var(--space-3);
-    border: none;
-    border-radius: var(--radius-control);
-    background: var(--accent);
-    color: var(--accent-fg);
-    cursor: pointer;
-    font-weight: var(--fw-medium);
-    font-size: var(--fz-label);
-  }
-
-  .send-custom-go:disabled {
-    opacity: 0.5;
-    cursor: default;
   }
 
   .confirm-backdrop {

--- a/frontend/src/components/compose/Compose.svelte
+++ b/frontend/src/components/compose/Compose.svelte
@@ -24,6 +24,8 @@
   import EditorModeSwitch from './EditorModeSwitch.svelte'
   import EditorToolbar from './EditorToolbar.svelte'
   import AttachmentPicker from './AttachmentPicker.svelte'
+  import DateTimePicker from '../common/DateTimePicker.svelte'
+  import { currentUIScale } from '../../theme/theme'
   import { updateCompose, closeCompose, setComposeFullscreenDefault, type ComposeSession } from '../../stores/compose'
   import { signatures, signatureById, getAccountSignatures } from '../../stores/signatures'
   import type { Signature } from '../../lib/types'
@@ -51,6 +53,7 @@
   // the compose pane clips overflow.
   let sendMenuOpen = false
   let sendCaretEl: HTMLButtonElement
+  let sendMenuEl: HTMLDivElement
   let sendMenuLeft = 0
   let sendMenuTop = 0
   let customSendValue = ''
@@ -97,6 +100,9 @@
 
   // toggleSendMenu opens the menu anchored above the caret button (fixed
   // positioning, since the compose pane itself clips overflow) or closes it.
+  // position is computed after render, once the menu's own size is known, and
+  // clamped to the viewport so it never runs off-window regardless of where
+  // the compose pane (and its caret) happens to sit on screen.
   async function toggleSendMenu(): Promise<void> {
     if (sending) {
       return
@@ -107,10 +113,26 @@
     }
     sendMenuOpen = true
     await tick()
-    if (sendCaretEl) {
-      const rect = sendCaretEl.getBoundingClientRect()
-      sendMenuLeft = rect.right
-      sendMenuTop = rect.top - 8
+    if (sendCaretEl && sendMenuEl) {
+      // the app applies an interface zoom via css `zoom` on <html> (see
+      // ContextMenu.svelte): getBoundingClientRect position stays in unscaled
+      // screen pixels while a `position: fixed` element is placed in the
+      // zoomed layout space, so raw rect values must be divided by the scale
+      // (a no-op at 100%) before use as fixed left/top. offsetWidth/Height are
+      // already layout-space.
+      const scale = currentUIScale()
+      const margin = 8
+      const caretRect = sendCaretEl.getBoundingClientRect()
+      const caretRight = caretRect.right / scale
+      const caretTop = caretRect.top / scale
+      const menuW = sendMenuEl.offsetWidth
+      const menuH = sendMenuEl.offsetHeight
+      const vw = window.innerWidth / scale
+      const vh = window.innerHeight / scale
+      const maxLeft = vw - menuW - margin
+      const maxTop = vh - menuH - margin
+      sendMenuLeft = Math.min(Math.max(caretRight - menuW, margin), Math.max(margin, maxLeft))
+      sendMenuTop = Math.min(Math.max(caretTop - 8 - menuH, margin), Math.max(margin, maxTop))
     }
   }
 
@@ -505,6 +527,7 @@
     class="send-menu"
     role="menu"
     aria-label={$t('compose.sendLater.ariaLabel')}
+    bind:this={sendMenuEl}
     style={`left:${sendMenuLeft}px; top:${sendMenuTop}px`}
   >
     {#each formattedSendPresets as p}
@@ -517,7 +540,9 @@
     <div class="send-custom">
       <label for={`send-custom-${session.id}`}>{$t('compose.sendLater.customLabel')}</label>
       <div class="send-custom-row">
-        <input id={`send-custom-${session.id}`} type="datetime-local" bind:value={customSendValue} />
+        <div class="send-custom-picker">
+          <DateTimePicker id={`send-custom-${session.id}`} mode="datetime" bind:value={customSendValue} />
+        </div>
         <button type="button" class="send-custom-go" disabled={!customSendValue} on:click={confirmCustomSend}>
           {$t('compose.sendLater.schedule')}
         </button>
@@ -774,9 +799,11 @@
     cursor: default;
   }
 
-  /* the send-later menu is fixed-positioned (anchored to the caret button) and
-     rendered outside .compose so the pane's own overflow:hidden never clips
-     it. it opens upward, anchored by its bottom-right corner. */
+  /* the send-later menu is fixed-positioned and rendered outside .compose so
+     the pane's own overflow:hidden never clips it. left/top are computed in
+     toggleSendMenu from the menu's own measured size, clamped to the
+     viewport, so it stays fully on-screen regardless of where the compose
+     pane (and its caret) sits. */
   .send-menu-scrim {
     position: fixed;
     inset: 0;
@@ -786,7 +813,6 @@
   .send-menu {
     position: fixed;
     z-index: 141;
-    transform: translate(-100%, -100%);
     width: 260px;
     max-height: min(360px, calc(100vh - 2 * var(--space-5)));
     overflow-y: auto;
@@ -852,15 +878,9 @@
     gap: var(--space-2);
   }
 
-  .send-custom-row input {
+  .send-custom-picker {
     flex: 1;
     min-width: 0;
-    padding: var(--space-1) var(--space-2);
-    border: var(--hairline) solid var(--border-default);
-    border-radius: var(--radius-control);
-    background: var(--surface-raised);
-    color: var(--text-primary);
-    font: inherit;
   }
 
   .send-custom-go {

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -48,6 +48,18 @@ export function applyScale(scale: string): void {
   root.style.setProperty('--ui-scale', String(factor))
 }
 
+// currentUIScale reads back the factor applyScale last set, for any fixed-
+// positioned overlay that must convert screen/pointer coordinates into the
+// zoomed layout space (see ContextMenu.svelte's comment for why: css `zoom`
+// leaves clientX/Y and getBoundingClientRect position in unscaled screen
+// pixels while a `position: fixed` element is placed in zoomed layout space).
+// a no-op divisor at the default 100%.
+export function currentUIScale(): number {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue('--ui-scale')
+  const n = parseFloat(raw)
+  return n > 0 ? n : 1
+}
+
 // watchSystemTheme calls back whenever the os color scheme changes. the caller
 // should re-apply the theme only while the preference is "system". returns an
 // unsubscribe function.


### PR DESCRIPTION
## Summary
- The friendly date/time picker's popover and the compose window's send-later menu are `position: fixed`, positioned from `getBoundingClientRect()` coordinates. The app's interface-scale feature applies css `zoom` on `<html>` (`theme.ts`), and under `zoom`, rect/pointer coordinates stay in unscaled screen pixels while a `position: fixed` element is placed in the zoomed layout space (`ContextMenu.svelte` already had to work around exactly this). Raw rect values landed both popovers in the wrong place, which presented as unclickable buttons and clicks appearing to hit unrelated controls underneath.
- Extracted the scale-conversion helper `ContextMenu.svelte` already had into a shared `currentUIScale()` in `theme.ts`, and applied the same conversion in `DateTimePicker`'s `positionPanel()` and Compose's `toggleSendMenu()`.
- Also swaps the send-later "Custom time…" field from a native `<input type="datetime-local">` to the shared `DateTimePicker` component, for visual/behavioral consistency with the rest of the app (it was the last native date/time input left).

## Test plan
- [x] `pnpm run check`: clean
- [ ] Manual verification in the running app pending - this is a fresh fix based on root-cause analysis (matching `ContextMenu.svelte`'s established pattern), not yet confirmed to fully resolve the reported symptoms end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes zoom-related positioning issues for fixed UI popovers by introducing a shared `currentUIScale()` helper and using it where screen coordinates need to be converted into zoomed layout space.

- Added `currentUIScale()` in `theme.ts` to read the app’s UI scale from `--ui-scale`.
- Updated `DateTimePicker` to measure and place its panel with explicit fixed coordinates, compensating for zoom and clamping to the viewport.
- Updated the compose send-later menu positioning to use the shared scale helper and viewport clamping.
- Replaced the send-later “Custom time…” native `datetime-local` input with the shared `DateTimePicker` component for consistency.

Testing noted: `pnpm run check` passes; manual E2E verification is still pending.

AI usage: Very Likely. The change set and summaries show strong AI/agent involvement signals (AI-generated summaries, code-review tooling reference, polished automated-style descriptions), though there’s no direct proof it was fully agentic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->