### PR TITLE
fix: linux menu crash when mail selection changes

### DIFF
--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -64,8 +64,11 @@ func (a *App) buildMenu() *menu.Menu {
 		mailMenu.AddText(s.archive, nil, a.menuAction("archive")),
 		mailMenu.AddText(s.deleteMessage, nil, a.menuAction("delete-message")),
 	}
+	// on Linux the items stay enabled permanently: their sensitivity can never
+	// be updated live there (see SetMailActionsEnabled), and the frontend
+	// already ignores mail actions with a hint toast while no message is open.
 	for _, item := range a.mailMenuItems {
-		item.Disabled = !a.mailActionsEnabled
+		item.Disabled = !a.mailActionsEnabled && goruntime.GOOS != "linux"
 	}
 
 	// view menu: a reliable fullscreen toggle (the native green button can be
@@ -116,8 +119,18 @@ func (a *App) RebuildMenu() {
 // only selectable while a message is actually open. The chosen state is kept on
 // the App so a later menu rebuild (RebuildMenu, on a language change) restores
 // it instead of resetting every item back to disabled.
+//
+// Skipped on Linux for the same reason as RebuildMenu: wails' GTK
+// MenuUpdateApplicationMenu rebuilds the menu from scratch under the hood
+// (it is not an in-place update), which orphans the visible menubar's
+// click-handler wiring and nil-pointer-crashes the process on the next menu
+// click. The items are built enabled there instead (buildMenu) and the
+// frontend guards empty-state clicks with a hint toast.
 func (a *App) SetMailActionsEnabled(enabled bool) {
 	a.mailActionsEnabled = enabled
+	if goruntime.GOOS == "linux" {
+		return
+	}
 	for _, item := range a.mailMenuItems {
 		item.Disabled = !enabled
 	}


### PR DESCRIPTION
Fixes #65.

On Linux, `SetMailActionsEnabled` called `MenuUpdateApplicationMenu` every time the open message changed. In wails' GTK backend that call is not an in-place update: it rebuilds the whole menu, wipes the signal-to-menu-item maps, and creates a new menubar widget that is never packed into the window. The visible menubar's click handlers then resolve to nil and the next menu click crashes the process in wails' `handleMenuItemClick`. Same failure family as the language-change crash fixed in #50, via the second entry point.

Changes in `internal/desktop/menu.go`:

- `SetMailActionsEnabled` returns early on Linux (still records the state), so the poisonous `MenuUpdateApplicationMenu` call never runs there.
- `buildMenu` builds the five mail action items enabled on Linux, since their sensitivity can never be updated live there. The frontend already guards mail actions with an "open a message first" toast when no message is open.

Windows and macOS keep live enable/disable exactly as before.

Verification: `go build ./...`, `go vet`, gofmt clean. On-device Fedora test to follow via the Codespace test-binary loop (add a mailbox, open/close a message, click Mail menu items).
