### PR TITLE
fix: webview not filling window on Wayland maximize

### DIFF
--- a/internal/desktop/run.go
+++ b/internal/desktop/run.go
@@ -8,6 +8,8 @@ package desktop
 
 import (
 	"embed"
+	"os"
+	goruntime "runtime"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -29,6 +31,20 @@ type Config struct {
 
 // Run constructs and runs the wails application. It returns wails.Run's error.
 func Run(cfg Config) error {
+	// WebKitGTK's DMA-BUF renderer misbehaves on many Wayland compositors
+	// (notably GNOME, which Fedora ships): the webview's GPU surface is not
+	// reallocated when the window manager resizes the window, so after a
+	// maximise the interface keeps rendering at its old size with the window
+	// background showing through the right and bottom. Falling back to the
+	// non-DMA-BUF path fixes that. Only set on Linux, and only when the user
+	// hasn't already chosen a value, so a distro package or power user can
+	// still override it.
+	if goruntime.GOOS == "linux" {
+		if _, set := os.LookupEnv("WEBKIT_DISABLE_DMABUF_RENDERER"); !set {
+			os.Setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
+		}
+	}
+
 	app := newApp(cfg.Version)
 	app.licenseManifest = cfg.LicenseManifest
 	app.programLicense = cfg.ProgramLicense


### PR DESCRIPTION
On GNOME/Wayland (e.g. Fedora 44), maximizing the window left the interface rendered at its old, smaller size with the window background showing through along the right and bottom edges.

Root cause is WebKitGTK's DMA-BUF renderer: on many Wayland compositors it does not reallocate the webview's GPU surface when the window manager resizes the window, so the content never grows to fill a maximised window. This is a well-known WebKitGTK issue that affects Wails and Tauri apps alike on modern Fedora/GNOME.

Fix: set `WEBKIT_DISABLE_DMABUF_RENDERER=1` on Linux before starting Wails, falling back to the non-DMA-BUF render path. Only applied on Linux, and only when the variable is unset, so a distro package or power user can still override it.

The earlier `fix/linux-maximize-scaling` (PR #51) reapplies the CSS zoom on `resize`; with the native resize now actually propagating to the webview, that recalculation gets correct dimensions to work with.