### PR TITLE
fix: copr srpm build failing on fedora 43/44

### DIFF
--- a/.github/copr/pelton.spec
+++ b/.github/copr/pelton.spec
@@ -17,6 +17,16 @@
 %global debug_package %{nil}
 AutoReqProv:    no
 
+# newer rpm (6.x, Fedora 43+) derives SOURCE_DATE_EPOCH from the top
+# %changelog entry's date by default, for reproducible builds. Our changelog
+# below is a static placeholder (the real history lives in git/GitHub
+# releases, not here) with a fake 1970 date that this rpm version's stricter
+# parser rejects outright as a "bad date", which aborted the whole SRPM build
+# on Copr. Disable that derivation since we don't need reproducible-build
+# timestamps from this placeholder.
+%global source_date_epoch_from_changelog 0
+%global _source_date_epoch_from_changelog 0
+
 Name:           pelton
 Version:        %{_pelton_version}
 Release:        1%{?dist}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,15 @@ jobs:
         run: |
           mkdir -p ~/rpmbuild/SOURCES ~/rpmbuild/SRPMS
           cp ".github/copr/pelton-$VERSION.tar.gz" ~/rpmbuild/SOURCES/
-          rpmbuild -bs --define "_pelton_version $VERSION" ".github/copr/pelton.spec"
+          # a plain `rpmbuild --define` only affects this one invocation; it
+          # is not stored inside the resulting SRPM. Copr re-runs `rpmbuild
+          # -bs` from the spec bundled in that SRPM as its own first build
+          # step, with no knowledge of our custom define, so %{_pelton_version}
+          # came out unexpanded there and broke Version/Source0. Bake the
+          # real version into the spec text itself instead, so it's self
+          # contained and needs no external define ever again.
+          { echo "%global _pelton_version $VERSION"; cat ".github/copr/pelton.spec"; } > /tmp/pelton.spec
+          rpmbuild -bs /tmp/pelton.spec
           cp ~/rpmbuild/SRPMS/*.src.rpm "pelton-$VERSION.src.rpm"
 
       - name: Configure copr-cli credentials


### PR DESCRIPTION
The v1.0.5 Copr build (https://copr.fedorainfracloud.org/coprs/build/10709296) failed on both fedora-43-x86_64 and fedora-44-x86_64, which is why `dnf install pelton` found an empty repo after enabling the Copr project - nothing had actually built.

Root cause, from the Copr build log:

```
warning: line 21: Possible unexpanded macro in: Version:        %{_pelton_version}
error: bad date in %changelog: Thu Jan 01 1970 Pelton release automation <me@arne.sh> - 0-1
error: Bad file: /builddir/build/SOURCES/pelton-%{_pelton_version}.tar.gz: No such file or directory
```

Two separate bugs, both in how the spec interacts with a newer rpm (6.x, shipped in Fedora 43+):

1. **Unexpanded `%{_pelton_version}`.** The release workflow passed the version via `rpmbuild --define "_pelton_version $VERSION"`, but that only affects that one local invocation - it's never stored inside the resulting SRPM. Copr re-runs `rpmbuild -bs` from the spec bundled in the SRPM as its own first build step, with no knowledge of that external define, so `Version:`/`Source0:` came out completely unresolved there. Fixed by baking `%global _pelton_version <version>` into the spec text itself before building, so it's self-contained.
2. **`%changelog`'s placeholder date rejected.** Fedora 43+'s rpm derives `SOURCE_DATE_EPOCH` from the top `%changelog` entry by default; our static placeholder entry's fake `Thu Jan 01 1970` date got rejected outright as a "bad date" by the newer parser. Disabled that derivation in the spec (`_source_date_epoch_from_changelog 0`, both macro spellings for safety) since we don't need reproducible-build timestamps from a placeholder changelog entry.

Also earlier in this pipeline: bug #36 (fedora-copr-rpm PR) fixed `AutoReqProv`/`debug_package`, which addressed a *different* failure mode. This is a second, independent bug that only shows up once the SRPM build itself can actually complete.