### PR TITLE
feat: add website and docs links to About settings

### DIFF
--- a/frontend/src/components/settings/AboutSection.svelte
+++ b/frontend/src/components/settings/AboutSection.svelte
@@ -5,7 +5,7 @@
   // in-app webview.
   import { onDestroy, onMount } from 'svelte'
   import { createEventDispatcher } from 'svelte'
-  import { IconBrandGithub, IconBug, IconLicense, IconX, IconRefresh, IconUsers } from '@tabler/icons-svelte'
+  import { IconBrandGithub, IconBug, IconLicense, IconX, IconRefresh, IconUsers, IconWorld, IconBook2 } from '@tabler/icons-svelte'
   import { BrowserOpenURL } from '../../../wailsjs/runtime/runtime'
   import { APP } from '../../lib/app-info'
   import { appVersion, checkForUpdates, type UpdateCheckResult } from '../../lib/api'
@@ -87,6 +87,14 @@
   <p class="tagline">{APP.tagline}</p>
 
   <div class="links">
+    <button type="button" on:click={() => open(APP.website)}>
+      <IconWorld size={15} stroke={1.6} />
+      {$t('about.website')}
+    </button>
+    <button type="button" on:click={() => open(APP.docs)}>
+      <IconBook2 size={15} stroke={1.6} />
+      {$t('about.docs')}
+    </button>
     <button type="button" on:click={() => open(APP.repo)}>
       <IconBrandGithub size={15} stroke={1.6} />
       GitHub

--- a/frontend/src/lib/app-info.ts
+++ b/frontend/src/lib/app-info.ts
@@ -6,6 +6,8 @@ export const APP = {
   name: 'Pelton',
   version: '0.1.0',
   tagline: 'An open-source desktop mail client.',
+  website: 'https://pelton.app',
+  docs: 'https://docs.pelton.app',
   repo: 'https://github.com/TRC-Loop/Pelton',
   issues: 'https://github.com/TRC-Loop/Pelton/issues',
   contributors: 'https://github.com/TRC-Loop/Pelton/graphs/contributors',

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -283,6 +283,8 @@ const de: Record<string, string> = {
   'compose.toolbar.edit': 'Bearbeiten',
   'compose.toolbar.preview': 'Vorschau',
   'compose.toolbar.linkUrlPrompt': 'Link-URL',
+  'about.website': 'Website',
+  'about.docs': 'Dokumentation',
   'about.reportIssue': 'Problem melden',
   'about.contributors': 'Mitwirkende',
   'about.licenses': 'Open-Source-Lizenzen',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -283,6 +283,8 @@ const en: Record<string, string> = {
   'compose.toolbar.edit': 'Edit',
   'compose.toolbar.preview': 'Preview',
   'compose.toolbar.linkUrlPrompt': 'Link URL',
+  'about.website': 'Website',
+  'about.docs': 'Docs',
   'about.reportIssue': 'Report an issue',
   'about.contributors': 'Contributors',
   'about.licenses': 'Open-source licenses',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -283,6 +283,8 @@ const es: Record<string, string> = {
   'compose.toolbar.edit': 'Editar',
   'compose.toolbar.preview': 'Vista previa',
   'compose.toolbar.linkUrlPrompt': 'URL del enlace',
+  'about.website': 'Sitio web',
+  'about.docs': 'Documentación',
   'about.reportIssue': 'Reportar un problema',
   'about.contributors': 'Colaboradores',
   'about.licenses': 'Licencias de código abierto',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -283,6 +283,8 @@ const fr: Record<string, string> = {
   'compose.toolbar.edit': 'Modifier',
   'compose.toolbar.preview': 'Aperçu',
   'compose.toolbar.linkUrlPrompt': 'URL du lien',
+  'about.website': 'Site web',
+  'about.docs': 'Documentation',
   'about.reportIssue': 'Signaler un problème',
   'about.contributors': 'Contributeurs',
   'about.licenses': 'Licences open source',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -283,6 +283,8 @@ const nl: Record<string, string> = {
   'compose.toolbar.edit': 'Bewerken',
   'compose.toolbar.preview': 'Voorbeeld',
   'compose.toolbar.linkUrlPrompt': 'Link-URL',
+  'about.website': 'Website',
+  'about.docs': 'Documentatie',
   'about.reportIssue': 'Probleem melden',
   'about.contributors': 'Bijdragers',
   'about.licenses': 'Opensource licenties',


### PR DESCRIPTION
Adds Website (pelton.app) and Docs (docs.pelton.app) buttons next to the existing GitHub/Report an issue/Contributors links in Settings > About, opening in the system browser like every other link there.