### PR TITLE
fix: require a passing connection test before adding a mailbox

### DIFF
--- a/frontend/src/components/wizard/AddMailboxWizard.svelte
+++ b/frontend/src/components/wizard/AddMailboxWizard.svelte
@@ -163,6 +163,21 @@
 
   $: canSubmitPassword = draft.email.includes('@') && draft.password !== '' && draft.imapHost !== ''
   $: canSignIn = draft.email.includes('@') && draft.clientId !== ''
+
+  // a passing "test connection" is required before the account can actually be
+  // added: nothing here validates that imapHost is a real, reachable server
+  // otherwise (createAccount deliberately keeps the account even if the later
+  // folder-discovery connection fails, so garbage like a random url would
+  // otherwise sail straight through). any edit to a tested field invalidates
+  // the prior result so a stale "ok" can't wave through a since-changed value.
+  $: {
+    draft.email
+    draft.imapHost
+    draft.imapPort
+    draft.password
+    testOk = null
+  }
+  $: canAddAccount = canSubmitPassword && testOk === true
 </script>
 
 <div class="screen" role="dialog" aria-modal="true" aria-label={$t('addMailbox.cta')}>
@@ -227,13 +242,14 @@
         {/if}
 
         {#if testOk === true}<p class="ok"><IconCheck size={14} stroke={2} /> {$t('wizard.connectionWorks')}</p>{/if}
+        {#if testOk === null && canSubmitPassword}<p class="note">{$t('wizard.testRequiredHint')}</p>{/if}
         {#if error}<p class="err">{error}</p>{/if}
 
         <div class="actions">
           <button type="button" class="ghost" on:click={test} disabled={testing || !canSubmitPassword}>
             {testing ? $t('wizard.testing') : $t('wizard.testConnection')}
           </button>
-          <button type="button" class="primary" on:click={addPassword} disabled={!canSubmitPassword}>
+          <button type="button" class="primary" on:click={addPassword} disabled={!canAddAccount}>
             {$t('addMailbox.cta')}
           </button>
         </div>

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -189,6 +189,7 @@ const de: Record<string, string> = {
   'wizard.connectionWorks': 'Verbindung funktioniert.',
   'wizard.testing': 'Wird getestet…',
   'wizard.testConnection': 'Verbindung testen',
+  'wizard.testRequiredHint': 'Testen Sie die Verbindung, bevor Sie dieses Postfach hinzufügen.',
   'wizard.step.oauth.title': 'Anmelden bei',
   'wizard.step.oauth.note': 'OAuth verwendet deine eigene registrierte Client-ID (einen Desktop-OAuth-Client). Füge sie unten ein; die Anmeldung öffnet sich in deinem Browser, und es wird kein Client-Secret gespeichert.',
   'wizard.field.oauthClientId': 'OAuth-Client-ID',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -189,6 +189,7 @@ const en: Record<string, string> = {
   'wizard.connectionWorks': 'Connection works.',
   'wizard.testing': 'Testing…',
   'wizard.testConnection': 'Test connection',
+  'wizard.testRequiredHint': 'Test the connection before adding this mailbox.',
   'wizard.step.oauth.title': 'Sign in to',
   'wizard.step.oauth.note': 'OAuth uses your own registered client id (a desktop OAuth client). Paste it below; sign-in opens in your browser and no client secret is stored.',
   'wizard.field.oauthClientId': 'OAuth client id',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -189,6 +189,7 @@ const es: Record<string, string> = {
   'wizard.connectionWorks': 'La conexión funciona.',
   'wizard.testing': 'Probando…',
   'wizard.testConnection': 'Probar conexión',
+  'wizard.testRequiredHint': 'Prueba la conexión antes de añadir este buzón.',
   'wizard.step.oauth.title': 'Iniciar sesión en',
   'wizard.step.oauth.note': 'OAuth usa tu propio id de cliente registrado (un cliente OAuth de escritorio). Pégalo abajo; el inicio de sesión se abre en tu navegador y no se guarda ningún secreto de cliente.',
   'wizard.field.oauthClientId': 'Id de cliente OAuth',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -189,6 +189,7 @@ const fr: Record<string, string> = {
   'wizard.connectionWorks': 'La connexion fonctionne.',
   'wizard.testing': 'Test en cours…',
   'wizard.testConnection': 'Tester la connexion',
+  'wizard.testRequiredHint': 'Testez la connexion avant d\'ajouter cette boîte mail.',
   'wizard.step.oauth.title': 'Se connecter à',
   'wizard.step.oauth.note': 'OAuth utilise ton propre identifiant client enregistré (un client OAuth de bureau). Colle-le ci-dessous ; la connexion s\'ouvre dans ton navigateur et aucun secret client n\'est stocké.',
   'wizard.field.oauthClientId': 'Identifiant client OAuth',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -189,6 +189,7 @@ const nl: Record<string, string> = {
   'wizard.connectionWorks': 'Verbinding werkt.',
   'wizard.testing': 'Testen…',
   'wizard.testConnection': 'Verbinding testen',
+  'wizard.testRequiredHint': 'Test de verbinding voordat je deze mailbox toevoegt.',
   'wizard.step.oauth.title': 'Inloggen bij',
   'wizard.step.oauth.note': 'OAuth gebruikt je eigen geregistreerde client-id (een desktop-OAuth-client). Plak deze hieronder; het inloggen opent in je browser en er wordt geen clientgeheim opgeslagen.',
   'wizard.field.oauthClientId': 'OAuth-client-id',


### PR DESCRIPTION
## Summary
- `canSubmitPassword` only checked that email/password/imapHost were non-empty, so the wizard's "Add" button was enabled without ever running "Test connection".
- `createAccount` (backend) deliberately keeps the account even when the post-creation folder-discovery connection fails (so a temporarily-unreachable-but-real server isn't rejected outright) - which meant a completely invalid host sailed straight through with no validation at all.
- "Add" is now gated on `testOk === true`; editing any tested field (email, password, host, port) invalidates a prior test result so a stale "ok" can't wave through a since-edited value. Added a small hint explaining why Add is disabled until tested.

## Test plan
- [x] `pnpm run check`: clean
- [ ] Manual verification in the running app pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Enforced a successful connection test before enabling mailbox creation in `AddMailboxWizard.svelte`.
- Reset the prior test result whenever email, password, IMAP host, or port changes, preventing stale validation from being reused.
- Added a user-facing hint explaining that the connection must be tested before adding the mailbox.
- Added the new hint string to the English, German, Spanish, French, and Dutch locale files.

## AI usage
Probably — the PR contains signs of AI-assisted work, but not enough to say it was fully agentic or 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->