### PR TITLE
feat: browse themes button in settings

### DIFF
--- a/frontend/src/components/settings/ThemesSection.svelte
+++ b/frontend/src/components/settings/ThemesSection.svelte
@@ -4,7 +4,8 @@
   // card applies immediately; the import flow goes through ThemeImportModal
   // (read-before-import, remote-reference choice).
   import { onMount } from 'svelte'
-  import { IconFileImport, IconRefresh, IconTrash, IconUpload, IconAlertTriangle, IconWorld, IconPlus, IconPencil, IconFolderOpen } from '@tabler/icons-svelte'
+  import { IconFileImport, IconRefresh, IconTrash, IconUpload, IconAlertTriangle, IconWorld, IconWorldWww, IconPlus, IconPencil, IconFolderOpen } from '@tabler/icons-svelte'
+  import { BrowserOpenURL } from '../../../wailsjs/runtime/runtime'
   import { listThemes, previewThemeImport, deleteTheme, exportTheme, getThemeApply, openThemesFolder } from '../../lib/api'
   import type { ThemeInfo, ThemeImportPreview, ThemePref } from '../../lib/types'
   import { prefs, setThemeId } from '../../stores/prefs'
@@ -104,6 +105,10 @@
     }
   }
 
+  // the gallery opens in the user's browser; nothing from it is fetched into
+  // the webview. downloads come back in through the normal import flow.
+  const galleryURL = 'https://themes.pelton.app'
+
   // closeEditor drops the draft preview and restores whatever theme was
   // active before the editor opened.
   async function closeEditor(): Promise<void> {
@@ -159,6 +164,10 @@
   <button type="button" class="action-btn" on:click={startImport}>
     <IconFileImport size={15} stroke={1.6} />
     {$t('themes.import')}
+  </button>
+  <button type="button" class="action-btn" on:click={() => BrowserOpenURL(galleryURL)} title={$t('themes.browseHint')}>
+    <IconWorldWww size={15} stroke={1.6} />
+    {$t('themes.browse')}
   </button>
   <button type="button" class="action-btn" on:click={openFolder} title={$t('themes.openFolderHint')}>
     <IconFolderOpen size={15} stroke={1.6} />

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -627,6 +627,8 @@ const de: Record<string, string> = {
   'themes.create': 'Neues Theme...',
   'themes.openFolder': 'Ordner öffnen',
   'themes.openFolderHint': 'Zeigt den Themes-Ordner. Lege .peltontheme-Dateien hier ab, um sie zu installieren.',
+  'themes.browse': 'Themes durchsuchen',
+  'themes.browseHint': 'Öffnet die Theme-Galerie auf themes.pelton.app im Browser',
   'themes.edit': 'Farben bearbeiten',
   'themeEditor.title': 'Theme-Editor',
   'themeEditor.nameLabel': 'Name',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -627,6 +627,8 @@ const en: Record<string, string> = {
   'themes.create': 'New theme...',
   'themes.openFolder': 'Open folder',
   'themes.openFolderHint': 'Show the themes folder. Drop .peltontheme files here to install them.',
+  'themes.browse': 'Browse themes',
+  'themes.browseHint': 'Open the theme gallery at themes.pelton.app in your browser',
   'themes.edit': 'Edit colors',
   'themeEditor.title': 'Theme editor',
   'themeEditor.nameLabel': 'Name',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -627,6 +627,8 @@ const es: Record<string, string> = {
   'themes.create': 'Nuevo tema...',
   'themes.openFolder': 'Abrir carpeta',
   'themes.openFolderHint': 'Muestra la carpeta de temas. Suelta archivos .peltontheme aquí para instalarlos.',
+  'themes.browse': 'Explorar temas',
+  'themes.browseHint': 'Abre la galería de temas en themes.pelton.app en tu navegador',
   'themes.edit': 'Editar colores',
   'themeEditor.title': 'Editor de temas',
   'themeEditor.nameLabel': 'Nombre',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -627,6 +627,8 @@ const fr: Record<string, string> = {
   'themes.create': 'Nouveau thème...',
   'themes.openFolder': 'Ouvrir le dossier',
   'themes.openFolderHint': 'Affiche le dossier des thèmes. Déposez-y des fichiers .peltontheme pour les installer.',
+  'themes.browse': 'Parcourir les thèmes',
+  'themes.browseHint': 'Ouvre la galerie de thèmes sur themes.pelton.app dans votre navigateur',
   'themes.edit': 'Modifier les couleurs',
   'themeEditor.title': 'Éditeur de thème',
   'themeEditor.nameLabel': 'Nom',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -627,6 +627,8 @@ const nl: Record<string, string> = {
   'themes.create': 'Nieuw thema...',
   'themes.openFolder': 'Map openen',
   'themes.openFolderHint': 'Toont de themamap. Zet hier .peltontheme-bestanden neer om ze te installeren.',
+  'themes.browse': 'Thema\'s verkennen',
+  'themes.browseHint': 'Opent de themagalerie op themes.pelton.app in je browser',
   'themes.edit': 'Kleuren bewerken',
   'themeEditor.title': 'Thema-editor',
   'themeEditor.nameLabel': 'Naam',


### PR DESCRIPTION
Closes #121

Adds a "Browse themes" button to the Themes settings category, between "Import theme..." and "Open folder". It opens https://themes.pelton.app in the user's browser via `BrowserOpenURL`, the same way About opens links.

Nothing is fetched into the webview, so no third-party content reaches the app. Downloads come back in through the existing import flow.

2 new i18n keys in all five locales.
