### PR TITLE
fix: keep local drafts out of backups and sync imported mailboxes

### DIFF
--- a/internal/desktop/bind_account_setup.go
+++ b/internal/desktop/bind_account_setup.go
@@ -209,6 +209,24 @@ func (a *App) discoverFolders(account storage.Account) error {
 	return a.createFolderTree(account.ID, folders)
 }
 
+// ensureFolders discovers the folder tree over an already-connected client when
+// the account has no folder rows yet: accounts restored from a backup import,
+// or whose discovery failed during setup. With folders present it is a no-op.
+func (a *App) ensureFolders(client *pimap.Client, accountID int64) error {
+	folders, err := a.store.ListFolders(a.ctx, accountID)
+	if err != nil {
+		return err
+	}
+	if len(folders) > 0 {
+		return nil
+	}
+	serverFolders, err := client.ListFolders()
+	if err != nil {
+		return err
+	}
+	return a.createFolderTree(accountID, serverFolders)
+}
+
 // createFolderTree inserts folders parent-first so each child can resolve its
 // parent id from the path above it, splitting on the server's delimiter.
 func (a *App) createFolderTree(accountID int64, folders []pimap.Folder) error {

--- a/internal/desktop/bind_backup.go
+++ b/internal/desktop/bind_backup.go
@@ -33,12 +33,16 @@ const backupFileTag = "pelton-backup"
 
 // backupSkipSettings are settings that must not travel between installs: the
 // search watermark and the pending-download marker are local, transient state,
-// and the whitelist keys are exported under their own category instead.
+// the whitelist keys are exported under their own category instead, and local
+// drafts reference account ids that don't exist on the target install (and can
+// carry whole attachments). The skip applies on import too, so backup files
+// written before a key landed here are also filtered.
 var backupSkipSettings = map[string]bool{
 	settingSearchWatermark: true,
 	settingDownloadPending: true,
 	settingRemoteSenders:   true,
 	settingRemoteDomains:   true,
+	draftsKey:              true,
 }
 
 // whitelistBackup is the trusted-sender allowlist as exported.
@@ -315,8 +319,21 @@ func (a *App) ImportData(path string, categories []string, credentialPassword st
 		}
 	}
 	if want[backupCategoryMailboxes] {
-		if err := a.importMailboxes(doc.Mailboxes, credentialPassword); err != nil {
+		created, err := a.importMailboxes(doc.Mailboxes, credentialPassword)
+		if err != nil {
 			return err
+		}
+		// sync and idle the new accounts in the background, same as the setup
+		// wizard does, so an import with credentials starts pulling mail right
+		// away instead of waiting for a restart. Accounts without credentials
+		// drop out of both with errNoCredentials, which is not an error here.
+		for _, acc := range created {
+			go func(acc storage.Account) {
+				if err := a.syncAccount(acc); err != nil && !errors.Is(err, errNoCredentials) {
+					a.log.Error("sync imported account", "account", acc.Email, "err", err)
+				}
+				go a.idleLoop(acc)
+			}(acc)
 		}
 	}
 	if want[backupCategorySignatures] {
@@ -327,56 +344,59 @@ func (a *App) ImportData(path string, categories []string, credentialPassword st
 	return nil
 }
 
-// importMailboxes recreates accounts from their backed-up server config,
-// skipping any email already present locally so a re-import never duplicates
-// a mailbox. When credentialPassword is non-empty and an entry carries an
-// encrypted credential, it's decrypted and stored in the keyring for the
-// newly created account; otherwise (no password given, or the entry has no
-// credential) the mailbox still needs its password re-entered once before it
-// can sync, same as before this existed.
-func (a *App) importMailboxes(mailboxes []mailboxBackup, credentialPassword string) error {
+// importMailboxes recreates accounts from their backed-up server config and
+// returns the ones it created, skipping any email already present locally so
+// a re-import never duplicates a mailbox. When credentialPassword is non-empty
+// and an entry carries an encrypted credential, it's decrypted and stored in
+// the keyring for the newly created account; otherwise (no password given, or
+// the entry has no credential) the mailbox still needs its password re-entered
+// once before it can sync, same as before this existed.
+func (a *App) importMailboxes(mailboxes []mailboxBackup, credentialPassword string) ([]storage.Account, error) {
 	if len(mailboxes) == 0 {
-		return nil
+		return nil, nil
 	}
 	existing, err := a.store.ListAccounts(a.ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	have := make(map[string]bool, len(existing))
 	for _, acc := range existing {
 		have[acc.Email] = true
 	}
+	var created []storage.Account
 	for _, m := range mailboxes {
 		if have[m.Email] {
 			continue
 		}
-		id, err := a.store.CreateAccount(a.ctx, &storage.Account{
+		account := storage.Account{
 			Email:       m.Email,
 			DisplayName: m.DisplayName,
 			IMAPHost:    m.IMAPHost,
 			IMAPPort:    m.IMAPPort,
 			SMTPHost:    m.SMTPHost,
 			SMTPPort:    m.SMTPPort,
-		})
+		}
+		id, err := a.store.CreateAccount(a.ctx, &account)
 		if err != nil {
-			return err
+			return created, err
 		}
 		have[m.Email] = true
+		created = append(created, account)
 		if credentialPassword != "" && m.Secret != nil {
 			plaintext, err := decryptWithPassword(credentialPassword, m.Secret)
 			if err != nil {
-				return err
+				return created, err
 			}
 			var secret credentials.Secret
 			if err := json.Unmarshal(plaintext, &secret); err != nil {
-				return err
+				return created, err
 			}
 			if err := credentials.Store(id, secret); err != nil {
-				return err
+				return created, err
 			}
 		}
 	}
-	return nil
+	return created, nil
 }
 
 // importSignatures recreates signatures from the backup, skipping any

--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -170,6 +170,13 @@ func (a *App) syncAccount(account storage.Account) error {
 	}
 	defer client.Logout()
 
+	// an account can reach here with no folder rows at all: restored from a
+	// backup import, or its setup-time discovery failed. syncFolders only walks
+	// existing rows, so without this the sync would be a silent no-op forever.
+	if err := a.ensureFolders(client, account.ID); err != nil {
+		return err
+	}
+
 	return a.syncFolders(client, account.ID)
 }
 


### PR DESCRIPTION
Fixes #80.

Two separate defects behind the report:

**Import error mentioning `local_drafts`**: drafts are stored as one JSON blob in the settings table, so they traveled inside the settings category of every backup. They reference account ids that don't exist on the target install and can carry whole base64 attachments in a single settings row. `local_drafts` is now on the backup skip list, which filters it on export and, because import runs the same list, also when importing older backup files that still contain it.

**Imported mailboxes never sync**: `importMailboxes` only created the account row; folder discovery only ever ran in the setup wizard. `syncFolders` walks the locally stored folder rows, so an imported account had zero folders and every sync completed instantly without doing anything ("not synced yet" forever). `syncAccount` now discovers the folder tree over its already-open connection whenever an account has no folder rows, which also covers accounts whose setup-time discovery failed. On top of that, `ImportData` now starts the same background sync + idle for freshly imported accounts that the setup wizard starts, so an import with credentials pulls mail immediately instead of after a restart.

Not addressed here: the wrong-password retry trap during credential import, which is #68.