### PR TITLE
feat: fullscreen empty-state background toggle

### DIFF
--- a/frontend/src/components/detail/MessageDetail.svelte
+++ b/frontend/src/components/detail/MessageDetail.svelte
@@ -143,9 +143,18 @@ ${bodyHtml}
 
 <section class="detail">
   {#if $openMessageId === null}
-    <div class="placeholder">
-      <img class="placeholder-logo" src={$prefs.emptyStateImage || peltonLogo} alt="Pelton" draggable="false" />
-    </div>
+    {#if $prefs.emptyStateFullscreen && $prefs.emptyStateImage}
+      <div
+        class="placeholder placeholder-full"
+        style={`background-image: url("${$prefs.emptyStateImage}")`}
+        role="img"
+        aria-label="Pelton"
+      ></div>
+    {:else}
+      <div class="placeholder">
+        <img class="placeholder-logo" src={$prefs.emptyStateImage || peltonLogo} alt="Pelton" draggable="false" />
+      </div>
+    {/if}
   {:else if $messageDetail.status === 'loading' && !$messageDetail.data}
     <Spinner label={$t('detail.loadingMessage')} />
   {:else if $messageDetail.status === 'error'}
@@ -212,6 +221,13 @@ ${bodyHtml}
     filter: grayscale(1);
     user-select: none;
     -webkit-user-select: none;
+  }
+
+  /* full-bleed variant: the chosen image covers the whole empty pane. */
+  .placeholder-full {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
   }
 
   .toolbar-bar {

--- a/frontend/src/components/settings/SettingsPanel.svelte
+++ b/frontend/src/components/settings/SettingsPanel.svelte
@@ -98,6 +98,7 @@
     setComposeAutocomplete,
     setComposeChips,
     setEmptyStateImage,
+    setEmptyStateFullscreen,
     setMenuBarInApp,
     setMenuBarNativeMinimal,
     setMenuBarIcons,
@@ -705,6 +706,16 @@
                 </div>
               </div>
             {/if}
+            <div class="toggle" class:disabled={!$prefs.emptyStateImage} title={$t('settingsPanel.hint.emptyStateFullscreen')}>
+              <span class="row-label">{$t('settingsPanel.toggle.emptyStateFullscreen')}</span>
+              <ToggleSwitch
+                checked={$prefs.emptyStateFullscreen}
+                disabled={!$prefs.emptyStateImage}
+                label={$t('settingsPanel.toggle.emptyStateFullscreen')}
+                on:change={(e) => setEmptyStateFullscreen(e.detail)}
+              />
+            </div>
+            <p class="hint">{$t('settingsPanel.hint.emptyStateFullscreen')}</p>
           </div>
         </section>
       {:else if active === 'list'}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -686,6 +686,7 @@ export const SettingKeys = {
   composeChips: 'compose_chips',
   updateCheckFrequency: 'update_check_frequency',
   emptyStateImage: 'empty_state_image',
+  emptyStateFullscreen: 'empty_state_fullscreen',
   cornerStyle: 'corner_style',
   themeId: 'theme_id',
   menuBarInApp: 'menu_bar_in_app',

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -829,6 +829,8 @@ const de: Record<string, string> = {
   'settingsPanel.label.interfaceScale': 'Oberflächengröße',
   'settingsPanel.hint.interfaceScale': 'Zoomt die gesamte Oberfläche. Mach alles etwas größer oder kleiner.',
   'settingsPanel.label.emptyStateImage': 'Bild im Lesebereich',
+  'settingsPanel.toggle.emptyStateFullscreen': 'Bereich mit dem Bild füllen',
+  'settingsPanel.hint.emptyStateFullscreen': 'Zeigt dein Bild als vollflächigen Hintergrund statt als kleine, zentrierte Marke. Erfordert ein ausgewähltes Bild.',
   'settingsPanel.hint.emptyStateImage': 'Das Bild, das im Lesebereich erscheint, wenn keine Nachricht geöffnet ist.',
   'settingsPanel.button.selectImage': 'Bild auswählen',
   'settingsPanel.button.resetImage': 'Auf Standard zurücksetzen',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -829,6 +829,8 @@ const en: Record<string, string> = {
   'settingsPanel.label.interfaceScale': 'Interface scale',
   'settingsPanel.hint.interfaceScale': 'Zooms the whole interface. Make everything a bit bigger or smaller.',
   'settingsPanel.label.emptyStateImage': 'Reading pane image',
+  'settingsPanel.toggle.emptyStateFullscreen': 'Fill the pane with the image',
+  'settingsPanel.hint.emptyStateFullscreen': 'Show your image as a full-bleed background instead of a small centered mark. Needs a selected image.',
   'settingsPanel.hint.emptyStateImage': 'The image shown in the reading pane when no message is open.',
   'settingsPanel.button.selectImage': 'Select image',
   'settingsPanel.button.resetImage': 'Reset to default',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -829,6 +829,8 @@ const es: Record<string, string> = {
   'settingsPanel.label.interfaceScale': 'Escala de la interfaz',
   'settingsPanel.hint.interfaceScale': 'Amplía toda la interfaz. Haz que todo sea un poco más grande o más pequeño.',
   'settingsPanel.label.emptyStateImage': 'Imagen del panel de lectura',
+  'settingsPanel.toggle.emptyStateFullscreen': 'Rellenar el panel con la imagen',
+  'settingsPanel.hint.emptyStateFullscreen': 'Muestra tu imagen como fondo a sangre completa en lugar de una pequeña marca centrada. Requiere una imagen seleccionada.',
   'settingsPanel.hint.emptyStateImage': 'La imagen que se muestra en el panel de lectura cuando no hay ningún mensaje abierto.',
   'settingsPanel.button.selectImage': 'Elegir imagen',
   'settingsPanel.button.resetImage': 'Restablecer',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -829,6 +829,8 @@ const fr: Record<string, string> = {
   'settingsPanel.label.interfaceScale': 'Échelle de l\'interface',
   'settingsPanel.hint.interfaceScale': 'Zoome sur toute l\'interface. Rend tout un peu plus grand ou plus petit.',
   'settingsPanel.label.emptyStateImage': 'Image du volet de lecture',
+  'settingsPanel.toggle.emptyStateFullscreen': 'Remplir le volet avec l’image',
+  'settingsPanel.hint.emptyStateFullscreen': 'Affiche votre image en fond plein écran au lieu d’une petite marque centrée. Nécessite une image sélectionnée.',
   'settingsPanel.hint.emptyStateImage': 'L\'image affichée dans le volet de lecture quand aucun message n\'est ouvert.',
   'settingsPanel.button.selectImage': 'Choisir une image',
   'settingsPanel.button.resetImage': 'Réinitialiser',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -829,6 +829,8 @@ const nl: Record<string, string> = {
   'settingsPanel.label.interfaceScale': 'Interfacegrootte',
   'settingsPanel.hint.interfaceScale': 'Zoomt de hele interface. Maak alles een beetje groter of kleiner.',
   'settingsPanel.label.emptyStateImage': 'Afbeelding leesvenster',
+  'settingsPanel.toggle.emptyStateFullscreen': 'Venster vullen met de afbeelding',
+  'settingsPanel.hint.emptyStateFullscreen': 'Toont je afbeelding als volledige achtergrond in plaats van een klein gecentreerd merk. Vereist een geselecteerde afbeelding.',
   'settingsPanel.hint.emptyStateImage': 'De afbeelding in het leesvenster wanneer er geen bericht open is.',
   'settingsPanel.button.selectImage': 'Afbeelding kiezen',
   'settingsPanel.button.resetImage': 'Terug naar standaard',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -237,6 +237,9 @@ export interface UIPrefs {
   // emptyStateImage is a data-uri image shown in the reading pane when no
   // message is open; empty means the bundled Pelton logo.
   emptyStateImage: string
+  // emptyStateFullscreen shows the empty-state image as a full-bleed cover
+  // background instead of a small centered mark.
+  emptyStateFullscreen: boolean
   // cornerStyle picks the corner radius look: default, square, or round.
   cornerStyle: string
   // themeId selects an installed custom theme; empty means the built-in

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -60,6 +60,7 @@ const defaults: UIPrefs = {
   composeChips: true,
   updateCheckFrequency: 'off',
   emptyStateImage: '',
+  emptyStateFullscreen: false,
   cornerStyle: 'default',
   themeId: '',
   menuBarInApp: false,
@@ -330,6 +331,13 @@ export function setUpdateCheckFrequency(value: string): void {
 export function setEmptyStateImage(value: string): void {
   prefs.update((p) => ({ ...p, emptyStateImage: value }))
   void setSetting(SettingKeys.emptyStateImage, value)
+}
+
+// setEmptyStateFullscreen toggles showing the empty-state image as a full-bleed
+// cover background instead of a small centered mark.
+export function setEmptyStateFullscreen(value: boolean): void {
+  prefs.update((p) => ({ ...p, emptyStateFullscreen: value }))
+  void setSetting(SettingKeys.emptyStateFullscreen, String(value))
 }
 
 // setAutoSyncInterval persists how often a full sync pass runs, in seconds (0

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -978,6 +978,7 @@ export namespace desktop {
 	    composeChips: boolean;
 	    updateCheckFrequency: string;
 	    emptyStateImage: string;
+	    emptyStateFullscreen: boolean;
 	    cornerStyle: string;
 	    themeId: string;
 	    menuBarInApp: boolean;
@@ -1044,6 +1045,7 @@ export namespace desktop {
 	        this.composeChips = source["composeChips"];
 	        this.updateCheckFrequency = source["updateCheckFrequency"];
 	        this.emptyStateImage = source["emptyStateImage"];
+	        this.emptyStateFullscreen = source["emptyStateFullscreen"];
 	        this.cornerStyle = source["cornerStyle"];
 	        this.themeId = source["themeId"];
 	        this.menuBarInApp = source["menuBarInApp"];

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -57,6 +57,7 @@ const (
 	settingComposeAutocomplete = "compose_autocomplete"
 	settingComposeChips        = "compose_chips"
 	settingEmptyStateImage     = "empty_state_image"
+	settingEmptyStateFull      = "empty_state_fullscreen"
 	// menu bar settings only matter on macOS: Windows/Linux always use the
 	// in-app bar (no native menu is created there at all).
 	settingMenuBarInApp         = "menu_bar_in_app"
@@ -227,6 +228,9 @@ type UIPrefsDTO struct {
 	// EmptyStateImage is a data-uri image shown in the reading pane when no
 	// message is open. Empty means the bundled Pelton logo.
 	EmptyStateImage string `json:"emptyStateImage"`
+	// EmptyStateFullscreen shows the empty-state image as a full-bleed cover
+	// background instead of a small centered mark. Off by default.
+	EmptyStateFullscreen bool `json:"emptyStateFullscreen"`
 	// CornerStyle picks the corner radius look: default, square, or round.
 	CornerStyle string `json:"cornerStyle"`
 	// ThemeID selects an installed custom theme (see bind_themes.go). Empty
@@ -313,6 +317,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 		ComposeChips:               a.boolSetting(settingComposeChips, true),
 		UpdateCheckFrequency:       a.stringSetting(settingUpdateCheckFreq, defaultUpdateCheckFrequency),
 		EmptyStateImage:            a.stringSetting(settingEmptyStateImage, ""),
+		EmptyStateFullscreen:       a.boolSetting(settingEmptyStateFull, false),
 		CornerStyle:                a.stringSetting(settingCornerStyle, "default"),
 		ThemeID:                    a.stringSetting(settingThemeID, ""),
 		MenuBarInApp:               a.boolSetting(settingMenuBarInApp, false),


### PR DESCRIPTION
Closes #148.

Adds an option to show the empty-state image as a full-screen background of the reading pane, instead of the small centered mark.

## Changes

- New `emptyStateFullscreen` boolean preference, **off by default**.
- When on (and an empty-state image is set), the reading pane renders that image as a full-bleed `cover` background when no message is open. Otherwise the existing small, faded, centered mark is unchanged.
- Toggle added in Settings next to the empty-state image picker; it is disabled until an image is chosen.
- Wired through backend setting (`empty_state_fullscreen`), UIPrefsDTO, prefs store + setter, api key, types, and generated bindings.
- i18n keys added to all five locales (en/de/fr/es/nl).

## Verification

- go build, svelte-check, and pnpm build all clean.
