### PR TITLE
fix: rename settings category Network to Proxy

### DIFF
--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -581,7 +581,7 @@ const de: Record<string, string> = {
   'settingsPanel.category.power': 'Sync & Energie',
   'settingsPanel.category.contacts': 'Kontakte',
   'settingsPanel.category.mailboxes': 'Postfächer',
-  'settingsPanel.category.network': 'Netzwerk',
+  'settingsPanel.category.network': 'Proxy',
   'network.proxy.hint': 'Leite alle Verbindungen von Pelton (Mail und Web) über einen Proxy.',
   'network.proxy.mode': 'Proxy',
   'network.proxy.mode.off': 'Aus',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -581,7 +581,7 @@ const en: Record<string, string> = {
   'settingsPanel.category.power': 'Sync & Power',
   'settingsPanel.category.contacts': 'Contacts',
   'settingsPanel.category.mailboxes': 'Mailboxes',
-  'settingsPanel.category.network': 'Network',
+  'settingsPanel.category.network': 'Proxy',
   'network.proxy.hint': 'Route all of Pelton\'s connections (mail and web) through a proxy.',
   'network.proxy.mode': 'Proxy',
   'network.proxy.mode.off': 'Off',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -581,7 +581,7 @@ const es: Record<string, string> = {
   'settingsPanel.category.power': 'Sincronización y energía',
   'settingsPanel.category.contacts': 'Contactos',
   'settingsPanel.category.mailboxes': 'Buzones',
-  'settingsPanel.category.network': 'Red',
+  'settingsPanel.category.network': 'Proxy',
   'network.proxy.hint': 'Enruta todas las conexiones de Pelton (correo y web) a través de un proxy.',
   'network.proxy.mode': 'Proxy',
   'network.proxy.mode.off': 'Desactivado',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -581,7 +581,7 @@ const fr: Record<string, string> = {
   'settingsPanel.category.power': 'Synchro et énergie',
   'settingsPanel.category.contacts': 'Contacts',
   'settingsPanel.category.mailboxes': 'Boîtes mail',
-  'settingsPanel.category.network': 'Réseau',
+  'settingsPanel.category.network': 'Proxy',
   'network.proxy.hint': 'Faire passer toutes les connexions de Pelton (mail et web) par un proxy.',
   'network.proxy.mode': 'Proxy',
   'network.proxy.mode.off': 'Désactivé',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -581,7 +581,7 @@ const nl: Record<string, string> = {
   'settingsPanel.category.power': 'Synchronisatie & energie',
   'settingsPanel.category.contacts': 'Contacten',
   'settingsPanel.category.mailboxes': 'Mailboxen',
-  'settingsPanel.category.network': 'Netwerk',
+  'settingsPanel.category.network': 'Proxy',
   'network.proxy.hint': 'Leid alle verbindingen van Pelton (mail en web) via een proxy.',
   'network.proxy.mode': 'Proxy',
   'network.proxy.mode.off': 'Uit',


### PR DESCRIPTION
Renames the user-facing settings category label from Network to Proxy in all five locales, since the category only holds proxy settings. Internal category id and the network.proxy.* key namespace are unchanged.

Closes #116