### PR TITLE
fix: avatar crash when sender has no photo candidates

### DIFF
--- a/frontend/src/components/common/Avatar.svelte
+++ b/frontend/src/components/common/Avatar.svelte
@@ -31,7 +31,7 @@
     }
     const found = await photosFor(source, em)
     if (source === $prefs.avatarSource && em === email) {
-      candidates = found
+      candidates = found ?? []
     }
   }
 

--- a/frontend/src/lib/avatar.ts
+++ b/frontend/src/lib/avatar.ts
@@ -18,7 +18,12 @@ export function photosFor(source: string, email: string): Promise<string[]> {
   const key = `${source}:${email.toLowerCase()}`
   let pending = cache.get(key)
   if (!pending) {
-    pending = senderPhotos(email).catch(() => [])
+    // the binding returns json null for a sender without candidates (a nil Go
+    // slice), which resolves successfully - normalize it, the catch alone
+    // does not cover it.
+    pending = senderPhotos(email)
+      .then((found) => found ?? [])
+      .catch(() => [])
     cache.set(key, pending)
   }
   return pending


### PR DESCRIPTION
Fixes #75.

`SenderPhotos` returns a nil Go slice for senders without remote photo candidates; wails marshals that to json null, which resolves successfully, so `photosFor`'s `.catch(() => [])` never fired and `Avatar.svelte`'s `attempt < candidates.length` threw on every affected message row.

Normalizes the resolved value in `photosFor` (`found ?? []`) and adds the same guard at the assignment in Avatar.svelte. Same nil-slice bridge family as the theme import modal crash fixed inside PR #74.

Verification: `pnpm run check` clean; `make run` no longer logs the unhandled TypeError per row.
