### PR TITLE
fix: scroll position kept across content changes

### DIFF
--- a/frontend/src/components/detail/MessageDetail.svelte
+++ b/frontend/src/components/detail/MessageDetail.svelte
@@ -31,6 +31,7 @@
   import { prefs } from '../../stores/prefs'
   import { t } from '../../lib/i18n'
   import { get } from 'svelte/store'
+  import { tick } from 'svelte'
   import type { MessageDetail, EditorMode } from '../../lib/types'
 
   // default editor mode for replies and forwards, from settings.
@@ -47,6 +48,26 @@
   $: if ($openMessageId === null && loadedId !== -1) {
     loadedId = -1
     clearMessage()
+  }
+
+  // the scroll container is reused across messages, so it keeps the offset of
+  // whatever was open before. after a long message a shorter one renders above
+  // the viewport and the pane looks blank until you scroll back up.
+  let scrollEl: HTMLDivElement | undefined
+  let scrolledId = -1
+  $: if ($messageDetail.data && $messageDetail.data.id !== scrolledId) {
+    scrolledId = $messageDetail.data.id
+    void resetScroll()
+  }
+
+  // the container only exists once a message has rendered, and the body iframe
+  // sizes itself after that, so this waits a tick rather than reading scrollEl
+  // straight out of the reactive block.
+  async function resetScroll(): Promise<void> {
+    await tick()
+    if (scrollEl) {
+      scrollEl.scrollTop = 0
+    }
   }
 
   $: canScan = scanEnabled($virusTotal)
@@ -235,7 +256,7 @@ ${bodyHtml}
       <SourceModal messageId={detail.id} on:close={() => (sourceOpen = false)} />
     {/if}
 
-    <div class="scroll selectable">
+    <div class="scroll selectable" bind:this={scrollEl}>
       <DetailHeader {detail} />
       <div class="body-wrap">
         <MailBody {detail} />

--- a/frontend/src/components/list/MessageList.svelte
+++ b/frontend/src/components/list/MessageList.svelte
@@ -147,11 +147,22 @@
     return `folder:${sel.folderId}`
   }
 
+  // resetScroll puts the list back at the top. the container outlives the rows
+  // it holds, so without this a change of content keeps the old offset and a
+  // short result set renders far above the viewport, looking like no results.
+  function resetScroll(): void {
+    scrollTop = 0
+    if (listEl) {
+      listEl.scrollTop = 0
+    }
+  }
+
   let lastKey = ''
   $: if ($selection && selectionKey($selection) !== lastKey) {
     lastKey = selectionKey($selection)
     activeIndex = -1
     clearSelection()
+    resetScroll()
     void loadList($selection)
   }
 
@@ -201,6 +212,7 @@
   function applySearch(query: string, filter: SearchFilter): void {
     activeIndex = -1
     clearSelection()
+    resetScroll()
     if (query === '' && !filterActive(filter)) {
       void loadList($selection)
     } else {


### PR DESCRIPTION
Fixes #216.

Both the message list and the reading pane kept their scroll offset when the content underneath them changed, leaving the user looking at empty space.

**Message list.** The container outlives the rows it holds, so searching from far down a long folder rendered the two matches above the viewport and read as "no results". Same for filter chips and for switching to a smaller folder or View. `resetScroll()` now puts `listEl.scrollTop` and the virtualization's own `scrollTop` back to 0 together, so the rendered window recomputes at the top instead of waiting for a scroll event. It runs on selection change and in `applySearch`, next to the existing `activeIndex` reset, so keyboard navigation starts on the first row rather than somewhere off screen.

**Reading pane.** The `.scroll` div sits inside `{#if $messageDetail.data}` and survives a message swap, so a short message opened after a long one appeared blank. It is now reset whenever the rendered message id changes, waiting a tick because the container does not exist on the first open and the body iframe sizes itself to content after render.

There is no per-folder scroll memory in the code today, so nothing is lost by resetting unconditionally.

Verified with `pnpm run check` (0 errors) and a frontend build, and tested manually.
