### PR TITLE
feat: compose uses the mail body font

### DIFF
--- a/frontend/src/components/compose/CodeMirrorEditor.svelte
+++ b/frontend/src/components/compose/CodeMirrorEditor.svelte
@@ -26,8 +26,12 @@
     {
       '&': { height: '100%', backgroundColor: 'transparent', color: 'var(--text-primary)' },
       '&.cm-focused': { outline: 'none' },
+      // --compose-font is the mail body font setting, set by Compose on the
+      // editor container (#64); unset, each mode keeps its built-in font. the
+      // markdown editor stays on the ui font: it edits source, and the
+      // preview pane is what mirrors the recipient's view.
       '.cm-scroller': {
-        fontFamily: mono ? 'var(--font-mono, ui-monospace, monospace)' : 'var(--font-ui)',
+        fontFamily: mono ? 'var(--compose-font, var(--font-mono, ui-monospace, monospace))' : 'var(--font-ui)',
         fontSize: 'var(--fz-body)',
         lineHeight: '1.55',
         overflow: 'auto',

--- a/frontend/src/components/compose/Compose.svelte
+++ b/frontend/src/components/compose/Compose.svelte
@@ -34,10 +34,17 @@
   import { loadOutbox } from '../../stores/outbox'
   import { scheduleUndo } from '../../stores/undosend'
   import { prefs } from '../../stores/prefs'
+  import { bodyFontStack } from '../../lib/fonts'
   import { buildRequest, hasRecipients } from '../../lib/mailcompose'
   import { atTime, addDays, nextWeekday } from '../../lib/datepresets'
   import { errorMessage, toastError, toastSuccess } from '../../stores/toast'
   import type CodeMirrorEditor from './CodeMirrorEditor.svelte'
+
+  // the mail body font setting flows into the editors as a css variable so
+  // what you type looks like what recipients without their own fonts see
+  // (#64). null (the default) leaves each editor's built-in font untouched.
+  let composeFont: string | null = null
+  $: composeFont = bodyFontStack($prefs.bodyFont)
   import type { EditorMode } from '../../lib/types'
   import { t } from '../../lib/i18n'
 
@@ -434,7 +441,7 @@
 
     <AddressFields {session} />
 
-    <div class="editor">
+    <div class="editor" style:--compose-font={composeFont}>
       {#if session.mode === 'wysiwyg'}
         <!-- the rich editor loads lazily; show a hint while the chunk arrives. -->
         {#if RichEditor}
@@ -672,6 +679,7 @@
     min-height: 0;
     background: transparent;
     color: var(--text-primary);
+    font-family: var(--compose-font, inherit);
     font-size: var(--fz-body);
     line-height: 1.55;
     overflow-y: auto;

--- a/frontend/src/components/compose/RichEditor.svelte
+++ b/frontend/src/components/compose/RichEditor.svelte
@@ -179,11 +179,14 @@
     overflow-y: auto;
   }
 
-  /* the prosemirror editable area. tokens only; the editor injects .ProseMirror. */
+  /* the prosemirror editable area. tokens only; the editor injects .ProseMirror.
+     --compose-font is the mail body font setting, set by Compose on the editor
+     container (#64); unset, the ui font is inherited as before. */
   .surface :global(.ProseMirror) {
     min-height: 100%;
     outline: none;
     padding: var(--space-3) var(--space-4);
+    font-family: var(--compose-font, inherit);
     font-size: var(--fz-body);
     line-height: 1.55;
     color: var(--text-primary);


### PR DESCRIPTION
Fixes #64

The compose editors now follow the mail body font setting, so what you type looks like what recipients without their own fonts will see:

- Compose resolves the body_font setting to its css stack and sets it as a --compose-font variable on the editor container; changes apply live, and the default keeps every editor exactly as it is today.
- The wysiwyg editor's content area and the plaintext editor pick the variable up (plaintext falls back to its monospace look when unset). The markdown source editor deliberately stays on the ui font - it edits source, and its preview pane is what mirrors the recipient's view, so the preview picks up the font instead.

Stacked on #90 (feat/body-font-dropdown), which introduces the body font setting and lib/fonts.ts; GitHub retargets this PR to dev when #90 merges. Independent of #99 (both sit directly on #90).

Verified: go build, svelte-check 0 errors.