### PR TITLE
fix: write backup exports with 0600 permissions

### DIFF
--- a/internal/desktop/bind_backup.go
+++ b/internal/desktop/bind_backup.go
@@ -140,7 +140,15 @@ func (a *App) ExportData(categories []string, credentialPassword string) (string
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(filepath.Clean(dest), data, 0o644); err != nil {
+	// 0600: the export always carries the full server config and settings, and
+	// optionally encrypted mailbox credentials; no other local user should be
+	// able to read it. The user can still loosen a file they intend to share.
+	if err := os.WriteFile(filepath.Clean(dest), data, 0o600); err != nil {
+		return "", err
+	}
+	// WriteFile keeps an existing file's mode, so overwriting an old export
+	// left with looser permissions must be tightened explicitly.
+	if err := os.Chmod(filepath.Clean(dest), 0o600); err != nil {
 		return "", err
 	}
 	return dest, nil


### PR DESCRIPTION
Fixes #69.

ExportData wrote the backup json world-readable (0644). The export always carries the full server configuration and settings, and optionally encrypted mailbox credentials, so on a multi-user system any local user could read it. It is now written 0600, and since `os.WriteFile` keeps an existing file's mode, overwriting an older export explicitly tightens the mode too. On Windows the chmod is effectively a no-op, which matches how the rest of the codebase treats posix modes there.