### PR TITLE
fix: show Settings in window title instead of last message

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -82,16 +82,22 @@
   // open; keep them greyed in step with the open message.
   $: setMailActionsEnabled($openMessageId != null)
 
-  // keep the native window title in sync with context: the open message's subject
-  // when reading, otherwise the current folder/view name.
-  $: updateWindowTitle($openMessageId, $selection, $messageList, $t)
+  // keep the native window title in sync with context: "Settings" while the
+  // settings screen is open, the open message's subject when reading, otherwise
+  // the current folder/view name.
+  $: updateWindowTitle(settingsOpen, $openMessageId, $selection, $messageList, $t)
   function updateWindowTitle(
+    inSettings: boolean,
     id: number | null,
     sel: typeof $selection,
     list: typeof $messageList,
     tFn: (key: string) => string,
   ): void {
     let title = 'Pelton'
+    if (inSettings) {
+      setWindowTitle(`${tFn('settings.title')} - Pelton`)
+      return
+    }
     if (id !== null) {
       const item = list.data?.items?.find((m) => m.id === id)
       if (item) {


### PR DESCRIPTION
While the settings screen is open, the native window title kept showing the last opened message's subject. Set it to the localized "Settings - Pelton" whenever settings is open, and restore the folder/message title on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)