### PR TITLE
feat: show a persistent developer mode indicator in the status bar

### DIFF
--- a/frontend/src/components/common/StatusBar.svelte
+++ b/frontend/src/components/common/StatusBar.svelte
@@ -3,15 +3,23 @@
   // clickable "N sending" that opens the outbox panel, plus a failed count. the
   // right side shows live sync state and the last-synced relative time. it is the
   // honest, always-visible window into background activity.
-  import { onDestroy } from 'svelte'
-  import { IconSend, IconAlertTriangle, IconRefresh, IconCheck, IconDownload, IconBatteryEco, IconX } from '@tabler/icons-svelte'
+  import { onDestroy, onMount } from 'svelte'
+  import { IconSend, IconAlertTriangle, IconRefresh, IconCheck, IconDownload, IconBatteryEco, IconX, IconBug } from '@tabler/icons-svelte'
   import { outbox, syncing, lastSynced } from '../../stores/outbox'
   import { downloadProgress, attachmentProgress } from '../../stores/progress'
   import { formatRelative } from '../../lib/format'
-  import { cancelDownload } from '../../lib/api'
+  import { cancelDownload, isDevMode } from '../../lib/api'
   import { prefs, setLowPowerMode } from '../../stores/prefs'
   import OutboxPanel from './OutboxPanel.svelte'
   import { t } from '../../lib/i18n'
+
+  // devMode is read once at startup: it's fixed for the lifetime of the
+  // process (set by the PELTON_DEV env var a dev run launches with), not
+  // something that can change while the app is open.
+  let devMode = false
+  onMount(async () => {
+    devMode = await isDevMode().catch(() => false)
+  })
 
   // format an eta in seconds as m:ss (or just seconds under a minute).
   function formatEta(sec: number): string {
@@ -50,6 +58,12 @@
 
 <footer class="statusbar">
   <div class="left">
+    {#if devMode}
+      <span class="dev-badge" title={$t('common.statusBar.devModeTitle')}>
+        <IconBug size={13} stroke={1.8} />
+        {$t('common.statusBar.devMode')}
+      </span>
+    {/if}
     {#if pending.length > 0 || failed.length > 0}
       <button type="button" class="outbox-btn" class:has-failed={failed.length > 0} on:click={() => (panelOpen = !panelOpen)}>
         {#if pending.length > 0}
@@ -280,6 +294,19 @@
     cursor: pointer;
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
+  }
+
+  .dev-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-control);
+    background: var(--danger-bg, var(--warning-bg, var(--surface-sunken)));
+    color: var(--danger, var(--warning));
+    font-size: var(--fz-meta);
+    font-weight: var(--fw-semibold);
+    letter-spacing: 0.02em;
   }
 
   .low-power:hover {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -41,6 +41,13 @@ export function isDemoMode(): Promise<boolean> {
   return App.IsDemoMode()
 }
 
+// isDevMode reports whether the app is running against the separate dev data
+// directory (PELTON_DEV), so the ui can show a persistent reminder that this
+// isn't pointed at a real install.
+export function isDevMode(): Promise<boolean> {
+  return App.IsDevMode()
+}
+
 // listAccounts returns every configured account.
 export function listAccounts(): Promise<Account[]> {
   if (isDemoActive()) {

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -178,6 +178,8 @@ const de: Record<string, string> = {
   'common.statusBar.saving': 'Wird gespeichert',
   'common.statusBar.lowPowerTitle': 'Energiesparmodus ist aktiv: Automatische Synchronisierung und Massendownloads sind pausiert. Klicken zum Ausschalten.',
   'common.statusBar.lowPower': 'Energiesparmodus',
+  'common.statusBar.devMode': 'ENTWICKLERMODUS',
+  'common.statusBar.devModeTitle': 'Läuft mit dem Entwickler-Datenverzeichnis, nicht mit deinem echten Postfach.',
   'common.statusBar.syncing': 'Synchronisiert…',
   'common.statusBar.synced': 'Synchronisiert',
   'common.techBadges.encrypted': 'Verschlüsselt',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -178,6 +178,8 @@ const en: Record<string, string> = {
   'common.statusBar.saving': 'Saving',
   'common.statusBar.lowPowerTitle': 'Low power mode is on: auto-sync and bulk downloads are paused. Click to turn off.',
   'common.statusBar.lowPower': 'Low power',
+  'common.statusBar.devMode': 'DEVELOPER MODE',
+  'common.statusBar.devModeTitle': 'Running against the dev data directory, not your real mailbox.',
   'common.statusBar.syncing': 'Syncing…',
   'common.statusBar.synced': 'Synced',
   'common.techBadges.encrypted': 'Encrypted',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -178,6 +178,8 @@ const es: Record<string, string> = {
   'common.statusBar.saving': 'Guardando',
   'common.statusBar.lowPowerTitle': 'El modo de bajo consumo está activado: la sincronización automática y las descargas masivas están en pausa. Haz clic para desactivarlo.',
   'common.statusBar.lowPower': 'Bajo consumo',
+  'common.statusBar.devMode': 'MODO DESARROLLADOR',
+  'common.statusBar.devModeTitle': 'Usando la carpeta de datos de desarrollo, no tu buzón real.',
   'common.statusBar.syncing': 'Sincronizando…',
   'common.statusBar.synced': 'Sincronizado',
   'common.techBadges.encrypted': 'Cifrado',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -178,6 +178,8 @@ const fr: Record<string, string> = {
   'common.statusBar.saving': 'Enregistrement',
   'common.statusBar.lowPowerTitle': 'Le mode basse consommation est activé : la synchronisation automatique et les téléchargements en masse sont en pause. Clique pour le désactiver.',
   'common.statusBar.lowPower': 'Basse consommation',
+  'common.statusBar.devMode': 'MODE DÉVELOPPEUR',
+  'common.statusBar.devModeTitle': "Utilise le dossier de données de développement, pas votre vraie boîte mail.",
   'common.statusBar.syncing': 'Synchronisation…',
   'common.statusBar.synced': 'Synchronisé',
   'common.techBadges.encrypted': 'Chiffré',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -178,6 +178,8 @@ const nl: Record<string, string> = {
   'common.statusBar.saving': 'Opslaan',
   'common.statusBar.lowPowerTitle': 'Energiebesparende modus staat aan: automatisch synchroniseren en bulkdownloads zijn gepauzeerd. Klik om uit te zetten.',
   'common.statusBar.lowPower': 'Energiebesparend',
+  'common.statusBar.devMode': 'ONTWIKKELMODUS',
+  'common.statusBar.devModeTitle': 'Draait op de ontwikkel-datamap, niet je echte mailbox.',
   'common.statusBar.syncing': 'Synchroniseren…',
   'common.statusBar.synced': 'Gesynchroniseerd',
   'common.techBadges.encrypted': 'Versleuteld',

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -56,6 +56,8 @@ export function InspectBackupFile():Promise<desktop.BackupInfoDTO>;
 
 export function IsDemoMode():Promise<boolean>;
 
+export function IsDevMode():Promise<boolean>;
+
 export function Licenses():Promise<string>;
 
 export function ListAccounts():Promise<Array<desktop.AccountDTO>>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -110,6 +110,10 @@ export function IsDemoMode() {
   return window['go']['desktop']['App']['IsDemoMode']();
 }
 
+export function IsDevMode() {
+  return window['go']['desktop']['App']['IsDevMode']();
+}
+
 export function Licenses() {
   return window['go']['desktop']['App']['Licenses']();
 }

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -64,6 +64,15 @@ func (a *App) IsDemoMode() bool {
 	return a.demoMode
 }
 
+// IsDevMode reports whether the app is running against the separate dev data
+// directory (the PELTON_DEV env var storage.DefaultPath checks), so the
+// frontend can show a persistent indicator that this isn't a normal install -
+// it's easy to forget a dev build is pointed at throwaway data instead of a
+// real mailbox.
+func (a *App) IsDevMode() bool {
+	return os.Getenv("PELTON_DEV") != ""
+}
+
 // newApp creates the App with the build version. The heavy initialization
 // happens in startup once wails has handed us a context we can emit runtime
 // events on.


### PR DESCRIPTION
When PELTON_DEV is set (the make run / wails dev loop), the app already points at a separate "Pelton-dev" data directory so a dev run never touches a real install's accounts or mail - but there was no visual sign of it in the running app, easy to forget mid-session.

Adds `App.IsDevMode()` on the backend (reads the same env var storage.DefaultPath already checks) and a small "DEVELOPER MODE" badge at the left of the status bar, always visible whenever it's on, i18n'd across en/de/fr/nl/es.