### PR TITLE
feat: reduce motion setting

### DIFF
--- a/frontend/src/components/common/Confetti.svelte
+++ b/frontend/src/components/common/Confetti.svelte
@@ -12,6 +12,15 @@
   let canvas: HTMLCanvasElement
   let raf = 0
 
+  // purely decorative, so it skips entirely under reduced motion (the in-app
+  // setting marks the root; the media query covers the os preference).
+  function motionReduced(): boolean {
+    return (
+      document.documentElement.hasAttribute('data-reduce-motion') ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    )
+  }
+
   interface Piece {
     x: number
     y: number
@@ -61,7 +70,7 @@
   }
 
   function start(): void {
-    if (!canvas) {
+    if (!canvas || motionReduced()) {
       return
     }
     const ctx = canvas.getContext('2d')

--- a/frontend/src/components/settings/SettingsPanel.svelte
+++ b/frontend/src/components/settings/SettingsPanel.svelte
@@ -86,6 +86,7 @@
     setComposeAutocomplete,
     setComposeChips,
     setEmptyStateImage,
+    setReduceMotion,
   } from '../../stores/prefs'
   import peltonLogo from '../../assets/images/icons/pelton-logo.png'
   import type { Locale } from '../../lib/i18n'
@@ -423,6 +424,16 @@
             on:change={(e) => setUIScale(e.detail)}
           />
           <p class="hint">{$t('settingsPanel.hint.interfaceScale')}</p>
+
+          <div class="toggle">
+            <span class="row-label">{$t('settingsPanel.toggle.reduceMotion')}</span>
+            <ToggleSwitch
+              checked={$prefs.reduceMotion}
+              label={$t('settingsPanel.toggle.reduceMotion')}
+              on:change={(e) => setReduceMotion(e.detail)}
+            />
+          </div>
+          <p class="hint">{$t('settingsPanel.hint.reduceMotion')}</p>
 
           <div class="field">
             <span class="row-label">{$t('settingsPanel.label.emptyStateImage')}</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -582,6 +582,7 @@ export const SettingKeys = {
   updateCheckFrequency: 'update_check_frequency',
   emptyStateImage: 'empty_state_image',
   themeId: 'theme_id',
+  reduceMotion: 'reduce_motion',
 } as const
 
 // --- custom themes ---

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -702,6 +702,8 @@ const de: Record<string, string> = {
   'settingsPanel.hint.plainRecipients': 'Empfänger werden als reiner Text angezeigt, durch Kommas getrennt.',
   'settingsPanel.hint.vimEditor': 'Verwendet Vim-Tastenkürzel im Verfassen-Editor.',
   'settingsPanel.hint.vimEditorDetail': 'Fügt dem Text- und Markdown-Editor eine modale Bedienung (Normal/Einfügen/Visuell) hinzu.',
+  'settingsPanel.toggle.reduceMotion': 'Bewegung reduzieren',
+  'settingsPanel.hint.reduceMotion': 'Schaltet Animationen und Übergänge der Oberfläche aus. Die Systemeinstellung für reduzierte Bewegung wird automatisch berücksichtigt.',
   'settingsPanel.toggle.shortcutHints': 'Tastenkürzel-Hinweise in der App anzeigen',
   'settingsPanel.hint.appVim': 'Nutze h/j/k/l, um dich außerhalb des Verfassens durch die App zu bewegen.',
   'settingsPanel.hint.appVimDetail': 'j/k bewegt durch die Nachrichtenliste, l/Enter öffnet, h/Escape geht zurück, gg/G springt an Anfang/Ende. Deaktiviert während der Eingabe, in der Seitenleiste oder wenn ein Dialog geöffnet ist.',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -702,6 +702,8 @@ const en: Record<string, string> = {
   'settingsPanel.hint.plainRecipients': 'Recipients show as plain text, separated by commas.',
   'settingsPanel.hint.vimEditor': 'Use vim keybindings in the compose editor.',
   'settingsPanel.hint.vimEditorDetail': 'Adds modal (normal/insert/visual) editing to the plain text and markdown editor.',
+  'settingsPanel.toggle.reduceMotion': 'Reduce motion',
+  'settingsPanel.hint.reduceMotion': 'Turns off interface animations and transitions. Also follows your system\'s reduced-motion preference automatically.',
   'settingsPanel.toggle.shortcutHints': 'Show keyboard shortcut hints in the app',
   'settingsPanel.hint.appVim': 'Use h/j/k/l to move around the app itself, outside of compose.',
   'settingsPanel.hint.appVimDetail': 'j/k move through the message list, l/Enter opens, h/Escape goes back, gg/G jump to the top/bottom. Disabled while typing, in the sidebar, or while a dialog is open.',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -702,6 +702,8 @@ const es: Record<string, string> = {
   'settingsPanel.hint.plainRecipients': 'Los destinatarios se muestran como texto plano, separados por comas.',
   'settingsPanel.hint.vimEditor': 'Usa los atajos de teclado de vim en el editor de redacción.',
   'settingsPanel.hint.vimEditorDetail': 'Añade edición modal (normal/inserción/visual) al editor de texto sin formato y markdown.',
+  'settingsPanel.toggle.reduceMotion': 'Reducir el movimiento',
+  'settingsPanel.hint.reduceMotion': 'Desactiva las animaciones y transiciones de la interfaz. La preferencia del sistema de movimiento reducido también se sigue automáticamente.',
   'settingsPanel.toggle.shortcutHints': 'Mostrar sugerencias de atajos de teclado en la aplicación',
   'settingsPanel.hint.appVim': 'Usa h/j/k/l para moverte por la aplicación, fuera del área de redacción.',
   'settingsPanel.hint.appVimDetail': 'j/k recorre la lista de mensajes, l/Intro lo abre, h/Esc vuelve atrás, gg/G salta al principio/final. Desactivado mientras escribes, en la barra lateral, o mientras un diálogo está abierto.',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -702,6 +702,8 @@ const fr: Record<string, string> = {
   'settingsPanel.hint.plainRecipients': 'Les destinataires s\'affichent en texte brut, séparés par des virgules.',
   'settingsPanel.hint.vimEditor': 'Utilise les raccourcis clavier vim dans l\'éditeur de rédaction.',
   'settingsPanel.hint.vimEditorDetail': 'Ajoute l\'édition modale (normal/insertion/visuel) à l\'éditeur de texte brut et markdown.',
+  'settingsPanel.toggle.reduceMotion': 'Réduire les animations',
+  'settingsPanel.hint.reduceMotion': 'Désactive les animations et transitions de l\'interface. La préférence système de réduction des animations est aussi suivie automatiquement.',
   'settingsPanel.toggle.shortcutHints': 'Afficher les indices de raccourcis clavier dans l\'application',
   'settingsPanel.hint.appVim': 'Utilise h/j/k/l pour te déplacer dans l\'application elle-même, en dehors de la rédaction.',
   'settingsPanel.hint.appVimDetail': 'j/k parcourt la liste des messages, l/Entrée ouvre, h/Échap revient en arrière, gg/G va au début/à la fin. Désactivé pendant la saisie, dans la barre latérale, ou quand une boîte de dialogue est ouverte.',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -702,6 +702,8 @@ const nl: Record<string, string> = {
   'settingsPanel.hint.plainRecipients': 'Ontvangers worden getoond als platte tekst, gescheiden door komma\'s.',
   'settingsPanel.hint.vimEditor': 'Gebruik vim-toetsbindingen in de opsteleditor.',
   'settingsPanel.hint.vimEditorDetail': 'Voegt modale bewerking (normaal/invoegen/visueel) toe aan de platte-tekst- en markdown-editor.',
+  'settingsPanel.toggle.reduceMotion': 'Beweging verminderen',
+  'settingsPanel.hint.reduceMotion': 'Schakelt animaties en overgangen van de interface uit. De systeemvoorkeur voor verminderde beweging wordt ook automatisch gevolgd.',
   'settingsPanel.toggle.shortcutHints': 'Sneltoetshints tonen in de app',
   'settingsPanel.hint.appVim': 'Gebruik h/j/k/l om door de app zelf te navigeren, buiten het opstellen.',
   'settingsPanel.hint.appVimDetail': 'j/k beweegt door de berichtenlijst, l/Enter opent, h/Escape gaat terug, gg/G springt naar het begin/einde. Uitgeschakeld tijdens typen, in de zijbalk, of wanneer een dialoogvenster open is.',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -220,6 +220,8 @@ export interface UIPrefs {
   // themeId selects an installed custom theme; empty means the built-in
   // default themes driven by the theme (light/dark/system) setting.
   themeId: string
+  // reduceMotion disables ui transitions and animations.
+  reduceMotion: boolean
 }
 
 // an installed custom theme, as shown in the settings gallery.

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -7,7 +7,7 @@
 import { writable } from 'svelte/store'
 import type { UIPrefs, ThemePref, DensityPref, EditorMode } from '../lib/types'
 import { getUIPrefs, setSetting, SettingKeys, systemColorScheme, setWindowTheme, getThemeApply } from '../lib/api'
-import { applyTheme, applyDensity, applyAccent, applyScale, watchSystemTheme, setSystemSchemeOverride, resolveTheme } from '../theme/theme'
+import { applyTheme, applyDensity, applyAccent, applyScale, applyReduceMotion, watchSystemTheme, setSystemSchemeOverride, resolveTheme } from '../theme/theme'
 import { applyUserTheme } from '../theme/usertheme'
 import { setLocale, type Locale } from '../lib/i18n'
 
@@ -59,6 +59,7 @@ const defaults: UIPrefs = {
   updateCheckFrequency: 'off',
   emptyStateImage: '',
   themeId: '',
+  reduceMotion: false,
 }
 
 export const prefs = writable<UIPrefs>(defaults)
@@ -76,6 +77,7 @@ function applyAll(p: UIPrefs): void {
   applyDensity(p.density as DensityPref)
   applyAccent(p.accent)
   applyScale(p.uiScale)
+  applyReduceMotion(p.reduceMotion)
   setLocale(p.language as Locale)
 }
 
@@ -288,6 +290,13 @@ export function setAccent(accent: string): void {
   prefs.update((p) => ({ ...p, accent }))
   applyAccent(accent)
   void setSetting(SettingKeys.accent, accent)
+}
+
+// setReduceMotion toggles the ui transition/animation kill switch.
+export function setReduceMotion(value: boolean): void {
+  prefs.update((p) => ({ ...p, reduceMotion: value }))
+  applyReduceMotion(value)
+  void setSetting(SettingKeys.reduceMotion, String(value))
 }
 
 // toggle keys map a boolean preference to its setting key so setToggle stays

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -106,3 +106,27 @@ a:hover {
   -webkit-user-select: text;
   user-select: text;
 }
+
+/* reduce motion: freeze animations and transitions when the user asked for it,
+   either through the in-app setting (data-reduce-motion on the root) or the
+   os-level preference. near-zero durations instead of `none` so animation and
+   transition end events still fire and js waiting on them never hangs. */
+:root[data-reduce-motion] *,
+:root[data-reduce-motion] *::before,
+:root[data-reduce-motion] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -46,6 +46,17 @@ export function applyDensity(pref: DensityPref): void {
   document.documentElement.setAttribute('data-density', pref)
 }
 
+// applyReduceMotion marks the root so css can disable transitions and
+// animations. the os-level prefers-reduced-motion query is honored by the
+// same css block regardless of this flag; this is the explicit in-app switch.
+export function applyReduceMotion(on: boolean): void {
+  if (on) {
+    document.documentElement.setAttribute('data-reduce-motion', '')
+  } else {
+    document.documentElement.removeAttribute('data-reduce-motion')
+  }
+}
+
 // applyScale zooms the whole interface by a string multiplier ("1" = 100%).
 // zoom (rather than a root font-size) scales the px-based tokens and layout
 // together, and is supported in both WKWebView and WebView2. an invalid or

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -786,6 +786,7 @@ export namespace desktop {
 	    updateCheckFrequency: string;
 	    emptyStateImage: string;
 	    themeId: string;
+	    reduceMotion: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new UIPrefsDTO(source);
@@ -838,6 +839,7 @@ export namespace desktop {
 	        this.updateCheckFrequency = source["updateCheckFrequency"];
 	        this.emptyStateImage = source["emptyStateImage"];
 	        this.themeId = source["themeId"];
+	        this.reduceMotion = source["reduceMotion"];
 	    }
 	}
 	export class UnifiedViewDTO {

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -56,6 +56,9 @@ const (
 	settingComposeAutocomplete = "compose_autocomplete"
 	settingComposeChips        = "compose_chips"
 	settingEmptyStateImage     = "empty_state_image"
+	// disable ui transitions and animations (the os-level preference is
+	// honored by the frontend css regardless).
+	settingReduceMotion = "reduce_motion"
 )
 
 // settingUpdateCheckFreq, settingLastUpdateCheck and defaultUpdateCheckFrequency
@@ -194,6 +197,8 @@ type UIPrefsDTO struct {
 	// ThemeID selects an installed custom theme (see bind_themes.go). Empty
 	// means the built-in default themes driven by the Theme setting.
 	ThemeID string `json:"themeId"`
+	// ReduceMotion disables ui transitions and animations.
+	ReduceMotion bool `json:"reduceMotion"`
 }
 
 // GetUIPrefs returns all ui preferences with defaults filled in, so startup is a
@@ -249,6 +254,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 		UpdateCheckFrequency:       a.stringSetting(settingUpdateCheckFreq, defaultUpdateCheckFrequency),
 		EmptyStateImage:            a.stringSetting(settingEmptyStateImage, ""),
 		ThemeID:                    a.stringSetting(settingThemeID, ""),
+		ReduceMotion:               a.boolSetting(settingReduceMotion, false),
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #63.

Adds a Reduce motion toggle under Settings > Appearance:

- The toggle marks the root element with `data-reduce-motion`; one global CSS block then clamps every animation and transition to a near-zero duration. Near-zero rather than `none`, so animation/transition end events still fire and nothing waiting on them can hang.
- The OS-level `prefers-reduced-motion` preference is honored by the same CSS via a media query, independent of the toggle, so the default already respects the system setting as the issue asked.
- The confetti burst (onboarding) is purely decorative and skips entirely under either signal instead of rendering a frozen frame.

Setting is `reduce_motion`, default off, wired through the usual prefs plumbing and applied at startup.