### PR TITLE
feat: persistent per-message remote content allow

### DIFF
--- a/frontend/src/components/detail/MailBody.svelte
+++ b/frontend/src/components/detail/MailBody.svelte
@@ -9,9 +9,9 @@
   // asks the backend to re-render with remote content allowed.
   import { onDestroy } from 'svelte'
   import { BrowserOpenURL } from '../../../wailsjs/runtime/runtime'
-  import { IconPhoto, IconUserCheck, IconWorldCheck } from '@tabler/icons-svelte'
+  import { IconPhoto, IconUserCheck, IconWorldCheck, IconMailCheck } from '@tabler/icons-svelte'
   import { prefs } from '../../stores/prefs'
-  import { getMessageHtml, trustSenderImages, allowDomainImages } from '../../lib/api'
+  import { getMessageHtml, trustSenderImages, allowDomainImages, allowRemoteForMessage } from '../../lib/api'
   import { setBodyHtml } from '../../stores/message'
   import { errorMessage, toastError, toastSuccess } from '../../stores/toast'
   import { displayName, linkifySegments } from '../../lib/format'
@@ -274,6 +274,17 @@
       toastError(errorMessage(err))
     }
   }
+
+  // allow remote content for this one message only (persists), then show it now.
+  // nothing else from the sender or domain is trusted.
+  async function trustThisEmail(): Promise<void> {
+    try {
+      await allowRemoteForMessage(detail.id)
+      await loadRemote()
+    } catch (err) {
+      toastError(errorMessage(err))
+    }
+  }
 </script>
 
 {#if detail.hasRemoteContent && !remoteLoaded}
@@ -290,6 +301,10 @@
       <button type="button" class="remote-btn" on:click={loadRemote}>
         <IconPhoto size={14} stroke={1.6} />
         {$t('detail.mailBody.loadOnce')}
+      </button>
+      <button type="button" class="remote-btn" on:click={trustThisEmail} title={$t('detail.mailBody.thisEmailTitle')}>
+        <IconMailCheck size={14} stroke={1.6} />
+        {$t('detail.mailBody.thisEmail')}
       </button>
       <button type="button" class="remote-btn" on:click={trustSender} title={$t('detail.mailBody.alwaysLoadFrom').replace('{who}', senderLabel)}>
         <IconUserCheck size={14} stroke={1.6} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -355,6 +355,12 @@ export function allowDomainImages(messageId: number): Promise<void> {
   return App.AllowDomainImages(messageId)
 }
 
+// allowRemoteForMessage permanently allows remote content for this one message,
+// without trusting the whole sender or domain.
+export function allowRemoteForMessage(messageId: number): Promise<void> {
+  return App.AllowRemoteForMessage(messageId)
+}
+
 // ImageAllowEntry is one trusted sender or domain in the remote-image
 // allowlist, with an example cached message when one exists.
 export type ImageAllowEntry = desktop.ImageAllowEntryDTO

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -494,6 +494,8 @@ const de: Record<string, string> = {
   'detail.mailBody.more': '+{count} weitere',
   'detail.mailBody.loadOnce': 'Einmal laden',
   'detail.mailBody.alwaysLoadFrom': 'Bilder von {who} immer laden',
+  'detail.mailBody.thisEmail': 'Diese E-Mail',
+  'detail.mailBody.thisEmailTitle': 'Externe Inhalte immer für diese eine E-Mail laden',
   'detail.mailBody.thisSender': 'Dieser Absender',
   'detail.mailBody.thisDomain': 'Diese Domain',
   'detail.mailBody.iframeTitle': 'Nachrichteninhalt',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -494,6 +494,8 @@ const en: Record<string, string> = {
   'detail.mailBody.more': '+{count} more',
   'detail.mailBody.loadOnce': 'Load once',
   'detail.mailBody.alwaysLoadFrom': 'Always load images from {who}',
+  'detail.mailBody.thisEmail': 'This email',
+  'detail.mailBody.thisEmailTitle': 'Always load remote content for this one email',
   'detail.mailBody.thisSender': 'This sender',
   'detail.mailBody.thisDomain': 'This domain',
   'detail.mailBody.iframeTitle': 'Message content',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -494,6 +494,8 @@ const es: Record<string, string> = {
   'detail.mailBody.more': '+{count} más',
   'detail.mailBody.loadOnce': 'Cargar una vez',
   'detail.mailBody.alwaysLoadFrom': 'Cargar siempre imágenes de {who}',
+  'detail.mailBody.thisEmail': 'Este correo',
+  'detail.mailBody.thisEmailTitle': 'Cargar siempre el contenido remoto solo para este correo',
   'detail.mailBody.thisSender': 'Este remitente',
   'detail.mailBody.thisDomain': 'Este dominio',
   'detail.mailBody.iframeTitle': 'Contenido del mensaje',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -494,6 +494,8 @@ const fr: Record<string, string> = {
   'detail.mailBody.more': '+{count} de plus',
   'detail.mailBody.loadOnce': 'Charger une fois',
   'detail.mailBody.alwaysLoadFrom': 'Toujours charger les images de {who}',
+  'detail.mailBody.thisEmail': 'Cet e-mail',
+  'detail.mailBody.thisEmailTitle': 'Toujours charger le contenu distant pour cet e-mail uniquement',
   'detail.mailBody.thisSender': 'Cet expéditeur',
   'detail.mailBody.thisDomain': 'Ce domaine',
   'detail.mailBody.iframeTitle': 'Contenu du message',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -494,6 +494,8 @@ const nl: Record<string, string> = {
   'detail.mailBody.more': '+{count} meer',
   'detail.mailBody.loadOnce': 'Eén keer laden',
   'detail.mailBody.alwaysLoadFrom': 'Altijd afbeeldingen laden van {who}',
+  'detail.mailBody.thisEmail': 'Deze e-mail',
+  'detail.mailBody.thisEmailTitle': 'Externe inhoud altijd laden voor alleen deze e-mail',
   'detail.mailBody.thisSender': 'Deze afzender',
   'detail.mailBody.thisDomain': 'Dit domein',
   'detail.mailBody.iframeTitle': 'Berichtinhoud',

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -10,6 +10,8 @@ export function AddVIPSender(arg1:string):Promise<void>;
 
 export function AllowDomainImages(arg1:number):Promise<void>;
 
+export function AllowRemoteForMessage(arg1:number):Promise<void>;
+
 export function AppVersion():Promise<string>;
 
 export function ArchiveMessage(arg1:number):Promise<desktop.ArchiveUndoDTO>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -18,6 +18,10 @@ export function AllowDomainImages(arg1) {
   return window['go']['desktop']['App']['AllowDomainImages'](arg1);
 }
 
+export function AllowRemoteForMessage(arg1) {
+  return window['go']['desktop']['App']['AllowRemoteForMessage'](arg1);
+}
+
 export function AppVersion() {
   return window['go']['desktop']['App']['AppVersion']();
 }

--- a/internal/desktop/bind_images.go
+++ b/internal/desktop/bind_images.go
@@ -3,6 +3,8 @@ package desktop
 import (
 	"fmt"
 	"strings"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
 )
 
 // remote image allowlist. mail remote content (images) is blocked by default to
@@ -11,8 +13,9 @@ import (
 // are consulted when a message is rendered so trusted senders load immediately
 // with no banner.
 const (
-	settingRemoteSenders = "remote_allow_senders"
-	settingRemoteDomains = "remote_allow_domains"
+	settingRemoteSenders  = "remote_allow_senders"
+	settingRemoteDomains  = "remote_allow_domains"
+	settingRemoteMessages = "remote_allow_messages"
 )
 
 // remoteSenders returns the lowercased from-addresses the user trusts for remote
@@ -28,6 +31,50 @@ func (a *App) remoteDomains() []string {
 	var out []string
 	_ = a.store.GetJSON(a.ctx, settingRemoteDomains, &out)
 	return out
+}
+
+// remoteMessages returns the stable keys of individual messages the user has
+// allowed remote content for, without trusting their sender or domain.
+func (a *App) remoteMessages() []string {
+	var out []string
+	_ = a.store.GetJSON(a.ctx, settingRemoteMessages, &out)
+	return out
+}
+
+// messageRemoteKey is the stable key used to remember a per-message remote
+// allow: the RFC Message-ID header when present (so it survives re-sync and
+// expunge), otherwise a local fallback tied to the row id.
+func messageRemoteKey(m *storage.Message) string {
+	if id := strings.ToLower(strings.TrimSpace(m.MessageID)); id != "" {
+		return id
+	}
+	return fmt.Sprintf("local:%d", m.ID)
+}
+
+// remoteMessageAllowed reports whether this one message was individually allowed
+// to render remote content.
+func (a *App) remoteMessageAllowed(m *storage.Message) bool {
+	key := messageRemoteKey(m)
+	for _, k := range a.remoteMessages() {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowRemoteForMessage permanently allows remote content for this one message,
+// keyed by its Message-ID, without trusting the whole sender or domain.
+func (a *App) AllowRemoteForMessage(messageID int64) error {
+	if err := a.ready(); err != nil {
+		return err
+	}
+	m, err := a.store.GetMessage(a.ctx, messageID)
+	if err != nil {
+		return err
+	}
+	keys := appendUnique(a.remoteMessages(), messageRemoteKey(m))
+	return a.store.SetJSON(a.ctx, settingRemoteMessages, keys)
 }
 
 // remoteAutoAllow reports whether a message from fromAddress should render remote

--- a/internal/desktop/bind_images_test.go
+++ b/internal/desktop/bind_images_test.go
@@ -1,0 +1,20 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+func TestMessageRemoteKey(t *testing.T) {
+	// a present Message-ID is used verbatim (lowercased/trimmed) so the allow
+	// survives re-sync, expunge and a changed local row id.
+	got := messageRemoteKey(&storage.Message{ID: 7, MessageID: "  <ABC@Example.com>  "})
+	if got != "<abc@example.com>" {
+		t.Errorf("messageRemoteKey with Message-ID = %q, want %q", got, "<abc@example.com>")
+	}
+	// without a Message-ID it falls back to the local row id.
+	if got := messageRemoteKey(&storage.Message{ID: 42}); got != "local:42" {
+		t.Errorf("messageRemoteKey fallback = %q, want %q", got, "local:42")
+	}
+}

--- a/internal/desktop/bind_messages.go
+++ b/internal/desktop/bind_messages.go
@@ -92,8 +92,9 @@ func (a *App) GetMessage(id int64) (MessageDetailDTO, error) {
 	}
 
 	// trusted senders/domains (or the global setting) render remote content with
-	// no prompt; everyone else is blocked until the user asks.
-	autoAllow := a.remoteAutoAllow(m.FromAddress)
+	// no prompt; a per-message allow does the same for this one message; everyone
+	// else is blocked until the user asks.
+	autoAllow := a.remoteAutoAllow(m.FromAddress) || a.remoteMessageAllowed(m)
 
 	detail := MessageDetailDTO{
 		MessageSummaryDTO: summary,


### PR DESCRIPTION
Closes #136.

Adds a persistent per-message remote-content allow, so a newsletter or receipt you reopen often can render remote images every time without trusting the whole sender or domain.

## Approach

Chose option 1 from the issue: a fourth banner action, **This email**, alongside "Load once" / "This sender" / "This domain". It is non-modal and does not change what "Load once" does (which stays ephemeral).

## Changes

- Backend `AllowRemoteForMessage(messageID)` records the message in a new `remote_allow_messages` setting. It is keyed by the RFC **Message-ID** header (lowercased/trimmed) so the allow survives re-sync, expunge and a changed local row id; when a message has no Message-ID it falls back to `local:<row id>`.
- `GetMessage` now renders remote content when the message is individually allowed: `remoteAutoAllow(from) || remoteMessageAllowed(m)`. The existing global / sender / domain paths are untouched, so privacy defaults (blocked by default) are unchanged and this stays an explicit per-message opt-in.
- Frontend: new banner button wired to `allowRemoteForMessage`; on click it persists and renders remote content immediately. New i18n keys added to all five locales (en/de/fr/es/nl). No em-dashes.
- Generated Wails bindings + api wrapper updated for the new method.

## Tests / verification

- `internal/desktop/bind_images_test.go`: Message-ID keying and local fallback.
- go build, go test (internal/desktop), svelte-check and pnpm build all pass.
