### PR TITLE
fix: nightly publish and prune failing without repo context

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -399,10 +399,13 @@ jobs:
           SHA: ${{ needs.check.outputs.sha }}
           SHORT_SHA: ${{ needs.check.outputs.short_sha }}
         run: |
+          # nothing is checked out here, so gh has no remote to infer the
+          # repository from and every call needs --repo.
+          #
           # a re-run on the same day replaces the day's release rather than
           # failing, so a half-finished nightly can be rebuilt.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release delete "$TAG" --yes --cleanup-tag
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
           fi
 
           cat > notes.md <<'NOTES'
@@ -454,6 +457,7 @@ jobs:
           } >> notes.md
 
           gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --target "$SHA" \
             --title "Nightly $TAG (untested, not a release)" \
             --notes-file notes.md \
@@ -476,12 +480,12 @@ jobs:
           KEEP_TAG: ${{ needs.check.outputs.tag }}
         run: |
           cutoff="$(date -u -d "-$RETENTION_DAYS days" +%s)"
-          gh release list --limit 200 --json tagName,createdAt,isPrerelease \
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName,createdAt,isPrerelease \
             --jq '.[] | select(.isPrerelease) | select(.tagName | startswith("nightly-")) | "\(.tagName) \(.createdAt)"' \
           | while read -r tag created; do
               [ "$tag" = "$KEEP_TAG" ] && continue
               if [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ]; then
                 echo "deleting $tag (created $created)"
-                gh release delete "$tag" --yes --cleanup-tag
+                gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
               fi
             done


### PR DESCRIPTION
Both of last night's nightly runs failed. All three platforms built and staged
their installers correctly; the new `publish` job is what died:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`publish` only downloads artifacts and calls `gh`, so it has no
`actions/checkout`. Without a checkout there is no git remote for `gh` to infer
the repository from, and `gh release create` exits 1 before creating anything.
The `draft` job in `release.yml` passes `--repo "$GITHUB_REPOSITORY"` for the
same reason; that was not carried over to `nightly.yml` in #200.

This also caused the double run: the first failure never created the tag that
tells the next run there is nothing left to build.

## prune had the same bug, silently

`prune` reports success but has never worked. From the last nightly that
actually ran (2026-08-07):

```
prune  2026-08-07T13:47:20  failed to run git: fatal: not a git repository
prune  conclusion: success
```

Same missing repo context. It is reported as a success because
`gh release list | while read` takes the exit status of the `while`, not of
`gh`, so the failure is swallowed. Nightlies have therefore never been pruned,
despite the release body promising it. Nothing is currently overdue, so this
deletes nothing on the next run.

## Change

Four `gh` calls gained `--repo "$GITHUB_REPOSITORY"`. The three
`gh release upload` calls in `release.yml` are left alone: those jobs do check
the repository out.

The pipeline that masks `prune`'s errors is deliberately left as-is.

Verified with `actionlint` (clean) on both workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `--repo "$GITHUB_REPOSITORY"` to four `gh` commands in the nightly publish and prune jobs.
- Fixed release creation and release listing when jobs do not check out the repository.
- Prevented nightly publish failures and repeated builds caused by missing repository context.
- Kept the existing prune error-masking pipeline unchanged.
- Left the three `gh release upload` commands in `release.yml` unchanged.
- Verified both workflows with `actionlint`.

## AI use

**Probably** AI-assisted. The change appears to use AI for summarization or review support, but there is no clear evidence of 100% agentic implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->