### PR TITLE
fix: detect the Linux system dark theme and match the Windows caption bar

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -443,6 +443,12 @@ export function setWindowTitle(title: string): void {
   void App.SetWindowTitle(title)
 }
 
+// setWindowTheme matches the native window chrome (the Windows caption bar) to
+// the resolved ui theme. No-op on macOS/Linux.
+export function setWindowTheme(dark: boolean): void {
+  void App.SetWindowTheme(dark)
+}
+
 // getUIPrefs returns all ui preferences with defaults applied server-side.
 export function getUIPrefs(): Promise<UIPrefs> {
   return App.GetUIPrefs()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -405,6 +405,13 @@ export function pickConfigSyncFolder(): Promise<string> {
   return App.PickConfigSyncFolder()
 }
 
+// systemColorScheme returns the OS dark/light preference ("dark" | "light"), or
+// "" when it cannot be determined. Only meaningful on Linux, where WebKitGTK
+// does not expose it to CSS prefers-color-scheme; elsewhere it returns "".
+export function systemColorScheme(): Promise<string> {
+  return App.SystemColorScheme()
+}
+
 export interface ConfigSyncFolderPeek {
   hasExistingData: boolean
   accountEmails: string[]

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -6,8 +6,8 @@
 
 import { writable } from 'svelte/store'
 import type { UIPrefs, ThemePref, DensityPref, EditorMode } from '../lib/types'
-import { getUIPrefs, setSetting, SettingKeys } from '../lib/api'
-import { applyTheme, applyDensity, applyAccent, applyScale, watchSystemTheme } from '../theme/theme'
+import { getUIPrefs, setSetting, SettingKeys, systemColorScheme } from '../lib/api'
+import { applyTheme, applyDensity, applyAccent, applyScale, watchSystemTheme, setSystemSchemeOverride } from '../theme/theme'
 import { setLocale, type Locale } from '../lib/i18n'
 
 // defaults match the backend defaults so the ui renders sanely even before the
@@ -74,6 +74,19 @@ function applyAll(p: UIPrefs): void {
 export async function initPrefs(): Promise<void> {
   const loaded = await getUIPrefs()
   prefs.set(loaded)
+
+  // on Linux the css prefers-color-scheme query never reports the desktop dark
+  // preference, so resolve it natively first; elsewhere this returns "" and the
+  // media query is used. done before applyAll so the first paint is correct.
+  try {
+    const scheme = await systemColorScheme()
+    if (scheme === 'dark' || scheme === 'light') {
+      setSystemSchemeOverride(scheme)
+    }
+  } catch {
+    // fall back to the media query
+  }
+
   applyAll(loaded)
 
   watchSystemTheme(() => {

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -6,8 +6,8 @@
 
 import { writable } from 'svelte/store'
 import type { UIPrefs, ThemePref, DensityPref, EditorMode } from '../lib/types'
-import { getUIPrefs, setSetting, SettingKeys, systemColorScheme } from '../lib/api'
-import { applyTheme, applyDensity, applyAccent, applyScale, watchSystemTheme, setSystemSchemeOverride } from '../theme/theme'
+import { getUIPrefs, setSetting, SettingKeys, systemColorScheme, setWindowTheme } from '../lib/api'
+import { applyTheme, applyDensity, applyAccent, applyScale, watchSystemTheme, setSystemSchemeOverride, resolveTheme } from '../theme/theme'
 import { setLocale, type Locale } from '../lib/i18n'
 
 // defaults match the backend defaults so the ui renders sanely even before the
@@ -60,9 +60,16 @@ const defaults: UIPrefs = {
 
 export const prefs = writable<UIPrefs>(defaults)
 
+// syncWindowChrome matches the native window chrome (the Windows caption bar) to
+// the resolved theme so it does not stay light under a dark ui.
+function syncWindowChrome(pref: ThemePref): void {
+  setWindowTheme(resolveTheme(pref) === 'dark')
+}
+
 // applyAll pushes the current preferences onto the document.
 function applyAll(p: UIPrefs): void {
   applyTheme(p.theme as ThemePref)
+  syncWindowChrome(p.theme as ThemePref)
   applyDensity(p.density as DensityPref)
   applyAccent(p.accent)
   applyScale(p.uiScale)
@@ -94,6 +101,7 @@ export async function initPrefs(): Promise<void> {
     prefs.subscribe((p) => (current = p))()
     if (current.theme === 'system') {
       applyTheme('system')
+      syncWindowChrome('system')
     }
   })
 }
@@ -105,6 +113,7 @@ export async function initPrefs(): Promise<void> {
 export function setTheme(theme: ThemePref): void {
   prefs.update((p) => ({ ...p, theme }))
   applyTheme(theme)
+  syncWindowChrome(theme)
   void setSetting(SettingKeys.theme, theme)
 }
 

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -8,8 +8,22 @@ import { applyAccent } from './accent'
 
 export { applyAccent }
 
+// systemSchemeOverride is set from a native probe at startup for platforms where
+// the css media query is unreliable (WebKitGTK on Linux never reports the
+// desktop dark preference). null means "trust the media query".
+let systemSchemeOverride: 'light' | 'dark' | null = null
+
+// setSystemSchemeOverride records the os color scheme resolved natively, so
+// resolveTheme('system') uses it instead of the (Linux-unreliable) media query.
+export function setSystemSchemeOverride(scheme: 'light' | 'dark' | null): void {
+  systemSchemeOverride = scheme
+}
+
 // prefersDark reports the current os color-scheme preference.
 function prefersDark(): boolean {
+  if (systemSchemeOverride) {
+    return systemSchemeOverride === 'dark'
+  }
   return window.matchMedia('(prefers-color-scheme: dark)').matches
 }
 

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -116,6 +116,8 @@ export function SetWindowTitle(arg1:string):Promise<void>;
 
 export function SnoozeMessage(arg1:number,arg2:string,arg3:boolean):Promise<void>;
 
+export function SystemColorScheme():Promise<string>;
+
 export function TestConnection(arg1:desktop.TestConnectionRequest):Promise<void>;
 
 export function TriggerConfigSync():Promise<desktop.ConfigSyncStatusDTO>;

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -112,6 +112,8 @@ export function SetSeen(arg1:number,arg2:boolean):Promise<void>;
 
 export function SetSetting(arg1:string,arg2:string):Promise<void>;
 
+export function SetWindowTheme(arg1:boolean):Promise<void>;
+
 export function SetWindowTitle(arg1:string):Promise<void>;
 
 export function SnoozeMessage(arg1:number,arg2:string,arg3:boolean):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -222,6 +222,10 @@ export function SetSetting(arg1, arg2) {
   return window['go']['desktop']['App']['SetSetting'](arg1, arg2);
 }
 
+export function SetWindowTheme(arg1) {
+  return window['go']['desktop']['App']['SetWindowTheme'](arg1);
+}
+
 export function SetWindowTitle(arg1) {
   return window['go']['desktop']['App']['SetWindowTitle'](arg1);
 }

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -230,6 +230,10 @@ export function SnoozeMessage(arg1, arg2, arg3) {
   return window['go']['desktop']['App']['SnoozeMessage'](arg1, arg2, arg3);
 }
 
+export function SystemColorScheme() {
+  return window['go']['desktop']['App']['SystemColorScheme']();
+}
+
 export function TestConnection(arg1) {
   return window['go']['desktop']['App']['TestConnection'](arg1);
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/wailsapp/wails/v2 v2.12.0
 	github.com/yuin/goldmark v1.8.2
@@ -50,7 +51,6 @@ require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/internal/desktop/bind_theme.go
+++ b/internal/desktop/bind_theme.go
@@ -1,0 +1,11 @@
+package desktop
+
+// SystemColorScheme reports the operating system's dark/light preference as
+// "dark" or "light", or "" when it cannot be determined. It exists because
+// WebKitGTK on Linux does not surface the desktop color-scheme to CSS's
+// prefers-color-scheme media query, so the frontend cannot detect dark mode on
+// its own there; it consults this and falls back to the media query (which is
+// correct on macOS and Windows) whenever this returns "".
+func (a *App) SystemColorScheme() string {
+	return detectSystemColorScheme()
+}

--- a/internal/desktop/bind_theme.go
+++ b/internal/desktop/bind_theme.go
@@ -1,5 +1,23 @@
 package desktop
 
+import wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+
+// SetWindowTheme matches the native window chrome (the Windows title/caption
+// bar) to the app's resolved theme, so a dark ui does not sit under a light
+// caption bar. It is a no-op on macOS and Linux, where Wails does not theme the
+// native chrome from the runtime; the frontend calls it whenever the resolved
+// theme changes.
+func (a *App) SetWindowTheme(dark bool) {
+	if a.ctx == nil {
+		return
+	}
+	if dark {
+		wailsruntime.WindowSetDarkTheme(a.ctx)
+	} else {
+		wailsruntime.WindowSetLightTheme(a.ctx)
+	}
+}
+
 // SystemColorScheme reports the operating system's dark/light preference as
 // "dark" or "light", or "" when it cannot be determined. It exists because
 // WebKitGTK on Linux does not surface the desktop color-scheme to CSS's

--- a/internal/desktop/system_color_scheme_linux.go
+++ b/internal/desktop/system_color_scheme_linux.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package desktop
+
+import "github.com/godbus/dbus/v5"
+
+// detectSystemColorScheme asks the XDG desktop portal for the freedesktop
+// "color-scheme" appearance setting, the same signal browsers use to resolve
+// prefers-color-scheme on Linux. It returns "dark", "light", or "" when the
+// preference is unset or the portal is unavailable. The session bus connection
+// is shared and must not be closed here.
+func detectSystemColorScheme() string {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return ""
+	}
+	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+
+	var v dbus.Variant
+	err = obj.Call("org.freedesktop.portal.Settings.ReadOne", 0, "org.freedesktop.appearance", "color-scheme").Store(&v)
+	if err != nil {
+		// older portals only expose Read, which wraps the value in an extra variant.
+		if err = obj.Call("org.freedesktop.portal.Settings.Read", 0, "org.freedesktop.appearance", "color-scheme").Store(&v); err != nil {
+			return ""
+		}
+	}
+
+	// unwrap any nested variants down to the concrete value.
+	for {
+		inner, ok := v.Value().(dbus.Variant)
+		if !ok {
+			break
+		}
+		v = inner
+	}
+
+	// 0 = no preference, 1 = prefer dark, 2 = prefer light.
+	switch scheme, _ := v.Value().(uint32); scheme {
+	case 1:
+		return "dark"
+	case 2:
+		return "light"
+	default:
+		return ""
+	}
+}

--- a/internal/desktop/system_color_scheme_other.go
+++ b/internal/desktop/system_color_scheme_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package desktop
+
+// detectSystemColorScheme returns "" on macOS and Windows, where the frontend's
+// prefers-color-scheme media query already reflects the OS setting; the caller
+// falls back to that. Only Linux (WebKitGTK) needs the native portal query.
+func detectSystemColorScheme() string {
+	return ""
+}


### PR DESCRIPTION
Two related native-theme fixes.

**Linux system dark theme** — WebKitGTK never maps the desktop dark preference onto CSS `prefers-color-scheme`, so "System" theme always resolved to light on Fedora/GNOME. A new `SystemColorScheme` binding queries the XDG desktop portal (`org.freedesktop.appearance` / `color-scheme`) over DBus (the same signal browsers use) and the frontend consults it before first paint, falling back to the media query where it returns "" (macOS/Windows). Build-tagged so DBus only compiles on Linux.

**Windows caption bar** — the native title bar stayed light under a dark UI. `SetWindowTheme` now calls `WindowSetDarkTheme`/`WindowSetLightTheme` to match the resolved theme (no-op on macOS/Linux).

Builds clean for host and linux/amd64. **Needs verification on Fedora (dark) and Windows (dark).** Note: the Linux native menu strip/decorations are GTK-drawn and not themeable through Wails; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)