### PR TITLE
fix: blank space reserved for the unread dot on read rows

### DIFF
--- a/frontend/src/components/list/MessageRow.svelte
+++ b/frontend/src/components/list/MessageRow.svelte
@@ -222,7 +222,9 @@
 
     <div class="content">
       <div class="line top">
-        <span class="dot" class:show={unread} aria-hidden="true"></span>
+        {#if unread}
+          <span class="dot" aria-hidden="true"></span>
+        {/if}
         {#if isVip}
           <IconStarFilled size={12} class="vip-star" aria-label={$t('vip.star')} />
         {/if}
@@ -363,13 +365,9 @@
     width: 7px;
     height: 7px;
     border-radius: 999px;
-    background: transparent;
+    background: var(--text-primary);
     flex-shrink: 0;
     align-self: center;
-  }
-
-  .dot.show {
-    background: var(--text-primary);
   }
 
   .sender {

--- a/frontend/src/components/settings/RowLayoutPreview.svelte
+++ b/frontend/src/components/settings/RowLayoutPreview.svelte
@@ -25,7 +25,9 @@
       {/if}
       <div class="content">
         <div class="top">
-          <span class="dot" class:show={s.unread}></span>
+          {#if s.unread}
+            <span class="dot"></span>
+          {/if}
           <span class="from">{s.from}</span>
           {#if template === 'single'}
             <span class="subj inline">{s.subject}</span>
@@ -122,11 +124,8 @@
     width: 7px;
     height: 7px;
     border-radius: 999px;
-    background: transparent;
-    flex-shrink: 0;
-  }
-  .dot.show {
     background: var(--text-primary);
+    flex-shrink: 0;
   }
   .from {
     font-size: var(--fz-list);


### PR DESCRIPTION
Fixes #217.

The odd space between the avatar and the sender name was not a spacing value that needed tuning, it was space reserved for something that is not drawn. The unread dot was always in the layout and only its colour changed:

```css
.dot { width: 7px; background: transparent; }
.dot.show { background: var(--text-primary); }
```

So a read row put `.row`'s 8px gap, then 7px of invisible dot, then `.line.top`'s 4px gap between the avatar and the name, and nothing was drawn in the middle of it.

The dot is now rendered only when the message is unread, so the gap around it collapses with it. A read row goes straight from the avatar to the sender at the row's normal 8px; an unread row gets the dot and its gap. Read rows therefore sit 11px tighter than unread ones, which is the honest consequence of not reserving space for an absent marker.

`RowLayoutPreview.svelte` in settings mirrors the row markup and had the same always-present dot, so it gets the same change. Without it the preview would keep advertising the old spacing.

The reading pane's VIP star is a real button rather than blank space, so it is deliberately left alone.

Verified with `pnpm run check` (0 errors) and a frontend build, and tested manually across the row templates and densities.
