### PR TITLE
fix: correct nfpm scripts placement so the .deb builds

### DIFF
--- a/.github/nfpm/pelton.yaml
+++ b/.github/nfpm/pelton.yaml
@@ -25,20 +25,23 @@ contents:
   - src: ./build/icons/pelton-default.png
     dst: /usr/share/pixmaps/pelton.png
 
+# Fedora runtime package names; applied to the .rpm. The .deb overrides these
+# below with the Debian/Ubuntu names.
+depends:
+  - gtk3
+  - webkit2gtk4.1
+
 rpm:
   group: Applications/Internet
+  # posttrans is rpm-specific and only valid here, not under overrides.
+  scripts:
+    posttrans: ./.github/nfpm/posttrans.sh
 
-# The gtk3/webkit2gtk runtime ships under different package names on Fedora and
-# Debian (and Ubuntu 24.04's t64 transition renamed libgtk-3-0 to
-# libgtk-3-0t64), so each packager gets its own dependency list. Both refresh
-# the desktop/icon caches after install via the same hook.
+# The gtk3/webkit2gtk runtime ships under different package names on Debian, and
+# Ubuntu 24.04's t64 transition renamed libgtk-3-0 to libgtk-3-0t64, so the .deb
+# gets its own dependency list and a postinstall hook that refreshes the
+# desktop/icon caches (the .rpm does the same via posttrans above).
 overrides:
-  rpm:
-    depends:
-      - gtk3
-      - webkit2gtk4.1
-    scripts:
-      posttrans: ./.github/nfpm/posttrans.sh
   deb:
     depends:
       - "libgtk-3-0 | libgtk-3-0t64"


### PR DESCRIPTION
The 1.0.9 linux release job failed with `Yaml: unmarshal errors: field posttrans not found in type nfpm.Scripts`: `posttrans` is rpm-specific and only valid under the top-level `rpm:` block, not under `overrides.<packager>.scripts`.

Fix: keep `posttrans` under `rpm.scripts`, keep the Fedora `depends` at top level (used by the .rpm), and override only the `.deb` with its Debian dependency names plus a `postinstall` hook.

Validated locally with nfpm: both `--packager deb` and `--packager rpm` now build, and the .deb control lists `Depends: libgtk-3-0 | libgtk-3-0t64, libwebkit2gtk-4.1-0`.

macOS/Windows/Copr artifacts on 1.0.9 were unaffected; this re-cuts the linux artifacts.