### PR TITLE
fix: linux menu-rebuild-on-language-change crashes the app

### DIFF
--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -95,8 +95,17 @@ func (a *App) buildMenu() *menu.Menu {
 // RebuildMenu rebuilds and applies the native menubar in the current language
 // setting. The frontend calls this right after writing a new language setting
 // so the menu updates immediately instead of waiting for the next launch.
+//
+// Skipped on Linux: wails' GTK MenuSetApplicationMenu does not cleanly replace
+// the previous native menu's click-handler wiring there, and once poisoned
+// every subsequent menu click (not just the item that triggered the rebuild)
+// nil-pointer-crashes the whole process inside wails' own gtk.go
+// handleMenuItemClick. buildMenu already reads the persisted language setting
+// fresh each call, so the menu still comes up correctly translated on the
+// next launch; it just doesn't live-update mid-session on Linux, which is a
+// far better tradeoff than crashing the app.
 func (a *App) RebuildMenu() {
-	if a.ctx == nil {
+	if a.ctx == nil || goruntime.GOOS == "linux" {
 		return
 	}
 	wailsruntime.MenuSetApplicationMenu(a.ctx, a.buildMenu())


### PR DESCRIPTION
Reported on Fedora 44: after going through onboarding (which picks a language, even just confirming the default), every subsequent native menu click - including "Add Mailbox" - crashed the whole app:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xf4a320]
github.com/wailsapp/wails/v2/internal/frontend/desktop/linux.handleMenuItemClick(...)
    .../wails/v2@v2.13.0/internal/frontend/desktop/linux/gtk.go:53
```

Root cause: `App.RebuildMenu()` (added for menu localization, #45) calls `wails runtime.MenuSetApplicationMenu` whenever the language setting changes, to update the native menu without a restart. On Linux, wails' GTK menu implementation doesn't cleanly replace the previous native menu's click-handler wiring (`gtkSignalToMenuItem`) when swapping in a new tree - once that's poisoned, *every* subsequent menu click nil-derefs inside wails' own code, not just the one that triggered the rebuild. Since a language change (even confirming the default during onboarding) happens near the very start of a session, this effectively broke the entire native menu for the rest of the session on Linux.

Fix: skip the live rebuild on Linux specifically (`goruntime.GOOS == "linux"`). `buildMenu()` already reads the persisted language fresh on every call, so the menu still comes up correctly translated on the *next* launch - it just doesn't live-update mid-session on Linux, which is a far better tradeoff than crashing. macOS and Windows are unaffected and keep the live update.