### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something in Pelton isn't working as expected
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: distro
+    attributes:
+      label: Linux distro and version
+      description: Only if you selected Linux above.
+      placeholder: e.g. Fedora 40
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: How did you install Pelton
+      options:
+        - macOS .dmg
+        - Windows installer (.exe/NSIS)
+        - Fedora Copr (dnf copr enable + dnf install)
+        - Downloaded .rpm directly
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Pelton version
+      placeholder: e.g. v1.2.0
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste any relevant logs, stack traces, or screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea or improvement for Pelton
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: What are you trying to do that Pelton doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/localization_issue.yml
+++ b/.github/ISSUE_TEMPLATE/localization_issue.yml
@@ -1,0 +1,41 @@
+name: Localization issue
+description: Missing, incorrect, or untranslated text in Pelton
+labels: ["area: localization", "needs-triage"]
+body:
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options:
+        - German (de)
+        - English (en)
+        - Spanish (es)
+        - French (fr)
+        - Dutch (nl)
+        - Other / not listed
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Where in the app
+      description: Which screen, button, or message shows the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected or corrected text
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Screenshots, context on tone/register, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/packaging_issue.yml
+++ b/.github/ISSUE_TEMPLATE/packaging_issue.yml
@@ -1,0 +1,55 @@
+name: Packaging / installation issue
+description: Trouble installing, updating, or uninstalling Pelton (dnf, Copr, Windows installer, macOS .dmg, etc.)
+labels: ["area: packaging", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: Describe the install, update, or uninstall problem.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: distro
+    attributes:
+      label: Linux distro and version
+      description: Only if you selected Linux above.
+      placeholder: e.g. Fedora 40, openSUSE Tumbleweed
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: How did you (try to) install Pelton
+      options:
+        - macOS .dmg
+        - Windows installer (.exe/NSIS)
+        - Fedora Copr (dnf copr enable + dnf install)
+        - Downloaded .rpm directly
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Pelton version
+      placeholder: e.g. v1.2.0
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands run and their output
+      description: e.g. the exact dnf/rpm/installer commands and any error output.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Additional logs or screenshots


### PR DESCRIPTION
Adds structured GitHub issue forms: bug report, feature request, localization issue, packaging/installation issue, plus a `config.yml` disabling blank issues so reporters land in one of these forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds structured GitHub issue forms for bug reports, feature requests, localization issues, and packaging/installation problems. Blank issues are disabled so reporters use the appropriate form.

AI use: **Not Likely** based on the available repository evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->