### PR TITLE
fix: stamp product version in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,17 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME:-dev}" >> "$GITHUB_OUTPUT"
 
+      # Stamp info.productVersion so the bundle's Info.plist
+      # (CFBundleVersion / CFBundleShortVersionString, i.e. Finder's Get
+      # Info) matches the app instead of the checked-in dev placeholder.
+      # Without this, every release reported the same bundle version and a
+      # stale app copy was indistinguishable from the new one (#83).
+      - name: Stamp product version
+        run: |
+          ver="${{ steps.version.outputs.version }}"
+          jq --arg v "${ver#v}" '.info.productVersion = $v' wails.json > wails.json.tmp
+          mv wails.json.tmp wails.json
+
       - name: Build (${{ matrix.arch }})
         run: wails build -platform darwin/${{ matrix.arch }} -ldflags "-X main.version=${{ steps.version.outputs.version }}"
 
@@ -162,6 +173,15 @@ jobs:
         id: version
         shell: bash
         run: echo "version=${GITHUB_REF_NAME:-dev}" >> "$GITHUB_OUTPUT"
+
+      # Stamp info.productVersion into the exe's version resources and the
+      # NSIS installer metadata, same reasoning as the macOS job (#83).
+      - name: Stamp product version
+        shell: bash
+        run: |
+          ver="${{ steps.version.outputs.version }}"
+          jq --arg v "${ver#v}" '.info.productVersion = $v' wails.json > wails.json.tmp
+          mv wails.json.tmp wails.json
 
       - name: Build + NSIS installer
         run: wails build -platform windows/amd64 -nsis -ldflags "-X main.version=${{ steps.version.outputs.version }}"

--- a/wails.json
+++ b/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "Arne K.",
     "productName": "Pelton",
-    "productVersion": "0.1.0",
+    "productVersion": "0.0.0",
     "copyright": "Copyright (c) 2026 Arne K. and the Pelton contributors. Licensed under GPL-3.0-or-later.",
     "comments": "Open-source desktop email client. https://github.com/TRC-Loop/Pelton"
   }


### PR DESCRIPTION
Fixes #83

**Investigation result: the released asset is fine.** I downloaded Pelton-v1.0.7-macos-applesilicon-app.zip fresh from the release and checked the binary: it contains v1.0.7 and no trace of v1.0.5, so the CI stamping from the tag worked. A Mac still reporting 1.0.5 after the drag-install is a stale app copy being launched (second Pelton.app in Downloads or on a still-mounted dmg, or the old bundle kept alive while it was replaced). The existing update check already surfaces this: a stale 1.0.5 copy with checks enabled reports that 1.0.7 is available.

**What made it hard to diagnose is real, and this fixes it:** the same extracted bundle shows CFBundleVersion / CFBundleShortVersionString 0.1.0, because info.productVersion in wails.json is a hardcoded placeholder that wails templates into Info.plist and the Windows exe/installer metadata. Every release therefore looked identical in Finder's Get Info, so two copies could not be told apart at a glance.

Changes:
- The macOS and Windows release jobs stamp info.productVersion from the tag (v prefix stripped) with jq before building, so Get Info and the exe properties match the app.
- The checked-in placeholder becomes 0.0.0, so a local dev build is recognizable as one instead of masquerading as an old release.

Verified locally: the jq stamp produces 1.0.8 from v1.0.8, and the workflow YAML parses. Note for merging: PR #86 touches the same workflow's wails install lines; both apply cleanly in either order.