### PR TITLE
feat: ship warranty and liability terms with installer, packages and releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# the windows installer reads this file verbatim: NSIS needs CRLF and the
+# UTF-8 BOM to render the liability page correctly.
+build/windows/installer/disclaimer.txt text eol=crlf

--- a/.github/nfpm/pelton.yaml
+++ b/.github/nfpm/pelton.yaml
@@ -24,6 +24,11 @@ contents:
     dst: /usr/share/icons/hicolor/1024x1024/apps/pelton.png
   - src: ./build/icons/pelton-default.png
     dst: /usr/share/pixmaps/pelton.png
+  # GPL-3.0 plus the warranty/liability terms that go with the copy
+  - src: ./LICENSE
+    dst: /usr/share/doc/pelton/LICENSE
+  - src: ./DISCLAIMER.md
+    dst: /usr/share/doc/pelton/DISCLAIMER.md
 
 # Fedora runtime package names; applied to the .rpm. The .deb overrides these
 # below with the Debian/Ubuntu names.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -112,6 +112,19 @@ jobs:
             if (PREVIOUS_TAG) {
               parts.push(`**Full Changelog**: https://github.com/${owner}/${repo}/compare/${PREVIOUS_TAG}...${CURRENT_TAG}`);
             }
+
+            // downloads straight from this page skip the confirmation on
+            // pelton.app, so the disclaimer has to be on the release itself
+            parts.push(
+              [
+                "---",
+                "",
+                "Pelton is free software under the GPL-3.0, provided without warranty and used at your own risk. It connects to your real mailboxes, deletions can be permanent, and Pelton is not a backup tool. Keep your own backup of anything you cannot afford to lose.",
+                "",
+                `Warranty and liability: [DISCLAIMER.md](https://github.com/${owner}/${repo}/blob/main/DISCLAIMER.md) - [pelton.app/terms](https://pelton.app/terms)`,
+              ].join("\n")
+            );
+
             const body = parts.join("\n\n");
 
             // getReleaseByTag only ever finds published releases, never

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,205 @@
+# Warranty and liability
+
+Pelton is provided free of charge by Stellar Foundry GmbH,
+Thomas-Mann-Straße 19, 53111 Bonn, Germany.
+
+This document is an additional term under section 7(a) of the GNU General
+Public License, version 3. For copies of Pelton distributed by Stellar
+Foundry GmbH, the sections below take the place of the warranty and
+liability provisions in sections 15 and 16 of the GPLv3. Anyone
+redistributing Pelton may remove this additional term under section 7,
+paragraph 2 of the GPLv3; that does not affect the redistributor's own
+liability for the copy they distribute.
+
+It does not restrict the rights the GPLv3 grants you to use, copy, modify
+and redistribute Pelton. The German version below is authoritative; the
+English text is a translation for convenience. The current version is
+published at https://pelton.app/terms.
+
+Last updated: 30 July 2026
+
+## 1. No warranty
+
+Pelton is provided free of charge and as it stands. We do not warrant that
+the software is free of defects, that it is continuously available, that it
+is fit for any particular purpose, or that it works with any given operating
+system, email provider or protocol implementation.
+
+Because the software is provided free of charge, we are liable for defects
+in quality only where we fraudulently concealed a defect (section 524 German
+Civil Code) and for defects in title accordingly (section 523 German Civil
+Code).
+
+## 2. Liability
+
+a) We are liable without limitation for intent and gross negligence, for
+injury to life, body or health, for the fraudulent concealment of a defect,
+to the extent of any guarantee we have expressly given, and in all cases of
+mandatory statutory liability, in particular under the German Product
+Liability Act.
+
+b) Otherwise our liability is limited to intent and gross negligence under
+section 521 of the German Civil Code, because we provide Pelton free of
+charge.
+
+c) Where we are nevertheless liable for ordinary negligence in breaching a
+material obligation, that liability is limited to the damage that was
+foreseeable and typical at the time the software was provided.
+
+d) Any liability beyond this is excluded. The limitations above also apply
+for the benefit of our legal representatives, employees and agents.
+
+## 3. Data integrity and backups
+
+Pelton connects to your live mailboxes and stores messages and metadata
+locally on your device. We do not warrant that locally stored data is
+complete, permanently available or recoverable, nor that an action you
+trigger in Pelton produces the expected result on your email provider's
+server. Deletions can be permanent.
+
+Pelton is not a backup tool and does not replace one. Keeping your own
+independent backup of your data is your responsibility. You use the software
+at your own risk.
+
+## 4. Development status, support and updates
+
+Pelton is under active development. Features may change, be restricted or be
+removed, and data formats may change between versions.
+
+You can report bugs as an issue at https://github.com/TRC-Loop/Pelton and we
+do read those reports. There is no entitlement to a reply, a fix, further
+development, updates or any level of availability.
+
+## 5. Third-party services
+
+Pelton communicates directly with the email providers you set up and, if you
+configure them, with further services such as MCP servers. We operate no
+servers in the data path and have no access to your messages or credentials.
+The respective provider is solely responsible for the performance,
+availability, security and terms of those services. The same applies to
+themes, extensions and configurations you obtain from third parties.
+
+## 6. Reporting security issues
+
+Please report security vulnerabilities confidentially as described in
+SECURITY.md rather than as a public issue.
+
+## 7. Governing law
+
+These terms are governed by the law of the Federal Republic of Germany. If
+you are a consumer, the mandatory consumer protection provisions of the
+country in which you have your habitual residence remain unaffected.
+
+## 8. Severability and changes
+
+If any provision of these terms is invalid, the remaining provisions stay in
+force. We may adjust these terms for future versions. For a version you have
+already downloaded, the wording published at the time of that download
+applies.
+
+---
+
+# Gewährleistung und Haftung
+
+Diese deutsche Fassung ist maßgeblich.
+
+Pelton wird unentgeltlich bereitgestellt von der Stellar Foundry GmbH,
+Thomas-Mann-Straße 19, 53111 Bonn, Deutschland.
+
+Dieses Dokument ist eine Zusatzbedingung nach § 7 lit. a der GNU
+General Public License, Version 3. Für Kopien von Pelton, die von der
+Stellar Foundry GmbH bereitgestellt werden, treten die nachfolgenden
+Ziffern an die Stelle der Gewährleistungs- und Haftungsregelungen in den
+§§ 15 und 16 GPLv3. Wer Pelton weitergibt, darf diese
+Zusatzbedingung nach § 7 Abs. 2 GPLv3 entfernen; die Haftung des
+Weitergebenden für die von ihm verbreitete Kopie bleibt davon unberührt.
+
+Die durch die GPLv3 gewährten Rechte an Nutzung, Vervielfältigung,
+Veränderung und Weitergabe werden dadurch nicht eingeschränkt. Die
+aktuelle Fassung ist unter https://pelton.app/terms/de veröffentlicht.
+
+Stand: 30. Juli 2026
+
+## 1. Keine Gewährleistung
+
+Pelton wird unentgeltlich und in der jeweils vorliegenden Fassung
+bereitgestellt. Wir sichern nicht zu, dass die Software fehlerfrei arbeitet,
+ununterbrochen verfügbar ist, sich für einen bestimmten Zweck eignet oder
+mit einem bestimmten Betriebssystem, E-Mail-Anbieter oder Protokollstand
+zusammenarbeitet.
+
+Da die Überlassung unentgeltlich erfolgt, haften wir für Sachmängel nach
+§ 524 BGB nur bei arglistigem Verschweigen eines Mangels und für
+Rechtsmängel entsprechend § 523 BGB.
+
+## 2. Haftung
+
+a) Unbeschränkt haften wir bei Vorsatz und grober Fahrlässigkeit, bei der
+Verletzung von Leben, Körper oder Gesundheit, bei arglistigem Verschweigen
+eines Mangels, im Umfang einer von uns ausdrücklich übernommenen Garantie
+sowie in allen Fällen zwingender gesetzlicher Haftung, insbesondere nach
+dem Produkthaftungsgesetz.
+
+b) Im Übrigen ist unsere Haftung nach § 521 BGB auf Vorsatz und
+grobe Fahrlässigkeit beschränkt, da wir Pelton unentgeltlich überlassen.
+
+c) Soweit wir gleichwohl für einfache Fahrlässigkeit bei der Verletzung
+einer wesentlichen Pflicht haften, ist die Haftung auf den bei
+Bereitstellung vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
+
+d) Eine weitergehende Haftung ist ausgeschlossen. Die vorstehenden
+Beschränkungen gelten auch zugunsten unserer gesetzlichen Vertreter,
+Mitarbeiter und Erfüllungsgehilfen.
+
+## 3. Datenintegrität und Backups
+
+Pelton greift auf Ihre echten Postfächer zu und speichert Nachrichten und
+Metadaten lokal auf Ihrem Gerät. Wir sichern nicht zu, dass lokal
+gespeicherte Daten vollständig, dauerhaft verfügbar oder wiederherstellbar
+sind, und nicht, dass eine in Pelton ausgelöste Aktion beim Server Ihres
+E-Mail-Anbieters das erwartete Ergebnis hat. Löschvorgänge können
+endgültig sein.
+
+Pelton ist kein Backup-Werkzeug und ersetzt kein Backup. Für eine eigene,
+unabhängige Sicherung Ihrer Daten sind Sie selbst verantwortlich. Die
+Nutzung erfolgt auf eigene Gefahr.
+
+## 4. Entwicklungsstand, Support und Updates
+
+Pelton befindet sich in aktiver Entwicklung. Funktionen können sich
+ändern, eingeschränkt werden oder entfallen, und Datenformate können sich
+zwischen Versionen ändern.
+
+Sie können Fehler als Issue unter https://github.com/TRC-Loop/Pelton
+melden, und wir lesen diese Meldungen. Ein Anspruch auf Antwort,
+Fehlerbehebung, Weiterentwicklung, Updates oder eine bestimmte
+Verfügbarkeit besteht nicht.
+
+## 5. Drittanbieter
+
+Pelton kommuniziert direkt mit den von Ihnen eingerichteten E-Mail-Anbietern
+und, sofern Sie das konfigurieren, mit weiteren Diensten wie MCP-Servern.
+Wir betreiben keine Server im Datenpfad und haben keinen Zugriff auf Ihre
+Nachrichten oder Zugangsdaten. Für Leistung, Verfügbarkeit, Sicherheit und
+Bedingungen dieser Dienste ist allein der jeweilige Anbieter verantwortlich.
+Das gilt auch für Themes, Erweiterungen und Konfigurationen, die Sie von
+Dritten beziehen.
+
+## 6. Sicherheitslücken melden
+
+Sicherheitslücken melden Sie bitte vertraulich wie in SECURITY.md
+beschrieben und nicht als öffentliches Issue.
+
+## 7. Anwendbares Recht
+
+Es gilt das Recht der Bundesrepublik Deutschland. Sind Sie Verbraucher,
+bleiben die zwingenden Verbraucherschutzvorschriften des Staates
+unberührt, in dem Sie Ihren gewöhnlichen Aufenthalt haben.
+
+## 8. Salvatorische Klausel und Änderungen
+
+Sollte eine Bestimmung dieser Bedingungen unwirksam sein, bleibt die
+Wirksamkeit der übrigen Bestimmungen unberührt. Wir können diese
+Bedingungen für künftige Versionen anpassen. Für eine bereits von Ihnen
+bezogene Version gilt die Fassung, die zum Zeitpunkt des Downloads
+veröffentlicht war.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -6,10 +6,9 @@ Thomas-Mann-Straße 19, 53111 Bonn, Germany.
 This document is an additional term under section 7(a) of the GNU General
 Public License, version 3. For copies of Pelton distributed by Stellar
 Foundry GmbH, the sections below take the place of the warranty and
-liability provisions in sections 15 and 16 of the GPLv3. Anyone
-redistributing Pelton may remove this additional term under section 7,
-paragraph 2 of the GPLv3; that does not affect the redistributor's own
-liability for the copy they distribute.
+liability provisions in sections 15 and 16 of the GPLv3. They do not apply
+to copies distributed by third parties; a redistributor's liability follows
+the terms under which they provide their copy.
 
 It does not restrict the rights the GPLv3 grants you to use, copy, modify
 and redistribute Pelton. The German version below is authoritative; the
@@ -25,10 +24,10 @@ the software is free of defects, that it is continuously available, that it
 is fit for any particular purpose, or that it works with any given operating
 system, email provider or protocol implementation.
 
-Because the software is provided free of charge, we are liable for defects
-in quality only where we fraudulently concealed a defect (section 524 German
-Civil Code) and for defects in title accordingly (section 523 German Civil
-Code).
+Where German gift law applies to the free provision of software, we are
+liable for defects in quality and in title only where we fraudulently
+concealed a defect (sections 524 and 523 German Civil Code applied
+accordingly).
 
 ## 2. Liability
 
@@ -38,18 +37,29 @@ to the extent of any guarantee we have expressly given, and in all cases of
 mandatory statutory liability, in particular under the German Product
 Liability Act.
 
-b) Otherwise our liability is limited to intent and gross negligence under
-section 521 of the German Civil Code, because we provide Pelton free of
-charge.
+b) For the ordinarily negligent breach of a material obligation, meaning an
+obligation whose fulfilment is what makes using Pelton as intended possible
+at all, our liability is limited to the damage that was foreseeable and
+typical at the time the software was provided.
 
-c) Where we are nevertheless liable for ordinary negligence in breaching a
-material obligation, that liability is limited to the damage that was
-foreseeable and typical at the time the software was provided.
+c) Any other liability is excluded.
 
-d) Any liability beyond this is excluded. The limitations above also apply
-for the benefit of our legal representatives, employees and agents.
+d) Where German gift law applies to the free provision of the software, the
+statutory privilege under section 521 German Civil Code, limiting our
+liability to intent and gross negligence, remains unaffected.
 
-## 3. Data integrity and backups
+e) The limitations above also apply for the benefit of our legal
+representatives, employees and agents.
+
+## 3. Mandatory consumer rights
+
+Mandatory rights consumers have under the German provisions on contracts for
+digital products (sections 327 et seq. German Civil Code) remain unaffected
+where those provisions apply. Sections 1, 2 and 5 of this document then apply
+only as far as differing agreements are permitted under section 327h German
+Civil Code.
+
+## 4. Data integrity and backups
 
 Pelton connects to your live mailboxes and stores messages and metadata
 locally on your device. We do not warrant that locally stored data is
@@ -61,16 +71,17 @@ Pelton is not a backup tool and does not replace one. Keeping your own
 independent backup of your data is your responsibility. You use the software
 at your own risk.
 
-## 4. Development status, support and updates
+## 5. Development status, support and updates
 
 Pelton is under active development. Features may change, be restricted or be
 removed, and data formats may change between versions.
 
 You can report bugs as an issue at https://github.com/TRC-Loop/Pelton and we
 do read those reports. There is no entitlement to a reply, a fix, further
-development, updates or any level of availability.
+development, updates or any level of availability, unless mandatory law
+provides otherwise.
 
-## 5. Third-party services
+## 6. Third-party services
 
 Pelton communicates directly with the email providers you set up and, if you
 configure them, with further services such as MCP servers. We operate no
@@ -79,23 +90,21 @@ The respective provider is solely responsible for the performance,
 availability, security and terms of those services. The same applies to
 themes, extensions and configurations you obtain from third parties.
 
-## 6. Reporting security issues
+## 7. Reporting security issues
 
 Please report security vulnerabilities confidentially as described in
 SECURITY.md rather than as a public issue.
 
-## 7. Governing law
+## 8. Governing law
 
 These terms are governed by the law of the Federal Republic of Germany. If
 you are a consumer, the mandatory consumer protection provisions of the
 country in which you have your habitual residence remain unaffected.
 
-## 8. Severability and changes
+## 9. Changes
 
-If any provision of these terms is invalid, the remaining provisions stay in
-force. We may adjust these terms for future versions. For a version you have
-already downloaded, the wording published at the time of that download
-applies.
+We may adjust these terms for future versions. For a version you have already
+downloaded, the wording published at the time of that download applies.
 
 ---
 
@@ -110,9 +119,9 @@ Dieses Dokument ist eine Zusatzbedingung nach § 7 lit. a der GNU
 General Public License, Version 3. Für Kopien von Pelton, die von der
 Stellar Foundry GmbH bereitgestellt werden, treten die nachfolgenden
 Ziffern an die Stelle der Gewährleistungs- und Haftungsregelungen in den
-§§ 15 und 16 GPLv3. Wer Pelton weitergibt, darf diese
-Zusatzbedingung nach § 7 Abs. 2 GPLv3 entfernen; die Haftung des
-Weitergebenden für die von ihm verbreitete Kopie bleibt davon unberührt.
+§§ 15 und 16 GPLv3. Für Kopien, die Dritte weitergeben, gelten sie
+nicht; die Haftung des Weitergebenden richtet sich nach den Bedingungen,
+unter denen er die Kopie bereitstellt.
 
 Die durch die GPLv3 gewährten Rechte an Nutzung, Vervielfältigung,
 Veränderung und Weitergabe werden dadurch nicht eingeschränkt. Die
@@ -128,9 +137,10 @@ ununterbrochen verfügbar ist, sich für einen bestimmten Zweck eignet oder
 mit einem bestimmten Betriebssystem, E-Mail-Anbieter oder Protokollstand
 zusammenarbeitet.
 
-Da die Überlassung unentgeltlich erfolgt, haften wir für Sachmängel nach
-§ 524 BGB nur bei arglistigem Verschweigen eines Mangels und für
-Rechtsmängel entsprechend § 523 BGB.
+Findet auf die unentgeltliche Überlassung von Software Schenkungsrecht
+Anwendung, haften wir für Sachmängel entsprechend § 524 BGB und für
+Rechtsmängel entsprechend § 523 BGB nur bei arglistigem Verschweigen eines
+Mangels.
 
 ## 2. Haftung
 
@@ -140,18 +150,29 @@ eines Mangels, im Umfang einer von uns ausdrücklich übernommenen Garantie
 sowie in allen Fällen zwingender gesetzlicher Haftung, insbesondere nach
 dem Produkthaftungsgesetz.
 
-b) Im Übrigen ist unsere Haftung nach § 521 BGB auf Vorsatz und
-grobe Fahrlässigkeit beschränkt, da wir Pelton unentgeltlich überlassen.
+b) Bei einfach fahrlässiger Verletzung einer wesentlichen Pflicht, also
+einer Pflicht, deren Erfüllung die bestimmungsgemäße Nutzung von Pelton
+überhaupt erst ermöglicht, ist unsere Haftung auf den bei Bereitstellung
+vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
 
-c) Soweit wir gleichwohl für einfache Fahrlässigkeit bei der Verletzung
-einer wesentlichen Pflicht haften, ist die Haftung auf den bei
-Bereitstellung vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
+c) Im Übrigen ist unsere Haftung ausgeschlossen.
 
-d) Eine weitergehende Haftung ist ausgeschlossen. Die vorstehenden
-Beschränkungen gelten auch zugunsten unserer gesetzlichen Vertreter,
-Mitarbeiter und Erfüllungsgehilfen.
+d) Findet auf die unentgeltliche Überlassung Schenkungsrecht Anwendung,
+bleibt die gesetzliche Haftungsprivilegierung nach § 521 BGB, die unsere
+Haftung auf Vorsatz und grobe Fahrlässigkeit beschränkt, unberührt.
 
-## 3. Datenintegrität und Backups
+e) Die vorstehenden Beschränkungen gelten auch zugunsten unserer
+gesetzlichen Vertreter, Mitarbeiter und Erfüllungsgehilfen.
+
+## 3. Zwingende Verbraucherrechte
+
+Zwingende Rechte, die Verbrauchern nach den Vorschriften über Verträge über
+digitale Produkte (§§ 327 ff. BGB) zustehen, bleiben unberührt, soweit diese
+Vorschriften anwendbar sind. Die Ziffern 1, 2 und 5 dieses Dokuments gelten
+insoweit nur in dem Umfang, in dem abweichende Vereinbarungen nach § 327h BGB
+zulässig sind.
+
+## 4. Datenintegrität und Backups
 
 Pelton greift auf Ihre echten Postfächer zu und speichert Nachrichten und
 Metadaten lokal auf Ihrem Gerät. Wir sichern nicht zu, dass lokal
@@ -164,7 +185,7 @@ Pelton ist kein Backup-Werkzeug und ersetzt kein Backup. Für eine eigene,
 unabhängige Sicherung Ihrer Daten sind Sie selbst verantwortlich. Die
 Nutzung erfolgt auf eigene Gefahr.
 
-## 4. Entwicklungsstand, Support und Updates
+## 5. Entwicklungsstand, Support und Updates
 
 Pelton befindet sich in aktiver Entwicklung. Funktionen können sich
 ändern, eingeschränkt werden oder entfallen, und Datenformate können sich
@@ -173,9 +194,10 @@ zwischen Versionen ändern.
 Sie können Fehler als Issue unter https://github.com/TRC-Loop/Pelton
 melden, und wir lesen diese Meldungen. Ein Anspruch auf Antwort,
 Fehlerbehebung, Weiterentwicklung, Updates oder eine bestimmte
-Verfügbarkeit besteht nicht.
+Verfügbarkeit besteht nicht, soweit sich nicht aus zwingendem Recht etwas
+anderes ergibt.
 
-## 5. Drittanbieter
+## 6. Drittanbieter
 
 Pelton kommuniziert direkt mit den von Ihnen eingerichteten E-Mail-Anbietern
 und, sofern Sie das konfigurieren, mit weiteren Diensten wie MCP-Servern.
@@ -185,21 +207,19 @@ Bedingungen dieser Dienste ist allein der jeweilige Anbieter verantwortlich.
 Das gilt auch für Themes, Erweiterungen und Konfigurationen, die Sie von
 Dritten beziehen.
 
-## 6. Sicherheitslücken melden
+## 7. Sicherheitslücken melden
 
 Sicherheitslücken melden Sie bitte vertraulich wie in SECURITY.md
 beschrieben und nicht als öffentliches Issue.
 
-## 7. Anwendbares Recht
+## 8. Anwendbares Recht
 
 Es gilt das Recht der Bundesrepublik Deutschland. Sind Sie Verbraucher,
 bleiben die zwingenden Verbraucherschutzvorschriften des Staates
 unberührt, in dem Sie Ihren gewöhnlichen Aufenthalt haben.
 
-## 8. Salvatorische Klausel und Änderungen
+## 9. Änderungen
 
-Sollte eine Bestimmung dieser Bedingungen unwirksam sein, bleibt die
-Wirksamkeit der übrigen Bestimmungen unberührt. Wir können diese
-Bedingungen für künftige Versionen anpassen. Für eine bereits von Ihnen
-bezogene Version gilt die Fassung, die zum Zeitpunkt des Downloads
-veröffentlicht war.
+Wir können diese Bedingungen für künftige Versionen anpassen. Für eine
+bereits von Ihnen bezogene Version gilt die Fassung, die zum Zeitpunkt des
+Downloads veröffentlicht war.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Pelton - email client (Wails + Svelte)
 
-.PHONY: build build-mac build-win build-linux dmg run app-dev dev clean tidy deps licenses icon
+.PHONY: build build-mac build-win build-linux dmg run app-dev dev clean tidy deps licenses icon disclaimer
 
 # version string injected into the binary. it prefers the latest git tag (with a
 # short commit suffix on untagged commits) and falls back to "dev". it is wired
@@ -17,8 +17,10 @@ build:
 icon:
 	scripts/build-icon.sh
 
-# macOS build that also installs the Liquid Glass icon into the .app.
+# macOS build that also installs the Liquid Glass icon into the .app, and ships
+# the warranty/liability terms inside the bundle so they travel with the copy.
 build-mac: build icon
+	cp DISCLAIMER.md build/bin/Pelton.app/Contents/Resources/DISCLAIMER.md
 
 # macOS build packaged into a distributable .dmg (build/bin/Pelton.dmg), with a
 # drag-to-Applications drop link. Needs create-dmg (`brew install create-dmg`).
@@ -37,7 +39,7 @@ dmg: build-mac
 
 # windows build (amd64). cross-compiling from another OS needs the appropriate
 # toolchain (mingw-w64) and webview2; run on Windows for a no-fuss build.
-build-win:
+build-win: disclaimer
 	wails build -platform windows/amd64 -ldflags "$(LDFLAGS)"
 
 # linux build (amd64), then drop the .desktop launcher next to the binary so it
@@ -77,6 +79,12 @@ deps:
 
 tidy:
 	go mod tidy
+
+# render DISCLAIMER.md into the plain text the windows installer shows on its
+# liability page. the result is committed, so this only needs running after an
+# edit to DISCLAIMER.md (build-win does it anyway).
+disclaimer:
+	node scripts/gen-installer-notice.mjs
 
 # build licenses/manifest.json (embedded and shown in the about section).
 licenses:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A `.zip` of the raw `.app` (`Pelton-<version>-macos-<arch>-app.zip`) is also att
 3. The installer walks you through:
    - an installer-language picker (matches Pelton's own UI languages: English, German, French, Dutch, Spanish)
    - the GPL-3.0 license
+   - the warranty and liability terms
    - **install for all users** (needs admin) or **just me** (no admin needed)
    - an optional desktop shortcut (Start Menu shortcut is always created)
    - a "Launch Pelton" checkbox on the last page
@@ -195,3 +196,7 @@ Contributions are welcome. Whether you are fixing bugs, refining the UI layout, 
 ## <img src="https://api.iconify.design/tabler/file-certificate.svg?color=white" width="26" style="vertical-align: -4px;"> License
 
 Pelton is distributed under the **[GPL-3.0 License](https://github.com/TRC-Loop/Pelton/blob/main/LICENSE)**. See `LICENSE` for details.
+
+Warranty and liability are set out in **[DISCLAIMER.md](DISCLAIMER.md)**, an additional term under GPLv3 section 7(a), published as well at [pelton.app/terms](https://pelton.app/terms). Pelton comes without warranty and you use it at your own risk: it connects to your real mailboxes, deletions can be permanent, and it is not a backup tool. Keep your own backup of anything you cannot afford to lose.
+
+Security issues belong in [SECURITY.md](SECURITY.md), not in a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report security vulnerabilities privately, not as a public issue, not in
+Discord, and not in a pull request.
+
+Two ways, either is fine:
+
+- [Open a private security advisory](https://github.com/TRC-Loop/Pelton/security/advisories/new)
+  on GitHub.
+- Email <pelton@arne.sh> with `security` in the subject.
+
+Please include, as far as you can:
+
+- what the issue is and which part of Pelton it affects
+  (IMAP/SMTP handling, credential storage, MCP, rendering of remote content,
+  themes, the update check, the build pipeline)
+- the Pelton version and your operating system
+- steps to reproduce, or a proof of concept
+- what an attacker gains, and what they need beforehand
+
+We look at every report and will keep you updated while we work on it. We do
+not promise a response time, and there is no bug bounty. Please give us a
+reasonable chance to ship a fix before you publish details, and let us know if
+you plan to disclose on a fixed date.
+
+You are welcome to be credited in the release notes, or to stay anonymous,
+whichever you prefer.
+
+## Supported versions
+
+Pelton is under active development and fixes go into the next release. Only the
+latest release is supported; there are no backports to older versions.
+
+## Scope
+
+In scope is anything in this repository and the code it ships: the Go backend,
+the Svelte frontend, the packaging in `.github/nfpm` and `build/`, and the
+release workflows.
+
+Out of scope are the security practices of the email providers you connect to,
+issues that require an attacker to already have full access to your unlocked
+device, and the content of third-party themes or MCP servers you install
+yourself. Reports about the website belong in the
+[pelton.app repository](https://github.com/TRC-Loop/pelton.app), same contact.
+
+## What Pelton does not do
+
+Pelton has no telemetry, no analytics and no servers of ours in the data path,
+so there is no backend of ours to attack. Your mail, credentials and settings
+stay on your device, and Pelton talks only to the providers you configure and
+to GitHub when you ask it to check for updates.
+
+Warranty and liability are covered in [DISCLAIMER.md](DISCLAIMER.md).

--- a/build/windows/installer/disclaimer.txt
+++ b/build/windows/installer/disclaimer.txt
@@ -1,0 +1,203 @@
+﻿WARRANTY AND LIABILITY
+
+Pelton is provided free of charge by Stellar Foundry GmbH,
+Thomas-Mann-Straße 19, 53111 Bonn, Germany.
+
+This document is an additional term under section 7(a) of the GNU General
+Public License, version 3. For copies of Pelton distributed by Stellar
+Foundry GmbH, the sections below take the place of the warranty and
+liability provisions in sections 15 and 16 of the GPLv3. Anyone
+redistributing Pelton may remove this additional term under section 7,
+paragraph 2 of the GPLv3; that does not affect the redistributor's own
+liability for the copy they distribute.
+
+It does not restrict the rights the GPLv3 grants you to use, copy, modify
+and redistribute Pelton. The German version below is authoritative; the
+English text is a translation for convenience. The current version is
+published at https://pelton.app/terms.
+
+Last updated: 30 July 2026
+
+1. No warranty
+
+Pelton is provided free of charge and as it stands. We do not warrant that
+the software is free of defects, that it is continuously available, that it
+is fit for any particular purpose, or that it works with any given operating
+system, email provider or protocol implementation.
+
+Because the software is provided free of charge, we are liable for defects
+in quality only where we fraudulently concealed a defect (section 524 German
+Civil Code) and for defects in title accordingly (section 523 German Civil
+Code).
+
+2. Liability
+
+a) We are liable without limitation for intent and gross negligence, for
+injury to life, body or health, for the fraudulent concealment of a defect,
+to the extent of any guarantee we have expressly given, and in all cases of
+mandatory statutory liability, in particular under the German Product
+Liability Act.
+
+b) Otherwise our liability is limited to intent and gross negligence under
+section 521 of the German Civil Code, because we provide Pelton free of
+charge.
+
+c) Where we are nevertheless liable for ordinary negligence in breaching a
+material obligation, that liability is limited to the damage that was
+foreseeable and typical at the time the software was provided.
+
+d) Any liability beyond this is excluded. The limitations above also apply
+for the benefit of our legal representatives, employees and agents.
+
+3. Data integrity and backups
+
+Pelton connects to your live mailboxes and stores messages and metadata
+locally on your device. We do not warrant that locally stored data is
+complete, permanently available or recoverable, nor that an action you
+trigger in Pelton produces the expected result on your email provider's
+server. Deletions can be permanent.
+
+Pelton is not a backup tool and does not replace one. Keeping your own
+independent backup of your data is your responsibility. You use the software
+at your own risk.
+
+4. Development status, support and updates
+
+Pelton is under active development. Features may change, be restricted or be
+removed, and data formats may change between versions.
+
+You can report bugs as an issue at https://github.com/TRC-Loop/Pelton and we
+do read those reports. There is no entitlement to a reply, a fix, further
+development, updates or any level of availability.
+
+5. Third-party services
+
+Pelton communicates directly with the email providers you set up and, if you
+configure them, with further services such as MCP servers. We operate no
+servers in the data path and have no access to your messages or credentials.
+The respective provider is solely responsible for the performance,
+availability, security and terms of those services. The same applies to
+themes, extensions and configurations you obtain from third parties.
+
+6. Reporting security issues
+
+Please report security vulnerabilities confidentially as described in
+SECURITY.md rather than as a public issue.
+
+7. Governing law
+
+These terms are governed by the law of the Federal Republic of Germany. If
+you are a consumer, the mandatory consumer protection provisions of the
+country in which you have your habitual residence remain unaffected.
+
+8. Severability and changes
+
+If any provision of these terms is invalid, the remaining provisions stay in
+force. We may adjust these terms for future versions. For a version you have
+already downloaded, the wording published at the time of that download
+applies.
+
+----------------------------------------------------------------------------
+
+GEWÄHRLEISTUNG UND HAFTUNG
+
+Diese deutsche Fassung ist maßgeblich.
+
+Pelton wird unentgeltlich bereitgestellt von der Stellar Foundry GmbH,
+Thomas-Mann-Straße 19, 53111 Bonn, Deutschland.
+
+Dieses Dokument ist eine Zusatzbedingung nach § 7 lit. a der GNU General
+Public License, Version 3. Für Kopien von Pelton, die von der Stellar
+Foundry GmbH bereitgestellt werden, treten die nachfolgenden Ziffern an die
+Stelle der Gewährleistungs- und Haftungsregelungen in den §§ 15 und 16
+GPLv3. Wer Pelton weitergibt, darf diese Zusatzbedingung nach § 7 Abs. 2
+GPLv3 entfernen; die Haftung des Weitergebenden für die von ihm verbreitete
+Kopie bleibt davon unberührt.
+
+Die durch die GPLv3 gewährten Rechte an Nutzung, Vervielfältigung,
+Veränderung und Weitergabe werden dadurch nicht eingeschränkt. Die aktuelle
+Fassung ist unter https://pelton.app/terms/de veröffentlicht.
+
+Stand: 30. Juli 2026
+
+1. Keine Gewährleistung
+
+Pelton wird unentgeltlich und in der jeweils vorliegenden Fassung
+bereitgestellt. Wir sichern nicht zu, dass die Software fehlerfrei arbeitet,
+ununterbrochen verfügbar ist, sich für einen bestimmten Zweck eignet oder
+mit einem bestimmten Betriebssystem, E-Mail-Anbieter oder Protokollstand
+zusammenarbeitet.
+
+Da die Überlassung unentgeltlich erfolgt, haften wir für Sachmängel nach §
+524 BGB nur bei arglistigem Verschweigen eines Mangels und für Rechtsmängel
+entsprechend § 523 BGB.
+
+2. Haftung
+
+a) Unbeschränkt haften wir bei Vorsatz und grober Fahrlässigkeit, bei der
+Verletzung von Leben, Körper oder Gesundheit, bei arglistigem Verschweigen
+eines Mangels, im Umfang einer von uns ausdrücklich übernommenen Garantie
+sowie in allen Fällen zwingender gesetzlicher Haftung, insbesondere nach dem
+Produkthaftungsgesetz.
+
+b) Im Übrigen ist unsere Haftung nach § 521 BGB auf Vorsatz und grobe
+Fahrlässigkeit beschränkt, da wir Pelton unentgeltlich überlassen.
+
+c) Soweit wir gleichwohl für einfache Fahrlässigkeit bei der Verletzung
+einer wesentlichen Pflicht haften, ist die Haftung auf den bei
+Bereitstellung vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
+
+d) Eine weitergehende Haftung ist ausgeschlossen. Die vorstehenden
+Beschränkungen gelten auch zugunsten unserer gesetzlichen Vertreter,
+Mitarbeiter und Erfüllungsgehilfen.
+
+3. Datenintegrität und Backups
+
+Pelton greift auf Ihre echten Postfächer zu und speichert Nachrichten und
+Metadaten lokal auf Ihrem Gerät. Wir sichern nicht zu, dass lokal
+gespeicherte Daten vollständig, dauerhaft verfügbar oder wiederherstellbar
+sind, und nicht, dass eine in Pelton ausgelöste Aktion beim Server Ihres
+E-Mail-Anbieters das erwartete Ergebnis hat. Löschvorgänge können endgültig
+sein.
+
+Pelton ist kein Backup-Werkzeug und ersetzt kein Backup. Für eine eigene,
+unabhängige Sicherung Ihrer Daten sind Sie selbst verantwortlich. Die
+Nutzung erfolgt auf eigene Gefahr.
+
+4. Entwicklungsstand, Support und Updates
+
+Pelton befindet sich in aktiver Entwicklung. Funktionen können sich ändern,
+eingeschränkt werden oder entfallen, und Datenformate können sich zwischen
+Versionen ändern.
+
+Sie können Fehler als Issue unter https://github.com/TRC-Loop/Pelton melden,
+und wir lesen diese Meldungen. Ein Anspruch auf Antwort, Fehlerbehebung,
+Weiterentwicklung, Updates oder eine bestimmte Verfügbarkeit besteht nicht.
+
+5. Drittanbieter
+
+Pelton kommuniziert direkt mit den von Ihnen eingerichteten E-Mail-Anbietern
+und, sofern Sie das konfigurieren, mit weiteren Diensten wie MCP-Servern.
+Wir betreiben keine Server im Datenpfad und haben keinen Zugriff auf Ihre
+Nachrichten oder Zugangsdaten. Für Leistung, Verfügbarkeit, Sicherheit und
+Bedingungen dieser Dienste ist allein der jeweilige Anbieter verantwortlich.
+Das gilt auch für Themes, Erweiterungen und Konfigurationen, die Sie von
+Dritten beziehen.
+
+6. Sicherheitslücken melden
+
+Sicherheitslücken melden Sie bitte vertraulich wie in SECURITY.md
+beschrieben und nicht als öffentliches Issue.
+
+7. Anwendbares Recht
+
+Es gilt das Recht der Bundesrepublik Deutschland. Sind Sie Verbraucher,
+bleiben die zwingenden Verbraucherschutzvorschriften des Staates unberührt,
+in dem Sie Ihren gewöhnlichen Aufenthalt haben.
+
+8. Salvatorische Klausel und Änderungen
+
+Sollte eine Bestimmung dieser Bedingungen unwirksam sein, bleibt die
+Wirksamkeit der übrigen Bestimmungen unberührt. Wir können diese Bedingungen
+für künftige Versionen anpassen. Für eine bereits von Ihnen bezogene Version
+gilt die Fassung, die zum Zeitpunkt des Downloads veröffentlicht war.

--- a/build/windows/installer/disclaimer.txt
+++ b/build/windows/installer/disclaimer.txt
@@ -6,10 +6,9 @@ Thomas-Mann-Straße 19, 53111 Bonn, Germany.
 This document is an additional term under section 7(a) of the GNU General
 Public License, version 3. For copies of Pelton distributed by Stellar
 Foundry GmbH, the sections below take the place of the warranty and
-liability provisions in sections 15 and 16 of the GPLv3. Anyone
-redistributing Pelton may remove this additional term under section 7,
-paragraph 2 of the GPLv3; that does not affect the redistributor's own
-liability for the copy they distribute.
+liability provisions in sections 15 and 16 of the GPLv3. They do not apply
+to copies distributed by third parties; a redistributor's liability follows
+the terms under which they provide their copy.
 
 It does not restrict the rights the GPLv3 grants you to use, copy, modify
 and redistribute Pelton. The German version below is authoritative; the
@@ -25,10 +24,10 @@ the software is free of defects, that it is continuously available, that it
 is fit for any particular purpose, or that it works with any given operating
 system, email provider or protocol implementation.
 
-Because the software is provided free of charge, we are liable for defects
-in quality only where we fraudulently concealed a defect (section 524 German
-Civil Code) and for defects in title accordingly (section 523 German Civil
-Code).
+Where German gift law applies to the free provision of software, we are
+liable for defects in quality and in title only where we fraudulently
+concealed a defect (sections 524 and 523 German Civil Code applied
+accordingly).
 
 2. Liability
 
@@ -38,18 +37,29 @@ to the extent of any guarantee we have expressly given, and in all cases of
 mandatory statutory liability, in particular under the German Product
 Liability Act.
 
-b) Otherwise our liability is limited to intent and gross negligence under
-section 521 of the German Civil Code, because we provide Pelton free of
-charge.
+b) For the ordinarily negligent breach of a material obligation, meaning an
+obligation whose fulfilment is what makes using Pelton as intended possible
+at all, our liability is limited to the damage that was foreseeable and
+typical at the time the software was provided.
 
-c) Where we are nevertheless liable for ordinary negligence in breaching a
-material obligation, that liability is limited to the damage that was
-foreseeable and typical at the time the software was provided.
+c) Any other liability is excluded.
 
-d) Any liability beyond this is excluded. The limitations above also apply
-for the benefit of our legal representatives, employees and agents.
+d) Where German gift law applies to the free provision of the software, the
+statutory privilege under section 521 German Civil Code, limiting our
+liability to intent and gross negligence, remains unaffected.
 
-3. Data integrity and backups
+e) The limitations above also apply for the benefit of our legal
+representatives, employees and agents.
+
+3. Mandatory consumer rights
+
+Mandatory rights consumers have under the German provisions on contracts for
+digital products (sections 327 et seq. German Civil Code) remain unaffected
+where those provisions apply. Sections 1, 2 and 5 of this document then
+apply only as far as differing agreements are permitted under section 327h
+German Civil Code.
+
+4. Data integrity and backups
 
 Pelton connects to your live mailboxes and stores messages and metadata
 locally on your device. We do not warrant that locally stored data is
@@ -61,16 +71,17 @@ Pelton is not a backup tool and does not replace one. Keeping your own
 independent backup of your data is your responsibility. You use the software
 at your own risk.
 
-4. Development status, support and updates
+5. Development status, support and updates
 
 Pelton is under active development. Features may change, be restricted or be
 removed, and data formats may change between versions.
 
 You can report bugs as an issue at https://github.com/TRC-Loop/Pelton and we
 do read those reports. There is no entitlement to a reply, a fix, further
-development, updates or any level of availability.
+development, updates or any level of availability, unless mandatory law
+provides otherwise.
 
-5. Third-party services
+6. Third-party services
 
 Pelton communicates directly with the email providers you set up and, if you
 configure them, with further services such as MCP servers. We operate no
@@ -79,21 +90,20 @@ The respective provider is solely responsible for the performance,
 availability, security and terms of those services. The same applies to
 themes, extensions and configurations you obtain from third parties.
 
-6. Reporting security issues
+7. Reporting security issues
 
 Please report security vulnerabilities confidentially as described in
 SECURITY.md rather than as a public issue.
 
-7. Governing law
+8. Governing law
 
 These terms are governed by the law of the Federal Republic of Germany. If
 you are a consumer, the mandatory consumer protection provisions of the
 country in which you have your habitual residence remain unaffected.
 
-8. Severability and changes
+9. Changes
 
-If any provision of these terms is invalid, the remaining provisions stay in
-force. We may adjust these terms for future versions. For a version you have
+We may adjust these terms for future versions. For a version you have
 already downloaded, the wording published at the time of that download
 applies.
 
@@ -110,9 +120,9 @@ Dieses Dokument ist eine Zusatzbedingung nach § 7 lit. a der GNU General
 Public License, Version 3. Für Kopien von Pelton, die von der Stellar
 Foundry GmbH bereitgestellt werden, treten die nachfolgenden Ziffern an die
 Stelle der Gewährleistungs- und Haftungsregelungen in den §§ 15 und 16
-GPLv3. Wer Pelton weitergibt, darf diese Zusatzbedingung nach § 7 Abs. 2
-GPLv3 entfernen; die Haftung des Weitergebenden für die von ihm verbreitete
-Kopie bleibt davon unberührt.
+GPLv3. Für Kopien, die Dritte weitergeben, gelten sie nicht; die Haftung des
+Weitergebenden richtet sich nach den Bedingungen, unter denen er die Kopie
+bereitstellt.
 
 Die durch die GPLv3 gewährten Rechte an Nutzung, Vervielfältigung,
 Veränderung und Weitergabe werden dadurch nicht eingeschränkt. Die aktuelle
@@ -128,9 +138,10 @@ ununterbrochen verfügbar ist, sich für einen bestimmten Zweck eignet oder
 mit einem bestimmten Betriebssystem, E-Mail-Anbieter oder Protokollstand
 zusammenarbeitet.
 
-Da die Überlassung unentgeltlich erfolgt, haften wir für Sachmängel nach §
-524 BGB nur bei arglistigem Verschweigen eines Mangels und für Rechtsmängel
-entsprechend § 523 BGB.
+Findet auf die unentgeltliche Überlassung von Software Schenkungsrecht
+Anwendung, haften wir für Sachmängel entsprechend § 524 BGB und für
+Rechtsmängel entsprechend § 523 BGB nur bei arglistigem Verschweigen eines
+Mangels.
 
 2. Haftung
 
@@ -140,18 +151,29 @@ eines Mangels, im Umfang einer von uns ausdrücklich übernommenen Garantie
 sowie in allen Fällen zwingender gesetzlicher Haftung, insbesondere nach dem
 Produkthaftungsgesetz.
 
-b) Im Übrigen ist unsere Haftung nach § 521 BGB auf Vorsatz und grobe
-Fahrlässigkeit beschränkt, da wir Pelton unentgeltlich überlassen.
+b) Bei einfach fahrlässiger Verletzung einer wesentlichen Pflicht, also
+einer Pflicht, deren Erfüllung die bestimmungsgemäße Nutzung von Pelton
+überhaupt erst ermöglicht, ist unsere Haftung auf den bei Bereitstellung
+vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
 
-c) Soweit wir gleichwohl für einfache Fahrlässigkeit bei der Verletzung
-einer wesentlichen Pflicht haften, ist die Haftung auf den bei
-Bereitstellung vorhersehbaren, typischerweise eintretenden Schaden begrenzt.
+c) Im Übrigen ist unsere Haftung ausgeschlossen.
 
-d) Eine weitergehende Haftung ist ausgeschlossen. Die vorstehenden
-Beschränkungen gelten auch zugunsten unserer gesetzlichen Vertreter,
-Mitarbeiter und Erfüllungsgehilfen.
+d) Findet auf die unentgeltliche Überlassung Schenkungsrecht Anwendung,
+bleibt die gesetzliche Haftungsprivilegierung nach § 521 BGB, die unsere
+Haftung auf Vorsatz und grobe Fahrlässigkeit beschränkt, unberührt.
 
-3. Datenintegrität und Backups
+e) Die vorstehenden Beschränkungen gelten auch zugunsten unserer
+gesetzlichen Vertreter, Mitarbeiter und Erfüllungsgehilfen.
+
+3. Zwingende Verbraucherrechte
+
+Zwingende Rechte, die Verbrauchern nach den Vorschriften über Verträge über
+digitale Produkte (§§ 327 ff. BGB) zustehen, bleiben unberührt, soweit diese
+Vorschriften anwendbar sind. Die Ziffern 1, 2 und 5 dieses Dokuments gelten
+insoweit nur in dem Umfang, in dem abweichende Vereinbarungen nach § 327h
+BGB zulässig sind.
+
+4. Datenintegrität und Backups
 
 Pelton greift auf Ihre echten Postfächer zu und speichert Nachrichten und
 Metadaten lokal auf Ihrem Gerät. Wir sichern nicht zu, dass lokal
@@ -164,7 +186,7 @@ Pelton ist kein Backup-Werkzeug und ersetzt kein Backup. Für eine eigene,
 unabhängige Sicherung Ihrer Daten sind Sie selbst verantwortlich. Die
 Nutzung erfolgt auf eigene Gefahr.
 
-4. Entwicklungsstand, Support und Updates
+5. Entwicklungsstand, Support und Updates
 
 Pelton befindet sich in aktiver Entwicklung. Funktionen können sich ändern,
 eingeschränkt werden oder entfallen, und Datenformate können sich zwischen
@@ -172,9 +194,10 @@ Versionen ändern.
 
 Sie können Fehler als Issue unter https://github.com/TRC-Loop/Pelton melden,
 und wir lesen diese Meldungen. Ein Anspruch auf Antwort, Fehlerbehebung,
-Weiterentwicklung, Updates oder eine bestimmte Verfügbarkeit besteht nicht.
+Weiterentwicklung, Updates oder eine bestimmte Verfügbarkeit besteht nicht,
+soweit sich nicht aus zwingendem Recht etwas anderes ergibt.
 
-5. Drittanbieter
+6. Drittanbieter
 
 Pelton kommuniziert direkt mit den von Ihnen eingerichteten E-Mail-Anbietern
 und, sofern Sie das konfigurieren, mit weiteren Diensten wie MCP-Servern.
@@ -184,20 +207,19 @@ Bedingungen dieser Dienste ist allein der jeweilige Anbieter verantwortlich.
 Das gilt auch für Themes, Erweiterungen und Konfigurationen, die Sie von
 Dritten beziehen.
 
-6. Sicherheitslücken melden
+7. Sicherheitslücken melden
 
 Sicherheitslücken melden Sie bitte vertraulich wie in SECURITY.md
 beschrieben und nicht als öffentliches Issue.
 
-7. Anwendbares Recht
+8. Anwendbares Recht
 
 Es gilt das Recht der Bundesrepublik Deutschland. Sind Sie Verbraucher,
 bleiben die zwingenden Verbraucherschutzvorschriften des Staates unberührt,
 in dem Sie Ihren gewöhnlichen Aufenthalt haben.
 
-8. Salvatorische Klausel und Änderungen
+9. Änderungen
 
-Sollte eine Bestimmung dieser Bedingungen unwirksam sein, bleibt die
-Wirksamkeit der übrigen Bestimmungen unberührt. Wir können diese Bedingungen
-für künftige Versionen anpassen. Für eine bereits von Ihnen bezogene Version
-gilt die Fassung, die zum Zeitpunkt des Downloads veröffentlicht war.
+Wir können diese Bedingungen für künftige Versionen anpassen. Für eine
+bereits von Ihnen bezogene Version gilt die Fassung, die zum Zeitpunkt des
+Downloads veröffentlicht war.

--- a/build/windows/installer/project.nsi
+++ b/build/windows/installer/project.nsi
@@ -81,6 +81,20 @@ ManifestDPIAware true
 !insertmacro MUI_PAGE_LICENSE "..\..\..\LICENSE" # GPL-3.0. Kept in the original English text on every install
                                                   # language: unofficial translations of the GPL aren't legally
                                                   # authoritative, so the FSF recommends distributing only this text.
+
+####
+## Warranty and liability, an additional term under GPLv3 section 7(a). It is a
+## separate page because the GPL text has to stay verbatim. disclaimer.txt is
+## generated from DISCLAIMER.md by `make disclaimer` and carries both the
+## English and the authoritative German wording, so it stays readable on every
+## installer language.
+####
+!define MUI_PAGE_HEADER_TEXT "Warranty and liability"
+!define MUI_PAGE_HEADER_SUBTEXT "Please read the terms under which Pelton is provided."
+!define MUI_LICENSEPAGE_TEXT_TOP "Pelton is provided free of charge and without warranty."
+!define MUI_LICENSEPAGE_TEXT_BOTTOM "Click Agree to continue installing Pelton."
+!define MUI_LICENSEPAGE_BUTTON "Agree"
+!insertmacro MUI_PAGE_LICENSE "disclaimer.txt"
 !insertmacro MULTIUSER_PAGE_INSTALLMODE # All users (admin) vs just me (no admin).
 !insertmacro MUI_PAGE_DIRECTORY # In which folder install page.
 !insertmacro MUI_PAGE_COMPONENTS # Optional components (currently just the desktop shortcut).

--- a/scripts/gen-installer-notice.mjs
+++ b/scripts/gen-installer-notice.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// gen-installer-notice.mjs renders DISCLAIMER.md into the plain text file the
+// windows installer shows on its liability page
+// (build/windows/installer/disclaimer.txt). NSIS reads that file verbatim, so it
+// needs hard-wrapped lines, no markdown, CRLF line endings and a UTF-8 BOM for
+// the umlauts to survive.
+//
+// the generated file is committed; `make disclaimer` (and `make build-win`)
+// regenerate it after every edit to DISCLAIMER.md.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const WIDTH = 76
+
+// wrap breaks a paragraph into lines of at most WIDTH characters. words longer
+// than the limit (urls) get their own line rather than being split.
+function wrap(text) {
+  const lines = []
+  let line = ''
+  for (const word of text.split(/\s+/)) {
+    if (line && line.length + 1 + word.length > WIDTH) {
+      lines.push(line)
+      line = word
+    } else {
+      line = line ? `${line} ${word}` : word
+    }
+  }
+  if (line) lines.push(line)
+  return lines
+}
+
+function render(markdown) {
+  const out = []
+  const paragraphs = markdown.split(/\n{2,}/)
+
+  for (const raw of paragraphs) {
+    const block = raw.trim()
+    if (!block) continue
+    if (block === '---') {
+      out.push('', '-'.repeat(WIDTH), '')
+      continue
+    }
+
+    const heading = block.match(/^(#{1,6})\s+(.*)$/)
+    if (heading) {
+      const title = heading[2].trim()
+      out.push(heading[1].length === 1 ? title.toUpperCase() : title, '')
+      continue
+    }
+
+    const text = block
+      .replace(/\n/g, ' ')
+      .replace(/\*\*(.+?)\*\*/g, '$1')
+      .replace(/\[(.+?)\]\((.+?)\)/g, '$1 ($2)')
+      .replace(/<(https?:[^>]+)>/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+    out.push(...wrap(text), '')
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+const markdown = readFileSync(join(root, 'DISCLAIMER.md'), 'utf8')
+const target = join(root, 'build', 'windows', 'installer', 'disclaimer.txt')
+writeFileSync(target, `﻿${render(markdown).replace(/\n/g, '\r\n')}\r\n`, 'utf8')
+console.log(`wrote ${target}`)


### PR DESCRIPTION
First of three PRs on the liability side. Companion to TRC-Loop/pelton.app#7, which adds `/terms` and the download dialog on the website.

## What is here

- **`DISCLAIMER.md`**: an additional term under GPLv3 section 7(a), German (authoritative) and English, wording identical to `/terms` on the website. No warranty based on sections 523/524 BGB, graded liability (unlimited for intent, gross negligence, personal injury and mandatory statutory liability, otherwise limited under section 521 BGB, ordinary negligence capped at foreseeable typical damage), data integrity and backup responsibility, development status, third-party services, governing law with a consumer carve-out.
- **`SECURITY.md`**: private advisory or email, what to include, scope. No promised response times, so there is no commitment we could breach.
- **Windows installer**: a second license page after the GPL page, headed "Warranty and liability", button labelled Agree. The GPL page stays untouched because that text has to remain verbatim.
- **`scripts/gen-installer-notice.mjs` plus `make disclaimer`**: renders `DISCLAIMER.md` into `build/windows/installer/disclaimer.txt`, the plain text NSIS reads. `make build-win` regenerates it, and `.gitattributes` pins that file to CRLF so the checkout stays valid for NSIS.
- **Packages**: `.deb` and `.rpm` now ship `LICENSE` and `DISCLAIMER.md` under `/usr/share/doc/pelton/`, and `make build-mac` copies `DISCLAIMER.md` into the app bundle's Resources.
- **Releases**: `draft-release.yml` appends a short disclaimer block with links to every generated draft, since a download straight off the releases page skips the dialog on the website.
- **README**: liability paragraph in the license section, security pointer, and the installer step list mentions the new page.

## Deliberately not done

`LICENSE` is unchanged. Adding a header to it would modify the verbatim GPL text, which the license itself does not allow. The additional term lives in its own file and is referenced from the README, the installer, the packages and the release notes instead.

## Open

The clause wording still needs review by a lawyer specialising in IT law. It ships now because the previous state was the GPL disclaimer alone, which is weaker under German law: an overly broad exclusion falls away entirely instead of being reduced.

Next PRs: onboarding step with confirmation plus locale keys for all six languages, then warnings before destructive actions.