### PR TITLE
chore: derive wails CLI version from go.mod in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ permissions:
 
 env:
   GO_VERSION: "1.25"
-  WAILS_VERSION: "v2.12.0"
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -48,7 +47,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@${{ env.WAILS_VERSION }}
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
 
       - name: Install dependencies
         run: |
@@ -141,7 +140,7 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@${{ env.WAILS_VERSION }}
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
 
       - name: Install NSIS
         shell: pwsh
@@ -208,7 +207,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config rpm
 
       - name: Install wails CLI
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@${{ env.WAILS_VERSION }}
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
 
       - name: Install nfpm
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
@@ -280,7 +279,7 @@ jobs:
 
       - name: Install wails CLI + copr-cli
         run: |
-          go install github.com/wailsapp/wails/v2/cmd/wails@${{ env.WAILS_VERSION }}
+          go install github.com/wailsapp/wails/v2/cmd/wails@$(go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2)
           pip install --user copr-cli
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
Fixes #70.

The release workflow pinned `WAILS_VERSION: v2.12.0` while go.mod moved to v2.13.0, so every release since the bump was built by the older CLI (the known class of problem where a mismatched wails CLI rewrites go.mod and the runtime bindings to its own version).

Instead of bumping the pin and hoping it stays in lockstep, the env var is gone entirely: all four install steps now derive the CLI version from the module pin itself (`go list -m -f '{{.Version}}' github.com/wailsapp/wails/v2`), so the CLI can never drift from go.mod again.