### PR TITLE
fix: preserve email background colors so light text stays readable

### DIFF
--- a/internal/mailview/mailview.go
+++ b/internal/mailview/mailview.go
@@ -62,10 +62,25 @@ func buildPolicy(allowRemote bool) *bluemonday.Policy {
 	p.AllowImages()
 	p.AllowAttrs("width", "height", "alt", "title").OnElements("img")
 
-	// keep simple inline styling that mail relies on, without url() vectors.
+	// keep simple inline styling that mail relies on.
 	p.AllowAttrs("style").Globally()
-	p.AllowStyles("color", "background-color", "text-align", "font-weight",
-		"font-style", "text-decoration", "font-size", "margin", "padding").Globally()
+	// "background" (shorthand) and "background-color" are both kept: many emails
+	// design a dark section with light text and set the background this way. if
+	// only the text color survived and the background was stripped, that light
+	// text landed on our fixed white page and became unreadable. any remote
+	// background image a shorthand might carry is still blocked by the iframe CSP
+	// (img-src) when remote content is off, so keeping it does not leak.
+	p.AllowStyles("color", "background-color", "background", "text-align",
+		"font-weight", "font-style", "text-decoration", "font-size", "line-height",
+		"margin", "padding", "border", "border-color").Globally()
+
+	// the legacy bgcolor attribute is the other common way mail sets a section
+	// background (on the body and table cells); preserve it for the same
+	// readability reason, alongside <font color> so its paired text color stays
+	// with the background instead of falling back to our dark default.
+	p.AllowAttrs("bgcolor").OnElements("body", "table", "thead", "tbody", "tfoot", "tr", "td", "th")
+	p.AllowElements("font")
+	p.AllowAttrs("color", "face", "size").OnElements("font")
 
 	// tables are heavily used by html mail.
 	p.AllowTables()


### PR DESCRIPTION
Emails that design a section with light text on a dark background (very common in newsletters/marketing mail) were unreadable in Pelton: white-on-white. The sanitizer kept the text `color` but stripped the background, so the light text landed on our fixed white page. Apple Mail keeps the background, so it looked fine there.

Fix in the sanitizer policy (`internal/mailview`):
- Keep the `background` shorthand style (not just `background-color`).
- Keep the legacy `bgcolor` attribute on `body` and table elements (the other common way mail sets a section background).
- Keep `<font color>` so its text color stays paired with the background instead of falling back to our dark default (which would flip the problem to dark-on-dark).

Remote safety is unchanged: any remote background image a style might carry is still blocked by the iframe CSP (`img-src`) when remote content is off, and still triggers the "remote content blocked" banner. `go build`/`go vet` pass; verified with a sanitize test that `bgcolor`, `background:` and `<font color>` survive.