### PR TITLE
fix: interface smaller than window on Linux

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
-    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <!-- no viewport meta on purpose: this is a desktop webview, not a mobile
+         page. WKWebView and WebView2 ignore the tag, but WebKitGTK (Linux) can
+         honor it and derive a layout viewport that disagrees with the actual
+         widget size, which left the interface smaller than the window with
+         dead space along the right and bottom edges. -->
     <title>Pelton</title>
     <style>
         /* instant splash painted before the bundle and svelte mount, so the

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -637,11 +637,15 @@
   .shell {
     display: grid;
     grid-template-rows: 1fr auto;
-    /* divide by the interface scale: css zoom enlarges everything but does not
-       shrink vh/vw, so without this a zoomed shell overflows and its bottom row
-       (the status bar) gets clipped. --ui-scale is set in theme.ts (default 1). */
-    height: calc(100vh / var(--ui-scale, 1));
-    width: calc(100vw / var(--ui-scale, 1));
+    /* percentages, not vh/vw: percentage sizes resolve against the zoomed
+       layout size, so they follow the css zoom the interface-scale setting
+       puts on the root (vh/vw don't, which is what the old
+       calc(100vh / var(--ui-scale)) compensated for), and they stay correct
+       on WebKitGTK, where viewport units misresolved and left the interface
+       smaller than the window. #app (the parent) is sized the same way in
+       style.css. */
+    height: 100%;
+    width: 100%;
     overflow: hidden;
   }
 

--- a/frontend/src/components/settings/AboutSection.svelte
+++ b/frontend/src/components/settings/AboutSection.svelte
@@ -66,6 +66,29 @@
   // code-split and only mounted (in a modal) when the user opens it.
   let showLicenses = false
 
+  // clicking the version toggles a small technical readout of the webview's
+  // layout viewport. It exists to debug platform rendering issues (a screenshot
+  // of it tells us whether the engine's viewport matches the real window, which
+  // WebKitGTK has gotten wrong) without needing a dev build on the affected
+  // machine. Untranslated on purpose: it is diagnostic output, not ui copy.
+  let showViewportInfo = false
+  let viewportInfo = ''
+  function refreshViewportInfo(): void {
+    const de = document.documentElement
+    viewportInfo =
+      `inner ${window.innerWidth}x${window.innerHeight}` +
+      ` / client ${de.clientWidth}x${de.clientHeight}` +
+      ` / outer ${window.outerWidth}x${window.outerHeight}` +
+      ` / dpr ${window.devicePixelRatio}` +
+      ` / zoom ${$prefs.uiScale}`
+  }
+  function toggleViewportInfo(): void {
+    showViewportInfo = !showViewportInfo
+    if (showViewportInfo) {
+      refreshViewportInfo()
+    }
+  }
+
   function open(url: string): void {
     BrowserOpenURL(url)
   }
@@ -77,14 +100,17 @@
   }
 </script>
 
-<svelte:window on:keydown={showLicenses ? onKeydown : undefined} />
+<svelte:window on:keydown={showLicenses ? onKeydown : undefined} on:resize={showViewportInfo ? refreshViewportInfo : undefined} />
 
 <div class="about">
   <div class="identity">
     <span class="name">{APP.name}</span>
-    <span class="version">{version.startsWith('v') ? version : `v${version}`}</span>
+    <button type="button" class="version" on:click={toggleViewportInfo}>{version.startsWith('v') ? version : `v${version}`}</button>
   </div>
   <p class="tagline">{APP.tagline}</p>
+  {#if showViewportInfo}
+    <p class="viewport-info">{viewportInfo}</p>
+  {/if}
 
   <div class="links">
     <button type="button" on:click={() => open(APP.website)}>
@@ -195,10 +221,25 @@
     color: var(--text-primary);
   }
 
+  /* the version is a button (it toggles the viewport readout) but should keep
+     looking like the plain text label it always was. */
   .version {
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: default;
     font-family: var(--font-mono);
     font-size: var(--fz-meta);
     color: var(--text-tertiary);
+  }
+
+  .viewport-info {
+    margin: var(--space-1) 0 0;
+    font-family: var(--font-mono);
+    font-size: var(--fz-meta);
+    color: var(--text-tertiary);
+    user-select: text;
+    -webkit-user-select: text;
   }
 
   .tagline {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -32,9 +32,14 @@ body {
   overflow: hidden;
 }
 
+/* percentages, not 100vh/100vw: viewport units misresolve on WebKitGTK (the
+   interface came up smaller than the window on Linux, with dead space along
+   the right and bottom), and unlike percentages they are not compensated for
+   the root css zoom the interface-scale setting applies. the percent chain
+   runs html -> body -> #app -> .shell. */
 #app {
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
 }
 
 code,

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -56,9 +56,9 @@ export function applyScale(scale: string): void {
   const root = document.documentElement
   // the typings don't include zoom, so assign through a loose style record.
   ;(root.style as unknown as Record<string, string>).zoom = String(factor)
-  // expose the factor so full-viewport flow containers (the shell) can divide
-  // their vh/vw by it: zoom does not shrink vh, so a 100vh shell would otherwise
-  // render factor*100vh tall and clip its bottom row (status bar) off-screen.
+  // expose the factor for currentUIScale below: fixed-positioned overlays need
+  // it to convert unscaled pointer coordinates into the zoomed layout space.
+  // the shell itself is sized with percentages, which follow zoom on their own.
   root.style.setProperty('--ui-scale', String(factor))
 }
 


### PR DESCRIPTION
On Fedora (WebKitGTK), the interface rendered smaller than the window at every window size and every display scale, leaving dead space along the right and bottom edges and squeezing the pane layout. Not a renderer/backend issue (disproven on-device via WEBKIT_DISABLE_DMABUF_RENDERER, GDK_BACKEND=x11 and WEBKIT_DISABLE_COMPOSITING_MODE tests): the layout viewport itself disagreed with the widget size.

Two layout-level causes addressed:

- Removed the mobile-style `<meta name="viewport">` tag from index.html. WKWebView and WebView2 ignore it, but WebKitGTK can honor it and derive a layout viewport that does not match the actual widget.
- The shell and `#app` are now sized with a percentage chain (`html -> body -> #app -> .shell`) instead of `100vw`/`100vh`. Viewport units misresolve on WebKitGTK, and unlike percentages they are not compensated for the root css `zoom` used by the interface-scale setting, so this also replaces the old `calc(100vh / var(--ui-scale))` workaround.

Also adds a small diagnostic: clicking the version in Settings > About toggles a readout of the engine's viewport numbers (inner/client/outer size, dpr, zoom), so future platform rendering issues can be diagnosed from a screenshot of a release build.

svelte-check: 0 errors. Verified on-device on Fedora 44 before merge.