### PR TITLE
ci: publish linux amd64 binary and .deb alongside the .rpm

### DIFF
--- a/.github/nfpm/pelton.yaml
+++ b/.github/nfpm/pelton.yaml
@@ -11,14 +11,6 @@ vendor: "Arne K. and the Pelton contributors"
 homepage: "https://github.com/TRC-Loop/Pelton"
 license: GPL-3.0-or-later
 
-# Fedora ships the webkit2gtk4.1/gtk3 runtime under these package names as of
-# Fedora 39+. If a release build fails to install on a given Fedora version,
-# this is the first place to check (`dnf provides` on the target box) and
-# adjust.
-depends:
-  - gtk3
-  - webkit2gtk4.1
-
 contents:
   - src: ./build/bin/Pelton
     dst: /usr/bin/pelton
@@ -35,5 +27,21 @@ contents:
 
 rpm:
   group: Applications/Internet
-  scripts:
-    posttrans: ./.github/nfpm/posttrans.sh
+
+# The gtk3/webkit2gtk runtime ships under different package names on Fedora and
+# Debian (and Ubuntu 24.04's t64 transition renamed libgtk-3-0 to
+# libgtk-3-0t64), so each packager gets its own dependency list. Both refresh
+# the desktop/icon caches after install via the same hook.
+overrides:
+  rpm:
+    depends:
+      - gtk3
+      - webkit2gtk4.1
+    scripts:
+      posttrans: ./.github/nfpm/posttrans.sh
+  deb:
+    depends:
+      - "libgtk-3-0 | libgtk-3-0t64"
+      - "libwebkit2gtk-4.1-0"
+    scripts:
+      postinstall: ./.github/nfpm/posttrans.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,10 +200,11 @@ jobs:
             --clobber
 
   # ---------------------------------------------------------------------------
-  # Linux: a Fedora .rpm built with nfpm (free, MIT-licensed, no external
-  # signing service). Package metadata lives in .github/nfpm/pelton.yaml.
+  # Linux: the raw amd64 binary plus a .deb (Debian/Ubuntu) and .rpm (Fedora),
+  # both built with nfpm (free, MIT-licensed, no external signing service).
+  # Package metadata lives in .github/nfpm/pelton.yaml.
   # ---------------------------------------------------------------------------
-  linux-fedora:
+  linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -242,14 +243,23 @@ jobs:
         run: |
           raw="${GITHUB_REF_NAME:-0.0.0-dev}"
           echo "version=$raw" >> "$GITHUB_OUTPUT"
-          echo "rpm_version=${raw#v}" >> "$GITHUB_OUTPUT"
+          # package managers reject a leading "v", so strip it for .deb/.rpm.
+          echo "pkg_version=${raw#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: wails build -platform linux/amd64 -tags webkit2_41 -ldflags "-X main.version=${{ steps.version.outputs.version }}"
 
+      - name: Stage raw binary
+        run: cp "build/bin/Pelton" "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64"
+
+      - name: Build .deb
+        env:
+          VERSION: ${{ steps.version.outputs.pkg_version }}
+        run: nfpm package --config .github/nfpm/pelton.yaml --packager deb --target "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64.deb"
+
       - name: Build .rpm
         env:
-          VERSION: ${{ steps.version.outputs.rpm_version }}
+          VERSION: ${{ steps.version.outputs.pkg_version }}
         run: nfpm package --config .github/nfpm/pelton.yaml --packager rpm --target "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-fedora-x86_64.rpm"
 
       - name: Upload to release
@@ -258,6 +268,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
+            "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64" \
+            "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64.deb" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-fedora-x86_64.rpm" \
             --clobber
 


### PR DESCRIPTION
Adds two Linux release artifacts next to the existing Fedora `.rpm`:

- **Raw amd64 binary** `Pelton-<version>-linux-amd64` for users who just want to run it directly.
- **Debian/Ubuntu `.deb`** `Pelton-<version>-linux-amd64.deb` built with the same nfpm config.

## How

- The `linux-fedora` job is renamed `linux` since it now produces the binary, the `.deb` and the `.rpm` from one build.
- nfpm's `depends` moved into per-packager `overrides`, because the gtk3/webkit2gtk runtime has different package names on Debian vs Fedora. The `.deb` depends on `libgtk-3-0 | libgtk-3-0t64` (the second covers Ubuntu 24.04's t64 rename) and `libwebkit2gtk-4.1-0`; the `.rpm` keeps `gtk3` / `webkit2gtk4.1`.
- The same post-install hook that refreshes the desktop/icon caches runs on both (`.rpm` posttrans, `.deb` postinstall).
- The version step strips a leading `v` for both package formats (`pkg_version`).

Targets `dev` for the 1.0.9 release.
