### PR TITLE
feat: split the Mailbox menu into Mailbox and Mail, move Low Power Mode

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -43,6 +43,7 @@
     getMessage,
     downloadMessageOffline,
     archiveMessage,
+    setMailActionsEnabled,
   } from './lib/api'
   import { recordArchived } from './stores/undoarchive'
   import { onMailNew, onSyncState, onOutboxChanged, onMenu, type Unsubscribe } from './lib/events'
@@ -73,6 +74,10 @@
     listW = $prefs.listWidth
   }
   $: locked = $prefs.paneLocked
+
+  // the native Mail menu's message actions are only usable while a message is
+  // open; keep them greyed in step with the open message.
+  $: setMailActionsEnabled($openMessageId != null)
 
   // keep the native window title in sync with context: the open message's subject
   // when reading, otherwise the current folder/view name.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -436,6 +436,13 @@ export function setWindowTitle(title: string): void {
   void App.SetWindowTitle(title)
 }
 
+// setMailActionsEnabled greys out or restores the native Mail menu's message
+// actions; the app calls it as the open message changes so those items are only
+// selectable while a message is open.
+export function setMailActionsEnabled(enabled: boolean): void {
+  void App.SetMailActionsEnabled(enabled)
+}
+
 // getUIPrefs returns all ui preferences with defaults applied server-side.
 export function getUIPrefs(): Promise<UIPrefs> {
   return App.GetUIPrefs()

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -108,6 +108,8 @@ export function SetFlagColor(arg1:number,arg2:number):Promise<void>;
 
 export function SetFlagged(arg1:number,arg2:boolean):Promise<void>;
 
+export function SetMailActionsEnabled(arg1:boolean):Promise<void>;
+
 export function SetSeen(arg1:number,arg2:boolean):Promise<void>;
 
 export function SetSetting(arg1:string,arg2:string):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -214,6 +214,10 @@ export function SetFlagged(arg1, arg2) {
   return window['go']['desktop']['App']['SetFlagged'](arg1, arg2);
 }
 
+export function SetMailActionsEnabled(arg1) {
+  return window['go']['desktop']['App']['SetMailActionsEnabled'](arg1);
+}
+
 export function SetSeen(arg1, arg2) {
   return window['go']['desktop']['App']['SetSeen'](arg1, arg2);
 }

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TRC-Loop/Pelton/internal/outbox"
 	"github.com/TRC-Loop/Pelton/internal/search"
 	"github.com/TRC-Loop/Pelton/internal/storage"
+	"github.com/wailsapp/wails/v2/pkg/menu"
 )
 
 // App is the bound application object. Its exported methods form the api the
@@ -46,6 +47,10 @@ type App struct {
 	// embedded license data served to the about section on demand.
 	licenseManifest string
 	programLicense  string
+	// mailMenuItems are the native Mail-menu items that act on the open message;
+	// they start disabled and SetMailActionsEnabled toggles them as the frontend's
+	// open message changes.
+	mailMenuItems []*menu.MenuItem
 }
 
 // newApp creates the App with the build version. The heavy initialization

--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -39,28 +39,34 @@ func (a *App) buildMenu() *menu.Menu {
 	fileMenu.AddSeparator()
 	fileMenu.AddText("Export Message as PDF…", keys.CmdOrCtrl("p"), a.menuAction("export-pdf"))
 
-	// mailbox menu: sync, account management, and the message-level actions
-	// that make sense to reach without the mouse (or a memorized shortcut).
-	// Undo has no accelerator here since Cmd/Ctrl+Z is already handled by the
-	// app's own keydown handler (the undo-send/delete/archive chain); binding
-	// it again here would double-fire.
-	mailMenu := root.AddSubmenu("Mailbox")
-	mailMenu.AddText("Sync Now", keys.CmdOrCtrl("r"), a.menuAction("sync"))
-	mailMenu.AddSeparator()
-	mailMenu.AddText("Add Mailbox…", keys.CmdOrCtrl("m"), a.menuAction("add-mailbox"))
-	mailMenu.AddSeparator()
+	// mailbox menu: mailbox-level operations - syncing and adding accounts.
+	mailboxMenu := root.AddSubmenu("Mailbox")
+	mailboxMenu.AddText("Sync Now", keys.CmdOrCtrl("r"), a.menuAction("sync"))
+	mailboxMenu.AddSeparator()
+	mailboxMenu.AddText("Add Mailbox…", keys.CmdOrCtrl("m"), a.menuAction("add-mailbox"))
+
+	// mail menu: actions on the open message. Undo stays enabled (it undoes the
+	// last send/delete/archive, which needs no open message), but the message-
+	// level items below start disabled and are only enabled while a message is
+	// open (SetMailActionsEnabled, driven by the frontend's selection). Undo has
+	// no accelerator here since Cmd/Ctrl+Z is already handled by the app's own
+	// keydown handler; binding it again would double-fire.
+	mailMenu := root.AddSubmenu("Mail")
 	mailMenu.AddText("Undo", nil, a.menuAction("undo"))
 	mailMenu.AddSeparator()
-	mailMenu.AddText("Mark as Read", nil, a.menuAction("mark-read"))
-	mailMenu.AddText("Mark as Unread", nil, a.menuAction("mark-unread"))
-	mailMenu.AddText("Flag / Unflag", nil, a.menuAction("flag"))
-	mailMenu.AddText("Archive", nil, a.menuAction("archive"))
-	mailMenu.AddText("Delete Message", nil, a.menuAction("delete-message"))
-	mailMenu.AddSeparator()
-	mailMenu.AddText("Low Power Mode", nil, a.menuAction("toggle-low-power"))
+	a.mailMenuItems = []*menu.MenuItem{
+		mailMenu.AddText("Mark as Read", nil, a.menuAction("mark-read")),
+		mailMenu.AddText("Mark as Unread", nil, a.menuAction("mark-unread")),
+		mailMenu.AddText("Flag / Unflag", nil, a.menuAction("flag")),
+		mailMenu.AddText("Archive", nil, a.menuAction("archive")),
+		mailMenu.AddText("Delete Message", nil, a.menuAction("delete-message")),
+	}
+	for _, item := range a.mailMenuItems {
+		item.Disabled = true
+	}
 
-	// view menu: a reliable fullscreen toggle. the native green button can be
-	// inconsistent in some setups, so this guarantees the app can go fullscreen.
+	// view menu: a reliable fullscreen toggle (the native green button can be
+	// inconsistent in some setups) plus the low-power mode toggle.
 	viewMenu := root.AddSubmenu("View")
 	viewMenu.AddText("Toggle Fullscreen", keys.Combo("f", keys.CmdOrCtrlKey, keys.ControlKey), func(_ *menu.CallbackData) {
 		if wailsruntime.WindowIsFullscreen(a.ctx) {
@@ -69,6 +75,8 @@ func (a *App) buildMenu() *menu.Menu {
 			wailsruntime.WindowFullscreen(a.ctx)
 		}
 	})
+	viewMenu.AddSeparator()
+	viewMenu.AddText("Low Power Mode", nil, a.menuAction("toggle-low-power"))
 
 	// the standard edit menu gives copy/paste/select-all their native bindings,
 	// which the webview needs on macos to work in inputs and the mail body.
@@ -77,6 +85,18 @@ func (a *App) buildMenu() *menu.Menu {
 	}
 
 	return root
+}
+
+// SetMailActionsEnabled greys out or restores the Mail menu's message-level
+// items. The frontend calls it as its open message changes, so those actions are
+// only selectable while a message is actually open.
+func (a *App) SetMailActionsEnabled(enabled bool) {
+	for _, item := range a.mailMenuItems {
+		item.Disabled = !enabled
+	}
+	if a.ctx != nil {
+		wailsruntime.MenuUpdateApplicationMenu(a.ctx)
+	}
 }
 
 // menuAction returns a menu callback that emits the menu event with the given


### PR DESCRIPTION
The native "Mailbox" menu was overloaded. It is now split:

- **Mailbox** menu keeps mailbox-level operations (Sync Now, Add Mailbox).
- New **Mail** menu holds the message actions (Undo, Mark as Read/Unread, Flag, Archive, Delete). The message-level items start disabled and are only enabled while a message is open, driven by a new `SetMailActionsEnabled` binding the frontend calls as the open message changes. Undo stays enabled (it needs no open message).
- **Low Power Mode** moves out to the **View** menu.

Verified on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)