### PR TITLE
fix: interface not resizing to fill window on linux maximize

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -20,6 +20,7 @@
   import MoveDialog from './components/detail/MoveDialog.svelte'
 
   import { initPrefs, prefs, setPaneWidths, setLowPowerMode } from './stores/prefs'
+  import { applyScale } from './theme/theme'
   import { loadSidebar, refreshSidebar, sidebar } from './stores/accounts'
   import { initSidebarState } from './stores/sidebarstate'
   import { loadSignatures } from './stores/signatures'
@@ -158,7 +159,30 @@
     )
     unsubscribers.push(onOutboxChanged(() => void loadOutbox()))
     unsubscribers.push(onMenu(handleMenu))
+
+    // WebKitGTK (Linux) has a known quirk where maximizing the window - a
+    // resize driven by the window manager rather than the user dragging an
+    // edge - doesn't always make the webview recompute layout against the
+    // new size, leaving the interface rendered at the old (smaller)
+    // dimensions with blank space along the right/bottom. Reapplying the css
+    // `zoom` we already use for interface scale forces a relayout; this is a
+    // no-op-looking but effective kick, and harmless on macOS/Windows where
+    // resize already reflows correctly on its own. Both a window 'resize'
+    // listener and a ResizeObserver on the root are wired up since it's
+    // unclear which signal fires reliably for a window-manager-driven
+    // maximize on WebKitGTK; either one firing is enough to fix it.
+    window.addEventListener('resize', onWindowResize)
+    unsubscribers.push(() => window.removeEventListener('resize', onWindowResize))
+    const rootResizeObserver = new ResizeObserver(onWindowResize)
+    rootResizeObserver.observe(document.documentElement)
+    unsubscribers.push(() => rootResizeObserver.disconnect())
   })
+
+  let resizeRelayoutHandle = 0
+  function onWindowResize(): void {
+    cancelAnimationFrame(resizeRelayoutHandle)
+    resizeRelayoutHandle = requestAnimationFrame(() => applyScale(get(prefs).uiScale))
+  }
 
   onDestroy(() => {
     for (const off of unsubscribers) {


### PR DESCRIPTION
Reported on Fedora: maximizing the Pelton window leaves blank space along the right and bottom edges, as if the interface rendered at the pre-maximize size and never grew to fill the new window bounds. Reproduced regardless of the interface scale setting (100% or otherwise), so it's not specific to the custom css `zoom` value - it's the underlying layout not recomputing at all against the new window size.

This matches a documented WebKitGTK quirk: a window-manager-driven resize (maximize), as opposed to a user manually dragging an edge, doesn't reliably make the webview recompute layout against the new viewport size.

Fix: reapply the current interface scale (which resets the root's css `zoom`, forcing a relayout) whenever a resize is detected, via both a `window resize` listener and a `ResizeObserver` on the document root (redundant on purpose, since it's unclear which signal reliably fires for a WM-driven maximize on WebKitGTK - either one firing is enough). Debounced via `requestAnimationFrame`. No-op-looking but effective; harmless on macOS/Windows where resize already reflows correctly on its own.