### PR TITLE
feat: cosmetic demo mode via --potatoes-are-nice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ run: deps
 	wails generate module
 	PELTON_DEV=1 wails dev -ldflags "$(LDFLAGS)"
 
+# run the app in the cosmetic demo mode (--potatoes-are-nice): the ui fills with
+# fixed potato-themed sample data for website screenshots and never touches real
+# accounts, mail or the network. Same dev setup as `run`, just with the flag.
+nice-potatoes: deps
+	wails generate module
+	PELTON_DEV=1 wails dev -appargs "--potatoes-are-nice" -ldflags "$(LDFLAGS)"
+
 dev: run
 
 # alias kept for discoverability; identical to run.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -44,7 +44,9 @@
     downloadMessageOffline,
     archiveMessage,
     setMailActionsEnabled,
+    isDemoMode,
   } from './lib/api'
+  import { setDemoActive } from './lib/demo'
   import { recordArchived } from './stores/undoarchive'
   import { onMailNew, onSyncState, onOutboxChanged, onMenu, type Unsubscribe } from './lib/events'
   import { matchShortcut, comboHasModifier, type ShortcutAction } from './lib/shortcuts'
@@ -110,6 +112,11 @@
   }
 
   onMount(async () => {
+    // cosmetic demo mode (--potatoes-are-nice): flip the data layer to sample
+    // data before anything loads, so the whole ui fills with the potato inbox.
+    const demo = await isDemoMode().catch(() => false)
+    setDemoActive(demo)
+
     await initPrefs()
     await initSidebarState()
     await initComposePrefs()
@@ -119,13 +126,19 @@
     await loadSidebar()
     await loadOutbox()
 
-    // show the first-run onboarding until it has been completed once.
-    try {
-      const r = await getSetting(SettingKeys.onboarded)
-      onboardingOpen = !(r.found && r.value === 'true')
-    } catch {
-      // if the lookup fails, do not block the app with onboarding.
+    // in demo mode, skip onboarding and show a sync in progress for the screenshot.
+    if (demo) {
       onboardingOpen = false
+      syncing.set(true)
+    } else {
+      // show the first-run onboarding until it has been completed once.
+      try {
+        const r = await getSetting(SettingKeys.onboarded)
+        onboardingOpen = !(r.found && r.value === 'true')
+      } catch {
+        // if the lookup fails, do not block the app with onboarding.
+        onboardingOpen = false
+      }
     }
 
     unsubscribers.push(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,15 @@
 
 import * as App from '../../wailsjs/go/desktop/App'
 import { desktop } from '../../wailsjs/go/models'
+import {
+  isDemoActive,
+  demoAccounts,
+  demoFolders,
+  demoViews,
+  demoList,
+  demoMessage,
+  demoOutbox,
+} from './demo'
 import type {
   Account,
   Folder,
@@ -26,8 +35,17 @@ import type {
   AttachmentContent,
 } from './types'
 
+// isDemoMode reports whether the app launched in the cosmetic --potatoes-are-nice
+// screenshot mode; the frontend reads it once to switch the data layer to samples.
+export function isDemoMode(): Promise<boolean> {
+  return App.IsDemoMode()
+}
+
 // listAccounts returns every configured account.
 export function listAccounts(): Promise<Account[]> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoAccounts())
+  }
   return App.ListAccounts()
 }
 
@@ -50,11 +68,17 @@ export function deleteAccount(id: number): Promise<void> {
 
 // listFolders returns one account's full mailbox tree with counts.
 export function listFolders(accountId: number): Promise<Folder[]> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoFolders(accountId))
+  }
   return App.ListFolders(accountId)
 }
 
 // listUnifiedViews returns the cross-account views with aggregate counts.
 export function listUnifiedViews(): Promise<UnifiedView[]> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoViews())
+  }
   return App.ListUnifiedViews()
 }
 
@@ -64,6 +88,9 @@ export function listFolderMessages(
   limit: number,
   offset: number,
 ): Promise<MessageList> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoList())
+  }
   return App.ListMessages(
     new desktop.ListMessagesRequest({ kind: 'folder', folderId, view: '', limit, offset }),
   )
@@ -75,6 +102,9 @@ export function listViewMessages(
   limit: number,
   offset: number,
 ): Promise<MessageList> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoList())
+  }
   return App.ListMessages(
     new desktop.ListMessagesRequest({ kind: 'view', folderId: 0, view, limit, offset }),
   )
@@ -82,6 +112,9 @@ export function listViewMessages(
 
 // getMessage returns the full message with sanitized body and attachments.
 export function getMessage(id: number): Promise<MessageDetail> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoMessage(id))
+  }
   return App.GetMessage(id)
 }
 
@@ -181,6 +214,9 @@ export function deleteDraft(id: number): Promise<void> {
 
 // listOutbox returns the current outbox contents.
 export function listOutbox(): Promise<OutboxRow[]> {
+  if (isDemoActive()) {
+    return Promise.resolve(demoOutbox())
+  }
   return App.ListOutbox()
 }
 
@@ -252,6 +288,10 @@ export function removeImageAllow(kind: 'sender' | 'domain', value: string): Prom
 // under the configured fallback chain. empty means "no network source"; the ui
 // then draws a generated placeholder.
 export function senderPhotos(email: string): Promise<string[]> {
+  if (isDemoActive()) {
+    // demo mode stays offline: fall back to the generated avatars, no network.
+    return Promise.resolve([])
+  }
   return App.SenderPhotos(email)
 }
 

--- a/frontend/src/lib/demo.ts
+++ b/frontend/src/lib/demo.ts
@@ -1,0 +1,205 @@
+// demo.ts holds the fixed, potato-themed sample data for the cosmetic demo mode
+// (the --potatoes-are-nice flag). None of it touches the backend: when demo mode
+// is active the api layer returns this data instead of calling the store, so a
+// website screenshot shows a full, friendly inbox without any real account. It is
+// 100% cosmetic and never persists anything.
+
+import type {
+  Account,
+  Folder,
+  UnifiedView,
+  MessageList,
+  MessageSummary,
+  MessageDetail,
+  OutboxRow,
+} from './types'
+
+// demoActive is set once at startup from the backend IsDemoMode() flag.
+let demoActive = false
+
+/** setDemoActive records whether the app launched in demo mode. */
+export function setDemoActive(value: boolean): void {
+  demoActive = value
+}
+
+/** isDemoActive reports whether the api layer should serve sample data. */
+export function isDemoActive(): boolean {
+  return demoActive
+}
+
+// relative timestamps computed once so the list reads like a live inbox.
+const now = Date.now()
+const ago = (mins: number): string => new Date(now - mins * 60_000).toISOString()
+
+// the two sample mailboxes, both Pelton/potato themed.
+const accounts: Account[] = [
+  {
+    id: 1,
+    email: 'spud@pelton.email',
+    displayName: 'Spud McPelton',
+    imapHost: 'imap.pelton.email',
+    imapPort: 993,
+    smtpHost: 'smtp.pelton.email',
+    smtpPort: 465,
+  },
+  {
+    id: 2,
+    email: 'harvest@pelton-potato.island',
+    displayName: 'Potato Island Co-op',
+    imapHost: 'imap.pelton-potato.island',
+    imapPort: 993,
+    smtpHost: 'smtp.pelton-potato.island',
+    smtpPort: 465,
+  },
+]
+
+function foldersFor(accountId: number, inboxUnread: number, inboxTotal: number): Folder[] {
+  const f = (id: number, name: string, role: string, unread: number, total: number): Folder => ({
+    id,
+    accountId,
+    name,
+    imapPath: name,
+    delimiter: '/',
+    parentId: null,
+    role,
+    unreadCount: unread,
+    totalCount: total,
+    attributes: [],
+  })
+  const base = accountId * 100
+  return [
+    f(base + 1, 'Inbox', 'inbox', inboxUnread, inboxTotal),
+    f(base + 2, 'Sent', 'sent', 0, 128),
+    f(base + 3, 'Drafts', 'drafts', 0, 2),
+    f(base + 4, 'Archive', 'archive', 0, 512),
+    f(base + 5, 'Spam', 'junk', 1, 9),
+    f(base + 6, 'Trash', 'trash', 0, 24),
+  ]
+}
+
+const foldersByAccount: Record<number, Folder[]> = {
+  1: foldersFor(1, 6, 42),
+  2: foldersFor(2, 2, 21),
+}
+
+const views: UnifiedView[] = [
+  { key: 'inbox', label: 'Unified Inbox', unreadCount: 8, totalCount: 63 },
+  { key: 'flagged', label: 'Flagged', unreadCount: 0, totalCount: 2 },
+  { key: 'drafts', label: 'Drafts', unreadCount: 0, totalCount: 3 },
+  { key: 'sent', label: 'Sent', unreadCount: 0, totalCount: 256 },
+  { key: 'archive', label: 'Archive', unreadCount: 0, totalCount: 1024 },
+  { key: 'junk', label: 'Spam', unreadCount: 1, totalCount: 18 },
+  { key: 'trash', label: 'Trash', unreadCount: 0, totalCount: 48 },
+]
+
+// one summary builder so every row is consistent.
+function msg(
+  id: number,
+  fromName: string,
+  fromAddress: string,
+  subject: string,
+  snippet: string,
+  minsAgo: number,
+  opts: Partial<MessageSummary> = {},
+): MessageSummary {
+  return {
+    id,
+    accountId: 1,
+    folderId: 101,
+    accountEmail: 'spud@pelton.email',
+    folderName: 'Inbox',
+    subject,
+    fromName,
+    fromAddress,
+    snippet,
+    date: ago(minsAgo),
+    seen: true,
+    flagged: false,
+    hasAttachments: false,
+    pgp: '',
+    auth: '',
+    flagColor: 0,
+    offline: false,
+    snoozeUntil: '',
+    ...opts,
+  }
+}
+
+const messages: MessageSummary[] = [
+  msg(1, 'Marina Tuber', 'marina@pelton-potato.island', 'Q4 potato numbers', 'Here are the Q4 yield figures for the russet fields, up 12% on last quarter. Take a look before the board call.', 14, { seen: false, flagged: true, hasAttachments: true, flagColor: 1 }),
+  msg(2, 'Pelton Potato Island', 'hello@pelton-potato.island', 'Welcome to Potato Island 🥔', 'Thanks for joining the co-op! Here is everything you need to know about this season’s harvest, storage and market days.', 52, { seen: false }),
+  msg(3, 'Chip Mash', 'chip@fryco.potato', 'Re: Fryer maintenance schedule', 'Sounds good, let’s do Tuesday. I’ll bring the oil samples and the new baskets.', 96, {}),
+  msg(4, 'Yukon Gold', 'billing@goldseed.potato', 'Invoice #4048 — seed potatoes', 'Your order of 4,048 sacks of certified seed potatoes is confirmed and ready for pickup.', 130, { seen: false, hasAttachments: true }),
+  msg(5, 'Marina Tuber', 'marina@pelton-potato.island', 'Harvest festival — potato salad?', 'Are you bringing potato salad on Friday? I’ll handle the mash and the gravy boat.', 200, { flagged: true, flagColor: 3 }),
+  msg(6, 'Spud Weekly', 'news@spudweekly.potato', 'This week in potatoes', 'Blight watch, market prices, and a loving profile of the humble fingerling.', 320, {}),
+  msg(7, 'Dr. Solanum', 'research@tuberlab.potato', 'New blight-resistant variety', 'We’ve had very promising results with the Pelton-7 cultivar this season. Details inside.', 540, {}),
+  msg(8, 'Rosa Fingerling', 'rosa@peltonfarms.potato', 'North field irrigation is in', 'The drip lines are installed. Soil moisture looks perfect for the earlies.', 900, {}),
+  msg(9, 'Couch Potato', 'relax@sofa.potato', 'Movie night?', 'Bringing chips (the potato kind). You in for Friday after the festival?', 1500, {}),
+  msg(10, 'Pelton HR', 'people@pelton.email', 'Your potato-leave request', 'Approved! Enjoy the long weekend at the spud festival. Bring us back some fries.', 2600, {}),
+]
+
+// the shared casual "coworker about potatoes" body every message opens to.
+const sharedBodyHtml = `
+<div style="font-family: system-ui, sans-serif; font-size: 14px; line-height: 1.6; color: inherit;">
+  <p>Hey,</p>
+  <p>Quick one before standup — the potato shipment from the north field came in this morning and it is looking <strong>great</strong>. Marina says the Q4 russet numbers are up 12% on last quarter. \u{1F954}</p>
+  <p>Could you double-check the crate counts for <strong>Pelton Potato Island</strong> before we send the invoice? I think we are at about <strong>4,048 sacks</strong>, but the paperwork says 4,032.</p>
+  <p>Also — potato salad for the harvest festival on Friday? I’ll bring the spuds if you handle the dressing.</p>
+  <p>Cheers,<br />Marina</p>
+  <p style="color: #999; font-size: 12px;">Pelton Potato Island · Grown with love, mostly underground</p>
+</div>`.trim()
+
+/** demoSidebar returns the sample accounts, their folders and the unified views. */
+export function demoAccounts(): Account[] {
+  return accounts
+}
+
+export function demoFolders(accountId: number): Folder[] {
+  return foldersByAccount[accountId] ?? []
+}
+
+export function demoViews(): UnifiedView[] {
+  return views
+}
+
+/** demoList returns the sample inbox for any folder or view selection. */
+export function demoList(): MessageList {
+  return { messages, total: 63 }
+}
+
+/** demoMessage returns the shared potato body wrapped as the given message. */
+export function demoMessage(id: number): MessageDetail {
+  const summary = messages.find((m) => m.id === id) ?? messages[0]
+  return {
+    ...summary,
+    seen: true,
+    toAddresses: 'spud@pelton.email',
+    ccAddresses: '',
+    bodyPlain: 'Hey, quick one about the potato shipment...',
+    bodyHtmlSafe: sharedBodyHtml,
+    isHtml: true,
+    hasRemoteContent: false,
+    remoteAllowed: true,
+    remoteHosts: [],
+    attachments: summary.hasAttachments
+      ? [{ id: id * 10, filename: 'q4-potato-yields.xlsx', contentType: 'application/vnd.ms-excel', sizeBytes: 48213, inline: false }]
+      : [],
+  }
+}
+
+/** demoOutbox returns a single message frozen in the "sending" state, so the
+ * status bar shows an email on its way out. */
+export function demoOutbox(): OutboxRow[] {
+  return [
+    {
+      id: 9001,
+      accountId: 1,
+      recipients: ['marina@pelton-potato.island'],
+      state: 'sending',
+      attempts: 1,
+      lastError: '',
+      nextAttemptAt: '',
+      createdAt: ago(0),
+    },
+  ]
+}

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -54,6 +54,8 @@ export function ImportData(arg1:string,arg2:Array<string>):Promise<void>;
 
 export function InspectBackupFile():Promise<desktop.BackupInfoDTO>;
 
+export function IsDemoMode():Promise<boolean>;
+
 export function Licenses():Promise<string>;
 
 export function ListAccounts():Promise<Array<desktop.AccountDTO>>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -106,6 +106,10 @@ export function InspectBackupFile() {
   return window['go']['desktop']['App']['InspectBackupFile']();
 }
 
+export function IsDemoMode() {
+  return window['go']['desktop']['App']['IsDemoMode']();
+}
+
 export function Licenses() {
   return window['go']['desktop']['App']['Licenses']();
 }

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -51,6 +51,17 @@ type App struct {
 	// job without tearing down the whole app context.
 	dlMu     sync.Mutex
 	dlCancel context.CancelFunc
+
+	// demoMode is the purely-cosmetic screenshot mode (the --potatoes-are-nice
+	// flag): the frontend fills the ui with fixed sample data instead of reading
+	// real accounts and mail. It never touches the store or the network.
+	demoMode bool
+}
+
+// IsDemoMode reports whether the app was launched in the cosmetic demo mode. The
+// frontend reads it once at startup to decide whether to render sample data.
+func (a *App) IsDemoMode() bool {
+	return a.demoMode
 }
 
 // newApp creates the App with the build version. The heavy initialization
@@ -80,6 +91,14 @@ func (a *App) startup(ctx context.Context) {
 	a.store = store
 	a.queue = outbox.NewQueue(store)
 	close(a.storeReady)
+
+	// demo mode is purely cosmetic: the frontend renders fixed sample data, so we
+	// skip everything that would touch the network or mutate the store (sync, idle,
+	// the outbox worker, auto-update checks, download resume, migrations). the
+	// store still opens so bound calls do not error, but nothing runs against it.
+	if a.demoMode {
+		return
+	}
 
 	// the old config-sync feature could redirect the data directory into a synced
 	// folder ("in-place" mode). that feature is gone; if a device still has that

--- a/internal/desktop/run.go
+++ b/internal/desktop/run.go
@@ -23,6 +23,8 @@ type Config struct {
 	Version         string
 	LicenseManifest string
 	ProgramLicense  string
+	// DemoMode runs the app in the cosmetic screenshot mode (--potatoes-are-nice).
+	DemoMode bool
 }
 
 // Run constructs and runs the wails application. It returns wails.Run's error.
@@ -30,6 +32,7 @@ func Run(cfg Config) error {
 	app := newApp(cfg.Version)
 	app.licenseManifest = cfg.LicenseManifest
 	app.programLicense = cfg.ProgramLicense
+	app.demoMode = cfg.DemoMode
 
 	return wails.Run(&options.App{
 		Title:     "Pelton",

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ package main
 
 import (
 	"embed"
+	"os"
+	"slices"
 
 	"github.com/TRC-Loop/Pelton/internal/desktop"
 )
@@ -29,11 +31,17 @@ var programLicense string
 var version = "dev"
 
 func main() {
+	// --potatoes-are-nice launches a purely-cosmetic demo mode used for website
+	// screenshots: the ui shows fixed potato-themed sample data instead of real
+	// accounts and mail. Nothing else changes.
+	demoMode := slices.Contains(os.Args[1:], "--potatoes-are-nice")
+
 	if err := desktop.Run(desktop.Config{
 		Assets:          assets,
 		Version:         version,
 		LicenseManifest: licenseManifest,
 		ProgramLicense:  programLicense,
+		DemoMode:        demoMode,
 	}); err != nil {
 		println("Error:", err.Error())
 	}


### PR DESCRIPTION
Adds a purely-cosmetic demo mode for website screenshots, launched with the `--potatoes-are-nice` flag (or `make nice-potatoes`).

When active, the frontend fills the whole UI with fixed potato-themed sample data instead of reading real accounts and mail:
- Two Pelton/potato mailboxes with folder trees and counts.
- A unified inbox of ~10 potato emails (Marina's Q4 numbers, Pelton Potato Island, seed-potato invoices, harvest festival, ...). Every message opens to the same casual "coworker about potatoes" HTML body.
- A sync shown in progress in the status bar, and one email frozen in the "sending" state so the outbox indicator is visible.

It is genuinely offline and non-destructive:
- Backend: when `--potatoes-are-nice` is set, startup skips all background services (sync, IMAP idle, the outbox worker, auto-update checks, download resume, migrations). The store still opens so bound calls don't error, but nothing runs against it or the network.
- Frontend: the data functions and `senderPhotos` short-circuit to the samples/generated avatars, so no Gravatar/BIMI lookups either.

Nothing persists. Verified by running `make nice-potatoes`: the potato inbox renders with generated avatars and zero IMAP/network activity in the logs. `go build`, `go vet`-clean, and `svelte-check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a cosmetic, offline potato-themed demo mode enabled with `--potatoes-are-nice` or `make nice-potatoes`.

- Frontend serves fixed sample accounts, folders, messages, avatars, sync status, and outbox data.
- Backend skips network services and state-changing startup tasks while keeping the store available for bound calls.
- No real account data is accessed, persisted, or modified.
- Validation completed with `go build`, `go vet`, and `svelte-check`.

## AI usage

AI assistance is **Very Likely**, but the available change summary does not establish whether usage was 100% agentic or limited assistance. No definitive AI authorship indicators were confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->