### PR TITLE
fix: resync off the idle connection so new mail arrives promptly

### DIFF
--- a/cmd/imaptest/main.go
+++ b/cmd/imaptest/main.go
@@ -209,25 +209,15 @@ func idleDemo(client *pimap.Client) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case u := <-client.Updates():
-				switch {
-				case u.NumMessages != nil:
-					fmt.Printf("** new mail: mailbox now has %d messages\n", *u.NumMessages)
-				case u.ExpungedSeqNum != nil:
-					fmt.Printf("** message expunged: seq %d\n", *u.ExpungedSeqNum)
-				}
-			}
+	for {
+		gotUpdate, err := client.IdleUntil(ctx)
+		if err != nil {
+			return err
 		}
-	}()
-
-	if err := client.Idle(ctx); err != nil {
-		return err
+		if !gotUpdate {
+			fmt.Println("idle stopped cleanly")
+			return nil
+		}
+		fmt.Println("** server pushed an update (new or expunged mail)")
 	}
-	fmt.Println("idle stopped cleanly")
-	return nil
 }

--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -310,35 +310,27 @@ func (a *App) idleSession(account storage.Account) error {
 		return fmt.Errorf("select inbox for idle: %w", err)
 	}
 
-	// client.Updates() is never closed, so without this the listener goroutine
-	// below would leak on every reconnect (idleLoop calls idleSession again on
-	// error, each time with a fresh client and channel). sessionCtx ties the
-	// goroutine's lifetime to this call.
-	sessionCtx, cancel := context.WithCancel(a.ctx)
-	defer cancel()
-
-	go func() {
-		for {
-			select {
-			case <-sessionCtx.Done():
-				return
-			case _, ok := <-client.Updates():
-				if !ok {
-					return
-				}
-				syncMu.Lock()
-				// idle only watches INBOX, so only resync INBOX here; a full
-				// resync of every folder would make each push wait on folders
-				// that did not change, delaying the new mail this update is
-				// actually about. other folders still get picked up by the
-				// periodic full sync (runAutoSyncLoop).
-				if err := a.syncOneFolder(client, *inbox); err != nil {
-					a.log.Error("idle resync", "err", err)
-				}
-				syncMu.Unlock()
-			}
+	// Park on IDLE; when the server pushes activity, IdleUntil stops IDLE and
+	// returns, freeing the connection so the resync FETCH can run on it. Doing
+	// the FETCH while IDLE was still held is what made new mail take minutes to
+	// arrive. Only INBOX is resynced here (idle watches only INBOX); other
+	// folders are covered by the periodic full sync (runAutoSyncLoop). syncMu is
+	// held only for the brief resync so manual and background syncs are not
+	// blocked while idling.
+	for a.ctx.Err() == nil {
+		gotUpdate, err := client.IdleUntil(a.ctx)
+		if err != nil {
+			return err
 		}
-	}()
-
-	return client.Idle(a.ctx)
+		if !gotUpdate {
+			return nil
+		}
+		syncMu.Lock()
+		err = a.syncOneFolder(client, *inbox)
+		syncMu.Unlock()
+		if err != nil {
+			a.log.Error("idle resync", "err", err)
+		}
+	}
+	return nil
 }

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -205,11 +205,6 @@ func (c *Client) Login() error {
 	return nil
 }
 
-// Updates returns the channel of server pushes delivered while idling.
-func (c *Client) Updates() <-chan MailboxUpdate {
-	return c.updates
-}
-
 // SupportsIdle reports whether the server advertises IDLE.
 func (c *Client) SupportsIdle() bool {
 	return c.raw.Caps().Has(imap.CapIdle)

--- a/internal/imap/idle.go
+++ b/internal/imap/idle.go
@@ -7,27 +7,83 @@ import (
 	"github.com/emersion/go-imap/v2"
 )
 
-// Idle blocks in IMAP IDLE until ctx is cancelled. Updates arrive on Updates().
-func (c *Client) Idle(ctx context.Context) error {
+// IdleUntil parks the connection in IMAP IDLE and blocks until the server
+// pushes a mailbox update, ctx is cancelled, or the connection drops. It always
+// stops IDLE before returning, so on return the connection is free for the
+// caller to issue commands (a FETCH resync, say). It reports whether an update
+// arrived: true means new server activity to sync, false means ctx ended.
+//
+// This replaces the old pattern of holding IDLE open for the whole session and
+// fetching on a separate goroutine: go-imap forbids sending any command while
+// IDLE runs, so that fetch blocked until the 28-minute idle restart, which is
+// what made new mail take minutes to appear.
+func (c *Client) IdleUntil(ctx context.Context) (bool, error) {
 	if !c.SupportsIdle() {
-		return fmt.Errorf("imap: server does not advertise the IDLE capability")
+		return false, fmt.Errorf("imap: server does not advertise the IDLE capability")
 	}
 	if c.raw.State() != imap.ConnStateSelected {
-		return fmt.Errorf("imap: a mailbox must be selected before idling")
+		return false, fmt.Errorf("imap: a mailbox must be selected before idling")
 	}
 
 	cmd, err := c.raw.Idle()
 	if err != nil {
-		return fmt.Errorf("imap: start idle: %w", err)
+		return false, fmt.Errorf("imap: start idle: %w", err)
 	}
 
-	<-ctx.Done()
+	// cmd.Wait blocks until IDLE terminates on its own, which is how a dropped
+	// connection surfaces; watch it so a dead link is reported instead of
+	// hanging until ctx is cancelled.
+	idleDone := make(chan error, 1)
+	go func() { idleDone <- cmd.Wait() }()
 
-	if err := cmd.Close(); err != nil {
-		return fmt.Errorf("imap: stop idle: %w", err)
+	select {
+	case <-ctx.Done():
+		return false, c.stopIdle(cmd, idleDone)
+	case _, ok := <-c.updates:
+		if !ok {
+			return false, c.stopIdle(cmd, idleDone)
+		}
+		if err := c.stopIdle(cmd, idleDone); err != nil {
+			return true, err
+		}
+		c.drainUpdates()
+		return true, nil
+	case err := <-idleDone:
+		if err == nil {
+			err = fmt.Errorf("imap: idle ended unexpectedly")
+		}
+		return false, fmt.Errorf("imap: idle terminated: %w", err)
 	}
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("imap: idle terminated: %w", err)
+}
+
+// stopIdle closes the IDLE command and reaps the Wait goroutine started in
+// IdleUntil, returning the first error from either.
+func (c *Client) stopIdle(cmd idleCloser, idleDone <-chan error) error {
+	closeErr := cmd.Close()
+	waitErr := <-idleDone
+	if closeErr != nil {
+		return fmt.Errorf("imap: stop idle: %w", closeErr)
+	}
+	if waitErr != nil {
+		return fmt.Errorf("imap: idle terminated: %w", waitErr)
 	}
 	return nil
+}
+
+// idleCloser is the slice of *imapclient.IdleCommand IdleUntil needs, named so
+// stopIdle stays testable without a live connection.
+type idleCloser interface {
+	Close() error
+}
+
+// drainUpdates clears any updates that coalesced while IDLE was stopping, so the
+// next IdleUntil starts clean and a single resync covers them all.
+func (c *Client) drainUpdates() {
+	for {
+		select {
+		case <-c.updates:
+		default:
+			return
+		}
+	}
 }

--- a/internal/imap/idle_test.go
+++ b/internal/imap/idle_test.go
@@ -1,0 +1,51 @@
+package imap
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeIdleCmd struct{ err error }
+
+func (f fakeIdleCmd) Close() error { return f.err }
+
+func TestStopIdle(t *testing.T) {
+	closeErr := errors.New("close boom")
+	waitErr := errors.New("wait boom")
+
+	tests := []struct {
+		name    string
+		close   error
+		wait    error
+		wantErr bool
+	}{
+		{"clean", nil, nil, false},
+		{"close fails", closeErr, nil, true},
+		{"wait fails", nil, waitErr, true},
+		{"both fail reports close", closeErr, waitErr, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{}
+			done := make(chan error, 1)
+			done <- tt.wait
+			err := c.stopIdle(fakeIdleCmd{err: tt.close}, done)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("stopIdle err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDrainUpdates(t *testing.T) {
+	c := &Client{updates: make(chan MailboxUpdate, updateBuffer)}
+	for range 5 {
+		c.updates <- MailboxUpdate{}
+	}
+	c.drainUpdates()
+	if len(c.updates) != 0 {
+		t.Fatalf("drainUpdates left %d updates", len(c.updates))
+	}
+	// safe to call on an empty channel.
+	c.drainUpdates()
+}


### PR DESCRIPTION
## What

New mail was fetched over the connection that was still parked in IMAP IDLE, so the fetch could not run until IDLE stopped, which only happened on go-imap's 28-minute idle restart (or app shutdown). New mail therefore took minutes to appear instead of seconds.

## Fix

- `internal/imap`: add `IdleUntil(ctx)` which parks on IDLE, blocks until the server pushes an update / ctx is cancelled / the connection drops, and **always stops IDLE before returning** so the connection is free to FETCH. Removed the now-unused `Updates()` accessor and the old `Idle()` that held IDLE open for the whole session (exposing it invited exactly this misuse).
- `internal/desktop`: `idleSession` is now a single-goroutine loop: `IdleUntil` -> on update take `syncMu`, resync INBOX, release, idle again. No concurrent FETCH on the idling connection; `syncMu` is held only for the brief resync, so manual/background syncs no longer stall behind it.
- `cmd/imaptest`: updated to the new loop API.

## Tests

- `TestStopIdle` (close/wait error reaping) and `TestDrainUpdates` in `internal/imap`.
- Existing imap + desktop suites pass.

Closes #125
