### PR TITLE
ci: build before publishing so releases and nightlies ship complete

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,12 @@ name: Nightly builds
 #     packages install as "pelton-nightly" alongside a real Pelton rather than
 #     replacing it.
 #
+# The prerelease is created last, after all three platforms have built, and it
+# is created with the installers already attached. A failed build therefore
+# leaves no nightly at all rather than an empty or half-filled one that looks
+# downloadable, and the previous day's nightly stays the newest thing on the
+# releases page.
+#
 # Nothing runs when dev has not moved since the last nightly, and nightlies
 # older than RETENTION_DAYS are deleted so the releases page stays readable.
 
@@ -110,94 +116,12 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
-  # Create the prerelease first, so the three build jobs can upload into it in
-  # parallel. The body carries the warning; it is the first thing anyone
-  # arriving from a link sees.
-  # ---------------------------------------------------------------------------
-  release:
-    needs: check
-    if: needs.check.outputs.build == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: dev
-          fetch-depth: 0
-
-      - name: Create prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.check.outputs.tag }}
-          SHA: ${{ needs.check.outputs.sha }}
-          SHORT_SHA: ${{ needs.check.outputs.short_sha }}
-        run: |
-          # a re-run on the same day replaces the day's release rather than
-          # failing, so a half-finished nightly can be rebuilt.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release delete "$TAG" --yes --cleanup-tag
-          fi
-
-          cat > notes.md <<'NOTES'
-          > [!CAUTION]
-          > ## This is not a release. Do not use it with your real inbox.
-          >
-          > This is an **automated nightly build** of Pelton, made from the `dev`
-          > branch. It has **not been reviewed, tested or released**, and it is
-          > expected to break.
-          >
-          > **It can lose or damage email.** It may fail to send, send the wrong
-          > thing, delete messages on your server, or corrupt its local cache of
-          > your mail. Deletions on an email server can be permanent and cannot
-          > be undone by us.
-          >
-          > **Use a test account whose contents you can afford to lose entirely.**
-          >
-          > There is **no warranty of any kind** and **no support**. You download
-          > and use this build entirely at your own risk. To the fullest extent
-          > permitted by law, the authors and distributors of Pelton accept no
-          > liability for any loss of or damage to data, for lost or misdirected
-          > email, or for any other loss or damage arising from its use. The full
-          > warranty and liability terms are at https://pelton.app/terms and in
-          > `DISCLAIMER.md`.
-          >
-          > If you want a working email client, download a
-          > [real release](https://github.com/TRC-Loop/Pelton/releases/latest)
-          > instead.
-
-          ### Installing alongside a normal Pelton
-
-          A nightly is deliberately kept separate from a real install and the two
-          can sit side by side:
-
-          - it installs as **Pelton Nightly** with its own icon,
-          - it keeps its **own accounts, mail and settings** in a separate data
-            directory, so it cannot touch or corrupt your normal install's mail,
-          - on Linux it is the `pelton-nightly` package with a `pelton-nightly`
-            binary, and it does **not** register itself as your `mailto:` handler.
-
-          Nightlies older than 14 days are deleted automatically.
-          NOTES
-
-          {
-            echo ""
-            echo "---"
-            echo ""
-            echo "Built from \`dev\` at [\`$SHORT_SHA\`](https://github.com/TRC-Loop/Pelton/commit/$SHA)."
-          } >> notes.md
-
-          gh release create "$TAG" \
-            --target "$SHA" \
-            --title "Nightly $TAG (untested, not a release)" \
-            --notes-file notes.md \
-            --prerelease
-
-  # ---------------------------------------------------------------------------
   # macOS, Apple Silicon. Bundle is "Pelton Nightly.app" with its own bundle id
   # so LaunchServices treats it as a different app from a real install, and the
   # nightly icon rather than the Liquid Glass one.
   # ---------------------------------------------------------------------------
   macos:
-    needs: [check, release]
+    needs: check
     if: needs.check.outputs.build == 'true'
     runs-on: macos-14
     steps:
@@ -289,22 +213,22 @@ jobs:
             "build/bin/Pelton-$TAG-macos-applesilicon.dmg" \
             "build/bin/Pelton Nightly.app"
 
-      - name: Upload
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.check.outputs.tag }}
-        run: |
-          gh release upload "$TAG" \
-            "build/bin/Pelton-$TAG-macos-applesilicon.dmg" \
-            "build/bin/Pelton-$TAG-macos-applesilicon-app.zip" \
-            --clobber
+      - name: Stage installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-macos
+          path: |
+            build/bin/Pelton-${{ needs.check.outputs.tag }}-macos-applesilicon.dmg
+            build/bin/Pelton-${{ needs.check.outputs.tag }}-macos-applesilicon-app.zip
+          if-no-files-found: error
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Windows amd64. channel.nsh switches on the installer's extra nightly
   # acknowledgement page and its up-front message box.
   # ---------------------------------------------------------------------------
   windows:
-    needs: [check, release]
+    needs: check
     if: needs.check.outputs.build == 'true'
     runs-on: windows-latest
     steps:
@@ -367,19 +291,20 @@ jobs:
           TAG: ${{ needs.check.outputs.tag }}
         run: mv "build/bin/PeltonNightly-amd64-installer.exe" "build/bin/Pelton-$TAG-windows-amd64-installer.exe"
 
-      - name: Upload
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.check.outputs.tag }}
-        run: gh release upload "$TAG" "build/bin/Pelton-$TAG-windows-amd64-installer.exe" --clobber
+      - name: Stage installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-windows
+          path: build/bin/Pelton-${{ needs.check.outputs.tag }}-windows-amd64-installer.exe
+          if-no-files-found: error
+          retention-days: 1
 
   # ---------------------------------------------------------------------------
   # Linux: the raw binary plus pelton-nightly .deb/.rpm. No Copr submission;
   # a distro repo is for releases, not for untested builds.
   # ---------------------------------------------------------------------------
   linux:
-    needs: [check, release]
+    needs: check
     if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -435,24 +360,113 @@ jobs:
           nfpm package --config .github/nfpm/pelton-nightly.yaml --packager deb --target "build/bin/Pelton-$TAG-linux-amd64.deb"
           nfpm package --config .github/nfpm/pelton-nightly.yaml --packager rpm --target "build/bin/Pelton-$TAG-linux-fedora-x86_64.rpm"
 
-      - name: Upload
+      - name: Stage packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-linux
+          path: |
+            build/bin/Pelton-${{ needs.check.outputs.tag }}-linux-amd64
+            build/bin/Pelton-${{ needs.check.outputs.tag }}-linux-amd64.deb
+            build/bin/Pelton-${{ needs.check.outputs.tag }}-linux-fedora-x86_64.rpm
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Publish only once every platform has actually produced an installer. The
+  # prerelease is created with all of them attached in one go, so a nightly on
+  # the releases page is always complete: there is no window in which it exists
+  # with nothing to download, and a build that fails publishes nothing at all.
+  #
+  # The body carries the warning; it is the first thing anyone arriving from a
+  # link sees.
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: [check, macos, windows, linux]
+    if: needs.check.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect installers
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: nightly-*
+          merge-multiple: true
+
+      - name: Create prerelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check.outputs.tag }}
+          SHA: ${{ needs.check.outputs.sha }}
+          SHORT_SHA: ${{ needs.check.outputs.short_sha }}
         run: |
-          gh release upload "$TAG" \
-            "build/bin/Pelton-$TAG-linux-amd64" \
-            "build/bin/Pelton-$TAG-linux-amd64.deb" \
-            "build/bin/Pelton-$TAG-linux-fedora-x86_64.rpm" \
-            --clobber
+          # a re-run on the same day replaces the day's release rather than
+          # failing, so a half-finished nightly can be rebuilt.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes --cleanup-tag
+          fi
+
+          cat > notes.md <<'NOTES'
+          > [!CAUTION]
+          > ## This is not a release. Do not use it with your real inbox.
+          >
+          > This is an **automated nightly build** of Pelton, made from the `dev`
+          > branch. It has **not been reviewed, tested or released**, and it is
+          > expected to break.
+          >
+          > **It can lose or damage email.** It may fail to send, send the wrong
+          > thing, delete messages on your server, or corrupt its local cache of
+          > your mail. Deletions on an email server can be permanent and cannot
+          > be undone by us.
+          >
+          > **Use a test account whose contents you can afford to lose entirely.**
+          >
+          > There is **no warranty of any kind** and **no support**. You download
+          > and use this build entirely at your own risk. To the fullest extent
+          > permitted by law, the authors and distributors of Pelton accept no
+          > liability for any loss of or damage to data, for lost or misdirected
+          > email, or for any other loss or damage arising from its use. The full
+          > warranty and liability terms are at https://pelton.app/terms and in
+          > `DISCLAIMER.md`.
+          >
+          > If you want a working email client, download a
+          > [real release](https://github.com/TRC-Loop/Pelton/releases/latest)
+          > instead.
+
+          ### Installing alongside a normal Pelton
+
+          A nightly is deliberately kept separate from a real install and the two
+          can sit side by side:
+
+          - it installs as **Pelton Nightly** with its own icon,
+          - it keeps its **own accounts, mail and settings** in a separate data
+            directory, so it cannot touch or corrupt your normal install's mail,
+          - on Linux it is the `pelton-nightly` package with a `pelton-nightly`
+            binary, and it does **not** register itself as your `mailto:` handler.
+
+          Nightlies older than 14 days are deleted automatically.
+          NOTES
+
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "Built from \`dev\` at [\`$SHORT_SHA\`](https://github.com/TRC-Loop/Pelton/commit/$SHA)."
+          } >> notes.md
+
+          gh release create "$TAG" \
+            --target "$SHA" \
+            --title "Nightly $TAG (untested, not a release)" \
+            --notes-file notes.md \
+            --prerelease \
+            dist/*
 
   # ---------------------------------------------------------------------------
   # Delete nightlies older than RETENTION_DAYS, tag included. Runs after the
-  # builds so a failed build never takes the pruning down with it, and only
-  # touches nightly-* tags.
+  # publish step so a failed build never takes the pruning down with it, and
+  # only touches nightly-* tags.
   # ---------------------------------------------------------------------------
   prune:
-    needs: [check, macos, windows, linux]
+    needs: [check, publish]
     if: always() && needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,82 @@
 name: Release builds
 
-# Builds Pelton for every published GitHub Release and attaches the installers
-# as release assets. All builds are unsigned (no Apple notarization, no
-# Windows code signing) - see README/CI notes for what that means for users.
-# workflow_dispatch is there so the build steps can be tested without cutting
-# a real release; it just skips the upload step.
+# Builds Pelton and attaches the installers to the release for a version tag.
+# All builds are unsigned (no Apple notarization, no Windows code signing) -
+# see README/CI notes for what that means for users.
+#
+# The builds run on the *tag push*, not on publish, so the assets are already
+# sitting on the draft by the time anyone looks at it: pushing v1.2.3 has
+# draft-release.yml write the changelog into a draft while this workflow fills
+# it with installers. Publishing then stays a manual, instant act with nothing
+# left to wait for, and it rebuilds nothing.
+#
+# The one thing that does wait for publishing is the Copr submission, which
+# pushes to a live dnf repo real users install from. That must not happen while
+# the release is still an unpublished draft.
+#
+# workflow_dispatch takes an optional tag: with one it builds and uploads into
+# that tag's existing release (repairing a draft whose build failed, or one
+# tagged before this workflow existed), without one it only exercises the build
+# steps and uploads nothing.
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and upload into, e.g. v2026.3.3. Empty builds without uploading."
+        required: false
+        default: ""
 
 permissions:
   contents: write
 
 env:
   GO_VERSION: "1.25"
+  # The release these installers belong to, empty when the run is only
+  # exercising the build steps. Job-level `if:` cannot read env, so the same
+  # condition is spelled out on the jobs that need it.
+  RELEASE_TAG: ${{ inputs.tag || (startsWith(github.ref, 'refs/tags/v') && github.ref_name) || '' }}
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Give the build jobs somewhere to upload to. draft-release.yml reacts to the
+  # same tag push and normally has the draft up within seconds, so this just
+  # waits for it; it only creates one itself if that job never got there, which
+  # would otherwise lose a whole build to a missing release.
+  #
+  # It runs even with no tag (a plain dispatch) and does nothing, so the build
+  # jobs can depend on it unconditionally.
+  # ---------------------------------------------------------------------------
+  draft:
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for the release to exist
+        if: env.RELEASE_TAG != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for _ in $(seq 1 30); do
+            if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "release $RELEASE_TAG exists, builds can upload into it"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "no release for $RELEASE_TAG after five minutes, creating an empty draft"
+          gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft --title "$RELEASE_TAG" --notes ""
+
   # ---------------------------------------------------------------------------
   # macOS: Apple Silicon only. Intel builds were dropped (no runner coverage
   # to keep validating them, and the target audience has moved to arm64).
   # ---------------------------------------------------------------------------
   macos:
+    needs: draft
+    if: github.event_name != 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +111,7 @@ jobs:
 
       - name: Resolve version
         id: version
-        run: echo "version=${GITHUB_REF_NAME:-dev}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${RELEASE_TAG:-dev}" >> "$GITHUB_OUTPUT"
 
       # Stamp info.productVersion so the bundle's Info.plist
       # (CFBundleVersion / CFBundleShortVersionString, i.e. Finder's Get
@@ -119,11 +174,11 @@ jobs:
             "build/bin/Pelton.app"
 
       - name: Upload to release
-        if: github.event_name == 'release'
+        if: env.RELEASE_TAG != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$RELEASE_TAG" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-macos-${{ matrix.label }}.dmg" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-macos-${{ matrix.label }}-app.zip" \
             --clobber
@@ -133,6 +188,8 @@ jobs:
   # no signing). windows-latest ships NSIS preinstalled.
   # ---------------------------------------------------------------------------
   windows:
+    needs: draft
+    if: github.event_name != 'release'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -171,7 +228,7 @@ jobs:
       - name: Resolve version
         id: version
         shell: bash
-        run: echo "version=${GITHUB_REF_NAME:-dev}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${RELEASE_TAG:-dev}" >> "$GITHUB_OUTPUT"
 
       # Stamp info.productVersion into the exe's version resources and the
       # NSIS installer metadata, same reasoning as the macOS job (#83).
@@ -200,12 +257,12 @@ jobs:
         run: mv "build/bin/Pelton-amd64-installer.exe" "build/bin/Pelton-${{ steps.version.outputs.version }}-windows-amd64-installer.exe"
 
       - name: Upload to release
-        if: github.event_name == 'release'
+        if: env.RELEASE_TAG != ''
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$RELEASE_TAG" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-windows-amd64-installer.exe" \
             --clobber
 
@@ -215,6 +272,8 @@ jobs:
   # Package metadata lives in .github/nfpm/pelton.yaml.
   # ---------------------------------------------------------------------------
   linux:
+    needs: draft
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -251,7 +310,7 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          raw="${GITHUB_REF_NAME:-0.0.0-dev}"
+          raw="${RELEASE_TAG:-0.0.0-dev}"
           echo "version=$raw" >> "$GITHUB_OUTPUT"
           # package managers reject a leading "v", so strip it for .deb/.rpm.
           echo "pkg_version=${raw#v}" >> "$GITHUB_OUTPUT"
@@ -273,11 +332,11 @@ jobs:
         run: nfpm package --config .github/nfpm/pelton.yaml --packager rpm --target "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-fedora-x86_64.rpm"
 
       - name: Upload to release
-        if: github.event_name == 'release'
+        if: env.RELEASE_TAG != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$RELEASE_TAG" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-amd64.deb" \
             "build/bin/Pelton-${{ steps.version.outputs.version }}-linux-fedora-x86_64.rpm" \
@@ -333,7 +392,7 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          raw="${GITHUB_REF_NAME:-0.0.0-dev}"
+          raw="${RELEASE_TAG:-0.0.0-dev}"
           echo "rpm_version=${raw#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build


### PR DESCRIPTION
Both workflows built their release *after* announcing it, which is backwards in two different ways.

## Releases: build on the tag, not on publish

`release.yml` only ran on `release: published`, so publishing a draft started a 15-minute wait during which the release was live and empty. Anyone arriving in that window found a version with nothing to download.

Builds now run on the **tag push** instead. Pushing `v1.2.3` has `draft-release.yml` write the changelog into a draft while this workflow fills that same draft with installers. By the time you look at it, everything is attached, and publishing is an instant manual click that rebuilds nothing.

A `draft` job waits for the release to appear before the builds finish (the two workflows react to the same push, and the changelog job is normally done in seconds). If it never shows up, it creates an empty draft itself rather than losing a whole build to a missing upload target.

**Copr still waits for publish.** It pushes to a live `dnf` repo that real users install from, so it must not fire while the release is an unpublished draft. It is the only job left on the `release: published` trigger.

`workflow_dispatch` gained an optional `tag`: with one it builds and uploads into that tag's existing release, which repairs a draft whose build failed or one tagged before this change. Without one it behaves as before and uploads nothing.

## Nightlies: publish only what actually built

The prerelease was created first so three jobs could upload into it in parallel. A failed build therefore left a nightly on the releases page that was empty or half-filled, and looked downloadable.

The three platform jobs now stage their installers as artifacts, and a new `publish` job creates the prerelease with all of them attached in one go. It only runs when every platform succeeded, so a broken build publishes nothing at all and yesterday's nightly stays the newest thing on the page. `prune` follows `publish` rather than the build jobs.

The warning body, the same-day replace behaviour and the retention pruning are unchanged.

## Notes

- Verified with `actionlint` (clean) and a YAML parse of all three workflows.
- This is on `main` because that is where releases are cut and where the scheduled nightly runs from. It will reach `dev` with the back-merge.
