### PR TITLE
feat: localize the native application menubar

### DIFF
--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -86,6 +86,8 @@ export function ProgramLicense():Promise<string>;
 
 export function ReadAttachment(arg1:number,arg2:number):Promise<desktop.AttachmentContentDTO>;
 
+export function RebuildMenu():Promise<void>;
+
 export function RemoveImageAllow(arg1:string,arg2:string):Promise<void>;
 
 export function RemoveOffline(arg1:number):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -170,6 +170,10 @@ export function ReadAttachment(arg1, arg2) {
   return window['go']['desktop']['App']['ReadAttachment'](arg1, arg2);
 }
 
+export function RebuildMenu() {
+  return window['go']['desktop']['App']['RebuildMenu']();
+}
+
 export function RemoveImageAllow(arg1, arg2) {
   return window['go']['desktop']['App']['RemoveImageAllow'](arg1, arg2);
 }

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -43,8 +43,11 @@ type App struct {
 	programLicense  string
 	// mailMenuItems are the native Mail-menu items that act on the open message;
 	// they start disabled and SetMailActionsEnabled toggles them as the frontend's
-	// open message changes.
-	mailMenuItems []*menu.MenuItem
+	// open message changes. mailActionsEnabled mirrors that same state so a menu
+	// rebuild (RebuildMenu, on a language change) can restore it instead of
+	// resetting every item back to disabled.
+	mailMenuItems      []*menu.MenuItem
+	mailActionsEnabled bool
 
 	// dlMu guards dlCancel, the cancel function of the running bulk offline
 	// download (nil when none is running). CancelDownload calls it to stop the

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -276,6 +276,9 @@ func (a *App) SetSetting(key, value string) error {
 	if key == storage.SettingTheme {
 		a.applyNativeTheme(value)
 	}
+	if key == settingLanguage {
+		a.RebuildMenu()
+	}
 	return nil
 }
 

--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -8,43 +8,45 @@ import (
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-// buildMenu builds the native application menubar. Menu items that map to ui
-// actions emit the menu event with a short action string; the frontend listens
-// and performs the action (open settings, compose, sync, add mailbox). Window
-// level items (hide, quit) call the wails runtime directly. Accelerators use
-// CmdOrCtrl so they read as Cmd on macos and Ctrl elsewhere automatically, which
-// is the localized-to-platform behavior users expect.
+// buildMenu builds the native application menubar in the current language
+// setting. Menu items that map to ui actions emit the menu event with a short
+// action string; the frontend listens and performs the action (open settings,
+// compose, sync, add mailbox). Window level items (hide, quit) call the wails
+// runtime directly. Accelerators use CmdOrCtrl so they read as Cmd on macos
+// and Ctrl elsewhere automatically, which is the localized-to-platform
+// behavior users expect.
 func (a *App) buildMenu() *menu.Menu {
+	s := menuStringsFor(a.stringSetting(settingLanguage, "en"))
 	root := menu.NewMenu()
 
 	// the app menu. on macos this folds under the "Pelton" bold menu next to the
 	// apple logo; on other platforms it is a normal "Pelton" menu.
-	appMenu := root.AddSubmenu("Pelton")
-	appMenu.AddText("About Pelton", nil, a.menuAction("about"))
+	appMenu := root.AddSubmenu(s.appMenu)
+	appMenu.AddText(s.about, nil, a.menuAction("about"))
 	appMenu.AddSeparator()
-	appMenu.AddText("Preferences…", keys.CmdOrCtrl(","), a.menuAction("preferences"))
+	appMenu.AddText(s.preferences, keys.CmdOrCtrl(","), a.menuAction("preferences"))
 	appMenu.AddSeparator()
 	if goruntime.GOOS == "darwin" {
-		appMenu.AddText("Hide Pelton", keys.CmdOrCtrl("h"), func(_ *menu.CallbackData) {
+		appMenu.AddText(s.hide, keys.CmdOrCtrl("h"), func(_ *menu.CallbackData) {
 			wailsruntime.WindowHide(a.ctx)
 		})
 	}
-	appMenu.AddText("Quit Pelton", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
+	appMenu.AddText(s.quit, keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
 		wailsruntime.Quit(a.ctx)
 	})
 
 	// file menu: composing new mail and exporting the open message.
-	fileMenu := root.AddSubmenu("File")
-	fileMenu.AddText("Compose", keys.CmdOrCtrl("n"), a.menuAction("compose"))
+	fileMenu := root.AddSubmenu(s.fileMenu)
+	fileMenu.AddText(s.compose, keys.CmdOrCtrl("n"), a.menuAction("compose"))
 	fileMenu.AddSeparator()
-	fileMenu.AddText("Export Message as PDF…", keys.CmdOrCtrl("p"), a.menuAction("export-pdf"))
+	fileMenu.AddText(s.exportPDF, keys.CmdOrCtrl("p"), a.menuAction("export-pdf"))
 
 	// mailbox menu: mailbox-level operations - syncing and managing accounts.
-	mailboxMenu := root.AddSubmenu("Mailbox")
-	mailboxMenu.AddText("Sync Now", keys.CmdOrCtrl("r"), a.menuAction("sync"))
+	mailboxMenu := root.AddSubmenu(s.mailboxMenu)
+	mailboxMenu.AddText(s.syncNow, keys.CmdOrCtrl("r"), a.menuAction("sync"))
 	mailboxMenu.AddSeparator()
-	mailboxMenu.AddText("Add Mailbox…", keys.CmdOrCtrl("m"), a.menuAction("add-mailbox"))
-	mailboxMenu.AddText("Manage Mailboxes…", nil, a.menuAction("open-mailboxes"))
+	mailboxMenu.AddText(s.addMailbox, keys.CmdOrCtrl("m"), a.menuAction("add-mailbox"))
+	mailboxMenu.AddText(s.manageMailboxes, nil, a.menuAction("open-mailboxes"))
 
 	// mail menu: actions on the open message. Undo stays enabled (it undoes the
 	// last send/delete/archive, which needs no open message), but the message-
@@ -52,24 +54,24 @@ func (a *App) buildMenu() *menu.Menu {
 	// open (SetMailActionsEnabled, driven by the frontend's selection). Undo has
 	// no accelerator here since Cmd/Ctrl+Z is already handled by the app's own
 	// keydown handler; binding it again would double-fire.
-	mailMenu := root.AddSubmenu("Mail")
-	mailMenu.AddText("Undo", nil, a.menuAction("undo"))
+	mailMenu := root.AddSubmenu(s.mailMenu)
+	mailMenu.AddText(s.undo, nil, a.menuAction("undo"))
 	mailMenu.AddSeparator()
 	a.mailMenuItems = []*menu.MenuItem{
-		mailMenu.AddText("Mark as Read", nil, a.menuAction("mark-read")),
-		mailMenu.AddText("Mark as Unread", nil, a.menuAction("mark-unread")),
-		mailMenu.AddText("Flag / Unflag", nil, a.menuAction("flag")),
-		mailMenu.AddText("Archive", nil, a.menuAction("archive")),
-		mailMenu.AddText("Delete Message", nil, a.menuAction("delete-message")),
+		mailMenu.AddText(s.markRead, nil, a.menuAction("mark-read")),
+		mailMenu.AddText(s.markUnread, nil, a.menuAction("mark-unread")),
+		mailMenu.AddText(s.flagUnflag, nil, a.menuAction("flag")),
+		mailMenu.AddText(s.archive, nil, a.menuAction("archive")),
+		mailMenu.AddText(s.deleteMessage, nil, a.menuAction("delete-message")),
 	}
 	for _, item := range a.mailMenuItems {
-		item.Disabled = true
+		item.Disabled = !a.mailActionsEnabled
 	}
 
 	// view menu: a reliable fullscreen toggle (the native green button can be
 	// inconsistent in some setups) plus the low-power mode toggle.
-	viewMenu := root.AddSubmenu("View")
-	viewMenu.AddText("Toggle Fullscreen", keys.Combo("f", keys.CmdOrCtrlKey, keys.ControlKey), func(_ *menu.CallbackData) {
+	viewMenu := root.AddSubmenu(s.viewMenu)
+	viewMenu.AddText(s.toggleFullscreen, keys.Combo("f", keys.CmdOrCtrlKey, keys.ControlKey), func(_ *menu.CallbackData) {
 		if wailsruntime.WindowIsFullscreen(a.ctx) {
 			wailsruntime.WindowUnfullscreen(a.ctx)
 		} else {
@@ -77,10 +79,12 @@ func (a *App) buildMenu() *menu.Menu {
 		}
 	})
 	viewMenu.AddSeparator()
-	viewMenu.AddText("Low Power Mode", nil, a.menuAction("toggle-low-power"))
+	viewMenu.AddText(s.lowPowerMode, nil, a.menuAction("toggle-low-power"))
 
 	// the standard edit menu gives copy/paste/select-all their native bindings,
 	// which the webview needs on macos to work in inputs and the mail body.
+	// wails' EditMenu() ships with its own fixed English labels (Cut/Copy/
+	// Paste/Select All/Undo/Redo), which it doesn't expose a way to translate.
 	if goruntime.GOOS == "darwin" {
 		root.Append(menu.EditMenu())
 	}
@@ -88,10 +92,23 @@ func (a *App) buildMenu() *menu.Menu {
 	return root
 }
 
+// RebuildMenu rebuilds and applies the native menubar in the current language
+// setting. The frontend calls this right after writing a new language setting
+// so the menu updates immediately instead of waiting for the next launch.
+func (a *App) RebuildMenu() {
+	if a.ctx == nil {
+		return
+	}
+	wailsruntime.MenuSetApplicationMenu(a.ctx, a.buildMenu())
+}
+
 // SetMailActionsEnabled greys out or restores the Mail menu's message-level
 // items. The frontend calls it as its open message changes, so those actions are
-// only selectable while a message is actually open.
+// only selectable while a message is actually open. The chosen state is kept on
+// the App so a later menu rebuild (RebuildMenu, on a language change) restores
+// it instead of resetting every item back to disabled.
 func (a *App) SetMailActionsEnabled(enabled bool) {
+	a.mailActionsEnabled = enabled
 	for _, item := range a.mailMenuItems {
 		item.Disabled = !enabled
 	}

--- a/internal/desktop/menu_i18n.go
+++ b/internal/desktop/menu_i18n.go
@@ -1,0 +1,166 @@
+package desktop
+
+// menuStrings holds every literal label buildMenu uses. Menu items that carry
+// a native "%s Pelton"-style app name (Hide/Quit/About) keep the app name as a
+// separate substitution since it's never translated.
+type menuStrings struct {
+	appMenu          string
+	about            string
+	preferences      string
+	hide             string
+	quit             string
+	fileMenu         string
+	compose          string
+	exportPDF        string
+	mailboxMenu      string
+	syncNow          string
+	addMailbox       string
+	manageMailboxes  string
+	mailMenu         string
+	undo             string
+	markRead         string
+	markUnread       string
+	flagUnflag       string
+	archive          string
+	deleteMessage    string
+	viewMenu         string
+	toggleFullscreen string
+	lowPowerMode     string
+}
+
+// menuLocales mirrors the frontend's supported languages (en/de/fr/nl/es).
+// Keeping this as a Go-side table, separate from the frontend's TypeScript
+// locale files, is unavoidable: the native menu is built by the Go process
+// before any frontend code runs, and wails' menu API takes plain strings, not
+// translation keys the webview could resolve later.
+var menuLocales = map[string]menuStrings{
+	"en": {
+		appMenu:          "Pelton",
+		about:            "About Pelton",
+		preferences:      "Preferences…",
+		hide:             "Hide Pelton",
+		quit:             "Quit Pelton",
+		fileMenu:         "File",
+		compose:          "Compose",
+		exportPDF:        "Export Message as PDF…",
+		mailboxMenu:      "Mailbox",
+		syncNow:          "Sync Now",
+		addMailbox:       "Add Mailbox…",
+		manageMailboxes:  "Manage Mailboxes…",
+		mailMenu:         "Mail",
+		undo:             "Undo",
+		markRead:         "Mark as Read",
+		markUnread:       "Mark as Unread",
+		flagUnflag:       "Flag / Unflag",
+		archive:          "Archive",
+		deleteMessage:    "Delete Message",
+		viewMenu:         "View",
+		toggleFullscreen: "Toggle Fullscreen",
+		lowPowerMode:     "Low Power Mode",
+	},
+	"de": {
+		appMenu:          "Pelton",
+		about:            "Über Pelton",
+		preferences:      "Einstellungen…",
+		hide:             "Pelton ausblenden",
+		quit:             "Pelton beenden",
+		fileMenu:         "Datei",
+		compose:          "Neue Nachricht",
+		exportPDF:        "Nachricht als PDF exportieren…",
+		mailboxMenu:      "Postfach",
+		syncNow:          "Jetzt synchronisieren",
+		addMailbox:       "Postfach hinzufügen…",
+		manageMailboxes:  "Postfächer verwalten…",
+		mailMenu:         "Nachricht",
+		undo:             "Rückgängig",
+		markRead:         "Als gelesen markieren",
+		markUnread:       "Als ungelesen markieren",
+		flagUnflag:       "Markieren / Demarkieren",
+		archive:          "Archivieren",
+		deleteMessage:    "Nachricht löschen",
+		viewMenu:         "Ansicht",
+		toggleFullscreen: "Vollbild umschalten",
+		lowPowerMode:     "Energiesparmodus",
+	},
+	"fr": {
+		appMenu:          "Pelton",
+		about:            "À propos de Pelton",
+		preferences:      "Préférences…",
+		hide:             "Masquer Pelton",
+		quit:             "Quitter Pelton",
+		fileMenu:         "Fichier",
+		compose:          "Nouveau message",
+		exportPDF:        "Exporter le message en PDF…",
+		mailboxMenu:      "Boîte mail",
+		syncNow:          "Synchroniser maintenant",
+		addMailbox:       "Ajouter une boîte mail…",
+		manageMailboxes:  "Gérer les boîtes mail…",
+		mailMenu:         "Message",
+		undo:             "Annuler",
+		markRead:         "Marquer comme lu",
+		markUnread:       "Marquer comme non lu",
+		flagUnflag:       "Marquer / Démarquer",
+		archive:          "Archiver",
+		deleteMessage:    "Supprimer le message",
+		viewMenu:         "Affichage",
+		toggleFullscreen: "Basculer le plein écran",
+		lowPowerMode:     "Mode basse consommation",
+	},
+	"nl": {
+		appMenu:          "Pelton",
+		about:            "Over Pelton",
+		preferences:      "Voorkeuren…",
+		hide:             "Pelton verbergen",
+		quit:             "Pelton afsluiten",
+		fileMenu:         "Bestand",
+		compose:          "Nieuw bericht",
+		exportPDF:        "Bericht exporteren als PDF…",
+		mailboxMenu:      "Mailbox",
+		syncNow:          "Nu synchroniseren",
+		addMailbox:       "Mailbox toevoegen…",
+		manageMailboxes:  "Mailboxen beheren…",
+		mailMenu:         "Bericht",
+		undo:             "Ongedaan maken",
+		markRead:         "Als gelezen markeren",
+		markUnread:       "Als ongelezen markeren",
+		flagUnflag:       "Markeren / demarkeren",
+		archive:          "Archiveren",
+		deleteMessage:    "Bericht verwijderen",
+		viewMenu:         "Beeld",
+		toggleFullscreen: "Volledig scherm in-/uitschakelen",
+		lowPowerMode:     "Energiebesparende modus",
+	},
+	"es": {
+		appMenu:          "Pelton",
+		about:            "Acerca de Pelton",
+		preferences:      "Preferencias…",
+		hide:             "Ocultar Pelton",
+		quit:             "Salir de Pelton",
+		fileMenu:         "Archivo",
+		compose:          "Redactar",
+		exportPDF:        "Exportar mensaje como PDF…",
+		mailboxMenu:      "Buzón",
+		syncNow:          "Sincronizar ahora",
+		addMailbox:       "Añadir buzón…",
+		manageMailboxes:  "Administrar buzones…",
+		mailMenu:         "Mensaje",
+		undo:             "Deshacer",
+		markRead:         "Marcar como leído",
+		markUnread:       "Marcar como no leído",
+		flagUnflag:       "Marcar / Desmarcar",
+		archive:          "Archivar",
+		deleteMessage:    "Eliminar mensaje",
+		viewMenu:         "Ver",
+		toggleFullscreen: "Alternar pantalla completa",
+		lowPowerMode:     "Modo de bajo consumo",
+	},
+}
+
+// menuStringsFor returns the translation table for lang, falling back to
+// English for an unrecognized or empty language code.
+func menuStringsFor(lang string) menuStrings {
+	if s, ok := menuLocales[lang]; ok {
+		return s
+	}
+	return menuLocales["en"]
+}


### PR DESCRIPTION
The native menu bar (built in Go, before the webview or any frontend i18n exists) stayed hardcoded in English regardless of the app's language setting.

- New `internal/desktop/menu_i18n.go`: a Go-side translation table for every menu label, covering en/de/fr/nl/es (falls back to English for anything else).
- `buildMenu` now reads the current language setting and looks up strings from there instead of hardcoding them.
- New `App.RebuildMenu()` swaps in a freshly-built menu via `wails runtime.MenuSetApplicationMenu`; `SetSetting` calls it whenever the `language` key changes, so switching language (in onboarding or Settings) updates the menu immediately instead of only on next launch.
- The Mail menu's enabled/disabled state (whether a message is open) is now tracked on the App struct (`mailActionsEnabled`) so a menu rebuild restores it instead of resetting every item back to disabled.

Not translated: macOS's built-in `menu.EditMenu()` (Cut/Copy/Paste/Select All/Undo/Redo) ships with fixed English labels from wails itself with no override hook.