### PR TITLE
fix: stop reading pane jitter on fractional display scaling

### DIFF
--- a/frontend/src/components/detail/MailBody.svelte
+++ b/frontend/src/components/detail/MailBody.svelte
@@ -143,8 +143,18 @@
     if (!body) {
       return
     }
-    const h = body.getBoundingClientRect().height
-    frameHeight = Math.max(40, Math.ceil(h))
+    const h = Math.max(40, Math.ceil(body.getBoundingClientRect().height))
+    // hysteresis: on fractional display scaling (125%/150%, common on Fedora's
+    // WebKitGTK) the applied iframe height rounds to a device pixel differently
+    // from how getBoundingClientRect measures it back, so writing every reading
+    // to frameHeight makes the body flip between two adjacent pixel heights
+    // forever, which reads as continuous shaking. only apply a change that moves
+    // the height by more than a pixel, which settles the loop while still
+    // tracking real content growth and shrink.
+    if (Math.abs(h - frameHeight) <= 1) {
+      return
+    }
+    frameHeight = h
   }
 
   // readyBody returns the iframe's body only once it's our own rendered


### PR DESCRIPTION
The reading pane iframe is sized to its content height via a ResizeObserver that writes each measured body height back onto the iframe. On fractional display scaling (125%/150%, common on Fedora's WebKitGTK) the applied height snaps to a device pixel differently from how getBoundingClientRect measures it back, so the body flips between two adjacent pixel heights forever. That continuous 1px oscillation is the visible shaking that makes mail unreadable.

Fix: add hysteresis in measure() so a new reading only takes effect when it differs from the applied height by more than a pixel. This settles the feedback loop while still tracking real content growth and shrink. No behavior change on integer scaling, where diffs were already 0.

Closes #123