### PR TITLE
fix: search misses mail whose body is html only

### DIFF
--- a/frontend/src/components/list/MessageList.svelte
+++ b/frontend/src/components/list/MessageList.svelte
@@ -156,7 +156,14 @@
   }
 
   $: items = $messageList.data?.items ?? []
-  $: hasMore = !($messageList.data?.searching ?? false) && items.length < ($messageList.data?.total ?? 0)
+  // a result set pages too: a broad query matches far more than one page, and
+  // stopping at the first page is what made a match ranked below it look like
+  // no match at all.
+  $: searching = $messageList.data?.searching ?? false
+  $: hasMore = searching
+    ? !($messageList.data?.exhausted ?? false) &&
+      ($messageList.data?.loadedHits ?? items.length) < ($messageList.data?.total ?? 0)
+    : items.length < ($messageList.data?.total ?? 0)
   // the cache is exhausted but the server still has older mail. hasMore covers
   // paging what is cached; this covers going back to the server for the rest.
   $: backfilling = $messageList.data?.backfilling ?? false
@@ -528,7 +535,15 @@
       {#if $messageList.data}
         <span class="count">
           {#if $messageList.data.searching}
-            {items.length} {items.length === 1 ? $t('messageList.result') : $t('messageList.results')}
+            <!-- showing the match count, not just the loaded count, is what
+                 tells "that is everything" apart from "there is more below". -->
+            {#if items.length < $messageList.data.total}
+              {$t('messageList.resultsOf')
+                .replace('{loaded}', String(items.length))
+                .replace('{total}', String($messageList.data.total))}
+            {:else}
+              {items.length} {items.length === 1 ? $t('messageList.result') : $t('messageList.results')}
+            {/if}
           {:else}
             {$messageList.data.total} {$messageList.data.total === 1 ? $t('messageList.message') : $t('messageList.messages')}
           {/if}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -356,6 +356,9 @@ export interface SearchRequest {
   afterUnix: number
   beforeUnix: number
   limit: number
+  // offset skips that many ranked hits, so the list can page through a result
+  // set instead of stopping at the first page.
+  offset: number
   // field-scoped constraints from typed search chips (from:/to:/subject:).
   from: string
   to: string
@@ -363,9 +366,17 @@ export interface SearchRequest {
   hasAttachment: boolean
 }
 
-// search runs a ranked, typo-tolerant search and returns matching summaries in
-// relevance order.
-export function search(req: SearchRequest): Promise<MessageSummary[]> {
+// SearchResult is one page of ranked results. total counts index matches and is
+// an upper bound on what is shown, since the attachment filter and any message
+// deleted since it was indexed are applied per page after ranking.
+export interface SearchResult {
+  messages: MessageSummary[]
+  total: number
+}
+
+// search runs a ranked, typo-tolerant search and returns a page of matching
+// summaries in relevance order.
+export function search(req: SearchRequest): Promise<SearchResult> {
   return App.Search(new desktop.SearchRequestDTO(req))
 }
 

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -585,6 +585,7 @@ const de: Record<string, string> = {
   'messageList.unflag': 'Markierung entfernen',
   'messageList.result': 'Ergebnis',
   'messageList.results': 'Ergebnisse',
+  'messageList.resultsOf': '{loaded} von {total} Ergebnissen',
   'messageList.message': 'Nachricht',
   'messageList.messages': 'Nachrichten',
   'messageList.ariaLabel': 'Nachrichten',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -585,6 +585,7 @@ const en: Record<string, string> = {
   'messageList.unflag': 'Unflag',
   'messageList.result': 'result',
   'messageList.results': 'results',
+  'messageList.resultsOf': '{loaded} of {total} results',
   'messageList.message': 'message',
   'messageList.messages': 'messages',
   'messageList.ariaLabel': 'Messages',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -585,6 +585,7 @@ const es: Record<string, string> = {
   'messageList.unflag': 'Desmarcar',
   'messageList.result': 'resultado',
   'messageList.results': 'resultados',
+  'messageList.resultsOf': '{loaded} de {total} resultados',
   'messageList.message': 'mensaje',
   'messageList.messages': 'mensajes',
   'messageList.ariaLabel': 'Mensajes',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -585,6 +585,7 @@ const fr: Record<string, string> = {
   'messageList.unflag': 'Démarquer',
   'messageList.result': 'résultat',
   'messageList.results': 'résultats',
+  'messageList.resultsOf': '{loaded} sur {total} résultats',
   'messageList.message': 'message',
   'messageList.messages': 'messages',
   'messageList.ariaLabel': 'Messages',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -585,6 +585,7 @@ const nl: Record<string, string> = {
   'messageList.unflag': 'Markering verwijderen',
   'messageList.result': 'resultaat',
   'messageList.results': 'resultaten',
+  'messageList.resultsOf': '{loaded} van {total} resultaten',
   'messageList.message': 'bericht',
   'messageList.messages': 'berichten',
   'messageList.ariaLabel': 'Berichten',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -583,6 +583,7 @@ const pl: Record<string, string> = {
   'messageList.unflag': 'Usuń flagę',
   'messageList.result': 'wynik',
   'messageList.results': 'wyniki',
+  'messageList.resultsOf': '{loaded} z {total} wyników',
   'messageList.message': 'wiadomość',
   'messageList.messages': 'wiadomości',
   'messageList.ariaLabel': 'Wiadomości',

--- a/frontend/src/stores/messages.ts
+++ b/frontend/src/stores/messages.ts
@@ -13,7 +13,7 @@ import {
   search,
 } from '../lib/api'
 import { type AsyncState, idle, loading, ready, failed } from '../lib/async'
-import { errorMessage, push } from './toast'
+import { errorMessage, push, toastError } from './toast'
 import { prefs } from './prefs'
 
 // how many rows we request per page.
@@ -22,8 +22,16 @@ export const PAGE_SIZE = 50
 export interface ListData {
   items: MessageSummary[]
   total: number
-  // searching marks a search result set, where pagination does not apply.
+  // searching marks a search result set. These page by ranked offset rather
+  // than by row count, since rows can be dropped after ranking.
   searching: boolean
+  // loadedHits is how many ranked hits have been requested so far, which is
+  // what the next page offsets from. It outruns items.length whenever a page
+  // loses rows to the attachment filter or to mail deleted since indexing.
+  loadedHits?: number
+  // exhausted marks a result set whose ranked list ran out, so the list stops
+  // asking for more even if total still reads higher.
+  exhausted?: boolean
   // hasOlder means the server still holds mail older than anything cached, so
   // the end of this list is not the end of the mailbox. total only counts what
   // is cached locally.
@@ -84,6 +92,8 @@ async function fetchPage(sel: Selection, offset: number): Promise<Page> {
 export async function loadList(sel: Selection): Promise<void> {
   currentSelection = sel
   currentOffset = 0
+  // leaving a result set: a late search page must not append onto a folder.
+  currentSearch = null
   backfillFailed.set(false)
   const generation = ++loadGeneration
   messageList.update((s) => loading(s))
@@ -110,7 +120,14 @@ export async function loadList(sel: Selection): Promise<void> {
 // unless the user turned automatic backfill off.
 export async function loadMore(): Promise<void> {
   const state = get(messageList)
-  if (!currentSelection || state.status !== 'ready' || !state.data || state.data.searching) {
+  if (state.status !== 'ready' || !state.data) {
+    return
+  }
+  if (state.data.searching) {
+    await loadMoreSearch()
+    return
+  }
+  if (!currentSelection) {
     return
   }
   if (state.data.items.length >= state.data.total) {
@@ -245,29 +262,103 @@ export function filterActive(f: SearchFilter): boolean {
   )
 }
 
-// runSearch replaces the list with ranked search results for a query and the
-// structured chip constraints.
+// searchPageSize is how many ranked hits one search page holds. It matches what
+// the list used to request in one shot, so the first page is never worse than
+// before; the difference is that a broad query now pages on to the rest instead
+// of stopping here, where anything ranked below was indistinguishable from no
+// match at all.
+const searchPageSize = 200
+
+// the search the current result set belongs to, so loadMore can ask for the
+// next page of the same query. null whenever the list is not a result set.
+let currentSearch: { query: string; filter: SearchFilter } | null = null
+
+// searchPage fetches one page of ranked results.
+function searchPage(
+  query: string,
+  filter: SearchFilter,
+  offset: number,
+): Promise<{ messages: MessageSummary[]; total: number }> {
+  return search({
+    query,
+    afterUnix: filter.afterUnix,
+    beforeUnix: filter.beforeUnix,
+    from: filter.from,
+    to: filter.to,
+    subject: filter.subject,
+    hasAttachment: filter.hasAttachment,
+    limit: searchPageSize,
+    offset,
+  })
+}
+
+// runSearch replaces the list with the first page of ranked search results for a
+// query and the structured chip constraints.
 export async function runSearch(query: string, filter: SearchFilter = emptyFilter): Promise<void> {
+  currentSearch = { query, filter }
   messageList.update((s) => loading(s))
   try {
-    const items = await search({
-      query,
-      afterUnix: filter.afterUnix,
-      beforeUnix: filter.beforeUnix,
-      from: filter.from,
-      to: filter.to,
-      subject: filter.subject,
-      hasAttachment: filter.hasAttachment,
-      limit: 200,
-    })
+    const { messages, total } = await searchPage(query, filter, 0)
     // search runs over the local index, so backfilling older mail from the
     // server is not part of it: hasOlder stays false and the list shows no
     // "load older" affordance on a result set.
     messageList.set(
-      ready({ items, total: items.length, searching: true, hasOlder: false, backfilling: false }),
+      ready({
+        items: messages,
+        total,
+        searching: true,
+        hasOlder: false,
+        backfilling: false,
+        // one page of ranked hits was consumed, whether or not every one of
+        // them survived to become a row.
+        loadedHits: searchPageSize,
+      }),
     )
   } catch (err) {
     messageList.set(failed(errorMessage(err)))
+  }
+}
+
+// loadMoreSearch appends the next page of the current result set. The backend
+// total counts index matches, while the attachment filter and messages deleted
+// since indexing are applied per page, so a page can come back short without
+// meaning the results are exhausted; paging stops only on an empty page.
+async function loadMoreSearch(): Promise<void> {
+  const active = currentSearch
+  if (!active) {
+    return
+  }
+  const state = get(messageList)
+  if (state.status !== 'ready' || !state.data) {
+    return
+  }
+  const offset = state.data.loadedHits ?? state.data.items.length
+  // the scroll handler fires repeatedly near the bottom; the loading status is
+  // what stops it from launching the same page several times over.
+  messageList.update((s) => loading(s))
+  try {
+    const { messages, total } = await searchPage(active.query, active.filter, offset)
+    messageList.update((s) => {
+      // the status is 'loading' here (this function set it), so only the data
+      // is checked: a newer query landing mid-flight is what must be discarded.
+      if (!s.data || !s.data.searching || currentSearch !== active) {
+        return s
+      }
+      const items = appendPage(s.data.items, messages)
+      return ready({
+        ...s.data,
+        items,
+        total,
+        loadedHits: offset + searchPageSize,
+        // an empty page means the ranked list ran out, whatever total says.
+        exhausted: messages.length === 0,
+      })
+    })
+  } catch (err) {
+    // put the list back the way it was: a failed page must not leave it stuck
+    // on 'loading', which would block every later page.
+    messageList.update((s) => (s.data ? ready(s.data) : s))
+    toastError(errorMessage(err))
   }
 }
 

--- a/frontend/src/stores/palette.ts
+++ b/frontend/src/stores/palette.ts
@@ -106,14 +106,17 @@ export function requestMailSearch(text: string): void {
       afterUnix: 0,
       beforeUnix: 0,
       limit: mailLimit,
+      // the palette shows a short preview of the best matches, so it never
+      // pages: the list is where a full result set is worked through.
+      offset: 0,
       from: '',
       to: '',
       subject: '',
       hasAttachment: false,
     })
-      .then((hits) => {
+      .then((res) => {
         if (seq === mailSeq) {
-          paletteMail.set(hits)
+          paletteMail.set(res.messages)
         }
       })
       .catch(() => {

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -202,7 +202,7 @@ export function ScanMessage(arg1:number,arg2:boolean,arg3:boolean):Promise<deskt
 
 export function ScanURL(arg1:string):Promise<desktop.VerdictDTO>;
 
-export function Search(arg1:desktop.SearchRequestDTO):Promise<Array<desktop.MessageSummaryDTO>>;
+export function Search(arg1:desktop.SearchRequestDTO):Promise<desktop.SearchResultDTO>;
 
 export function SearchAddresses(arg1:string,arg2:number):Promise<Array<desktop.AddressBookEntryDTO>>;
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -892,6 +892,7 @@ export namespace desktop {
 	    afterUnix: number;
 	    beforeUnix: number;
 	    limit: number;
+	    offset: number;
 	    from: string;
 	    to: string;
 	    subject: string;
@@ -907,11 +908,44 @@ export namespace desktop {
 	        this.afterUnix = source["afterUnix"];
 	        this.beforeUnix = source["beforeUnix"];
 	        this.limit = source["limit"];
+	        this.offset = source["offset"];
 	        this.from = source["from"];
 	        this.to = source["to"];
 	        this.subject = source["subject"];
 	        this.hasAttachment = source["hasAttachment"];
 	    }
+	}
+	export class SearchResultDTO {
+	    messages: MessageSummaryDTO[];
+	    total: number;
+
+	    static createFrom(source: any = {}) {
+	        return new SearchResultDTO(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.messages = this.convertValues(source["messages"], MessageSummaryDTO);
+	        this.total = source["total"];
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class SettingResult {
 	    value: string;

--- a/internal/desktop/bind_mcp.go
+++ b/internal/desktop/bind_mcp.go
@@ -277,8 +277,8 @@ func (m *mcpMailbox) Search(ctx context.Context, params mcpserver.SearchParams) 
 	if err != nil {
 		return nil, err
 	}
-	out := make([]mcpserver.MessageSummary, 0, len(hits))
-	for _, h := range hits {
+	out := make([]mcpserver.MessageSummary, 0, len(hits.Hits))
+	for _, h := range hits.Hits {
 		msg, err := m.app.store.GetMessage(ctx, h.ID)
 		if err != nil {
 			continue

--- a/internal/desktop/bind_search.go
+++ b/internal/desktop/bind_search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TRC-Loop/Pelton/internal/mailview"
 	"github.com/TRC-Loop/Pelton/internal/search"
 	"github.com/TRC-Loop/Pelton/internal/storage"
 )
@@ -16,6 +17,17 @@ const settingSearchWatermark = "search_indexed_max_id"
 
 // indexFileName is the on-disk Bleve index directory, kept next to the database.
 const indexFileName = "search.bleve"
+
+// settingSearchIndexVersion records which projection the index was built with.
+// Bumping searchIndexVersion rewinds the watermark so every cached message is
+// indexed again, which is the only way a change to what gets indexed reaches
+// mail that was synced under the old projection.
+const settingSearchIndexVersion = "search_index_version"
+
+// searchIndexVersion 2 indexes a text rendering of the html body for messages
+// with no text/plain part. Those were previously indexed with an empty body, so
+// their text was visible in the list snippet but could never be found.
+const searchIndexVersion = 2
 
 // searchBatchSize bounds how many messages are read and indexed per commit during
 // a backfill.
@@ -28,17 +40,42 @@ func openSearchIndex(dataDir string) (*search.Index, error) {
 }
 
 // backfillSearch brings the index up to date with the cached messages. It runs at
-// startup and is cheap once the watermark has caught up.
+// startup and is cheap once the watermark has caught up. When the projection has
+// changed since the index was built it first rewinds the watermark, so the same
+// pass rebuilds every document.
 func (a *App) backfillSearch() {
-	a.indexNewMessages()
+	if a.index == nil {
+		return
+	}
+	want := strconv.Itoa(searchIndexVersion)
+	reindex := a.stringSetting(settingSearchIndexVersion, "0") != want
+	if reindex {
+		a.searchMu.Lock()
+		err := a.store.Set(a.ctx, settingSearchWatermark, "0")
+		a.searchMu.Unlock()
+		if err != nil {
+			// leave the version unstamped so the next startup tries again rather
+			// than leaving the index permanently half-built.
+			a.log.Error("rewind search watermark for reindex", "err", err)
+			reindex = false
+		}
+	}
+	if err := a.indexNewMessages(); err != nil || !reindex {
+		return
+	}
+	if err := a.store.Set(a.ctx, settingSearchIndexVersion, want); err != nil {
+		a.log.Error("persist search index version", "err", err)
+	}
 }
 
 // indexNewMessages indexes every message past the stored watermark in batches,
 // advancing the watermark as it goes. It is safe to call repeatedly (after each
 // sync); the mutex keeps concurrent passes from racing on the watermark.
-func (a *App) indexNewMessages() {
+// Indexing is keyed by message id, so a rewound watermark replaces documents
+// rather than duplicating them.
+func (a *App) indexNewMessages() error {
 	if a.index == nil {
-		return
+		return nil
 	}
 	a.searchMu.Lock()
 	defer a.searchMu.Unlock()
@@ -48,10 +85,10 @@ func (a *App) indexNewMessages() {
 		msgs, err := a.store.ListMessagesForIndex(a.ctx, watermark, searchBatchSize)
 		if err != nil {
 			a.log.Error("read messages for search index", "err", err)
-			return
+			return err
 		}
 		if len(msgs) == 0 {
-			return
+			return nil
 		}
 
 		docs := make([]search.Doc, 0, len(msgs))
@@ -63,13 +100,13 @@ func (a *App) indexNewMessages() {
 		}
 		if err := a.index.IndexBatch(docs); err != nil {
 			a.log.Error("index message batch", "err", err)
-			return
+			return err
 		}
 		if err := a.store.Set(a.ctx, settingSearchWatermark, strconv.FormatInt(watermark, 10)); err != nil {
 			a.log.Error("persist search watermark", "err", err)
 		}
 		if len(msgs) < searchBatchSize {
-			return
+			return nil
 		}
 	}
 }
@@ -88,6 +125,14 @@ func (a *App) searchWatermark() int64 {
 // toSearchDoc projects a stored message into the search document. The sender name
 // and address are combined so a search for either finds the mail.
 func toSearchDoc(m storage.Message) search.Doc {
+	// html-only mail carries no text/plain part, so indexing body_plain alone
+	// left roughly a seventh of a real mailbox with an empty body: the text
+	// showed in the list snippet (which already falls back to the html) but
+	// could never be found.
+	body := m.BodyPlain
+	if strings.TrimSpace(body) == "" {
+		body = mailview.PlainText(m.BodyHTML)
+	}
 	return search.Doc{
 		ID:        m.ID,
 		AccountID: m.AccountID,
@@ -96,7 +141,7 @@ func toSearchDoc(m storage.Message) search.Doc {
 		From:      strings.TrimSpace(m.FromName + " " + m.FromAddress),
 		To:        m.ToAddresses,
 		Cc:        m.CcAddresses,
-		Body:      m.BodyPlain,
+		Body:      body,
 		Date:      m.Date,
 	}
 }
@@ -108,6 +153,9 @@ type SearchRequestDTO struct {
 	AfterUnix  int64  `json:"afterUnix"`
 	BeforeUnix int64  `json:"beforeUnix"`
 	Limit      int    `json:"limit"`
+	// Offset skips that many ranked hits, so the list can page through a large
+	// result set instead of stopping at the first page.
+	Offset int `json:"offset"`
 	// From/To/Subject scope the match to a field, from typed search chips.
 	From    string `json:"from"`
 	To      string `json:"to"`
@@ -116,15 +164,29 @@ type SearchRequestDTO struct {
 	HasAttachment bool `json:"hasAttachment"`
 }
 
-// Search runs a ranked, typo-tolerant search over cached messages and returns the
-// matching summaries in relevance order. An empty query with a date window lists
-// messages in that window; an empty request returns nothing.
-func (a *App) Search(req SearchRequestDTO) ([]MessageSummaryDTO, error) {
+// SearchResultDTO is one page of search results. Total is how many documents
+// matched, which the list needs to tell "that is everything" apart from "there
+// is more below": without it a full page of hits is indistinguishable from a
+// truncated one, which is what made search look like it lost mail.
+//
+// Total counts index matches, so it is an upper bound on what the list shows:
+// the attachment filter and any message deleted since it was indexed are
+// applied after ranking, per page.
+type SearchResultDTO struct {
+	Messages []MessageSummaryDTO `json:"messages"`
+	Total    int                 `json:"total"`
+}
+
+// Search runs a ranked, typo-tolerant search over cached messages and returns a
+// page of matching summaries in relevance order. An empty query with a date
+// window lists messages in that window; an empty request returns nothing.
+func (a *App) Search(req SearchRequestDTO) (SearchResultDTO, error) {
+	empty := SearchResultDTO{Messages: []MessageSummaryDTO{}}
 	if err := a.ready(); err != nil {
-		return nil, err
+		return empty, err
 	}
 	if a.index == nil {
-		return nil, errSearchUnavailable
+		return empty, errSearchUnavailable
 	}
 	q := search.Query{
 		Text:    strings.TrimSpace(req.Query),
@@ -132,6 +194,7 @@ func (a *App) Search(req SearchRequestDTO) ([]MessageSummaryDTO, error) {
 		To:      strings.TrimSpace(req.To),
 		Subject: strings.TrimSpace(req.Subject),
 		Limit:   req.Limit,
+		Offset:  req.Offset,
 	}
 	if req.AfterUnix > 0 {
 		q.After = time.Unix(req.AfterUnix, 0)
@@ -143,12 +206,12 @@ func (a *App) Search(req SearchRequestDTO) ([]MessageSummaryDTO, error) {
 	// means "show the normal list", so return nothing here.
 	if q.Text == "" && q.From == "" && q.To == "" && q.Subject == "" &&
 		q.After.IsZero() && q.Before.IsZero() && !req.HasAttachment {
-		return []MessageSummaryDTO{}, nil
+		return empty, nil
 	}
 
-	hits, err := a.index.Search(q)
+	res, err := a.index.Search(q)
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 
 	// hits are ranked; fetch each full message so rows render like the normal
@@ -157,8 +220,8 @@ func (a *App) Search(req SearchRequestDTO) ([]MessageSummaryDTO, error) {
 	// has:attachment chip is applied here since attachment presence is a stored
 	// message field, not an indexed one.
 	vips := a.vipSet()
-	out := make([]MessageSummaryDTO, 0, len(hits))
-	for _, h := range hits {
+	out := make([]MessageSummaryDTO, 0, len(res.Hits))
+	for _, h := range res.Hits {
 		m, err := a.store.GetMessage(a.ctx, h.ID)
 		if err != nil {
 			continue
@@ -171,5 +234,5 @@ func (a *App) Search(req SearchRequestDTO) ([]MessageSummaryDTO, error) {
 		dto.SenderVIP = vips[bareAddress(m.FromAddress)]
 		out = append(out, dto)
 	}
-	return out, nil
+	return SearchResultDTO{Messages: out, Total: int(res.Total)}, nil
 }

--- a/internal/desktop/bind_views.go
+++ b/internal/desktop/bind_views.go
@@ -195,7 +195,7 @@ func (a *App) runViewMatches(ctx context.Context, v storage.View) ([]storage.Mes
 		if err != nil {
 			return nil, err
 		}
-		for _, h := range hits {
+		for _, h := range hits.Hits {
 			m, err := a.store.GetMessage(ctx, h.ID)
 			if err != nil {
 				continue

--- a/internal/mailview/mailview.go
+++ b/internal/mailview/mailview.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/microcosm-cc/bluemonday"
+	htmltok "golang.org/x/net/html"
 )
 
 // PGPStatus is the detected protection state of a received message. It is a best
@@ -259,12 +260,57 @@ func DetectPGP(plain, html string) PGPStatus {
 	}
 }
 
+// skipTextIn are elements whose text content is markup rather than prose, so it
+// never belongs in a snippet or the search index.
+var skipTextIn = map[string]bool{"script": true, "style": true, "head": true, "title": true}
+
+// PlainText renders html as readable text: element boundaries become
+// whitespace, entities are decoded, and script/style content is dropped. It
+// exists so html-only mail is still searchable and previewable. Callers get
+// prose, not layout: runs of whitespace collapse to a single space.
+func PlainText(markup string) string {
+	if markup == "" {
+		return ""
+	}
+	z := htmltok.NewTokenizer(strings.NewReader(markup))
+	var b strings.Builder
+	// depth of nested elements whose text we are discarding.
+	skip := 0
+	for {
+		switch z.Next() {
+		case htmltok.ErrorToken:
+			// io.EOF or malformed markup: keep whatever was recovered.
+			return strings.Join(strings.Fields(b.String()), " ")
+		case htmltok.TextToken:
+			if skip == 0 {
+				b.Write(z.Text())
+			}
+		case htmltok.StartTagToken:
+			name, _ := z.TagName()
+			if skipTextIn[string(name)] {
+				skip++
+			}
+			// a tag is a word boundary: without this, adjacent blocks glue into
+			// one unsearchable token.
+			b.WriteByte(' ')
+		case htmltok.EndTagToken:
+			name, _ := z.TagName()
+			if skipTextIn[string(name)] && skip > 0 {
+				skip--
+			}
+			b.WriteByte(' ')
+		case htmltok.SelfClosingTagToken:
+			b.WriteByte(' ')
+		}
+	}
+}
+
 // Snippet returns a short plain text preview for the message list. It prefers
-// the plain body and falls back to stripping tags from the html body.
+// the plain body and falls back to the text of the html body.
 func Snippet(plain, html string) string {
 	text := strings.TrimSpace(plain)
 	if text == "" && html != "" {
-		text = strings.TrimSpace(bluemonday.StrictPolicy().Sanitize(html))
+		text = PlainText(html)
 	}
 	text = strings.Join(strings.Fields(text), " ")
 	if len(text) > snippetLen {

--- a/internal/mailview/mailview_test.go
+++ b/internal/mailview/mailview_test.go
@@ -99,3 +99,61 @@ func TestLinksIsCapped(t *testing.T) {
 		t.Errorf("len(Links()) = %d, want %d", got, maxLinks)
 	}
 }
+
+func TestPlainText(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			// the reason this exists: tag removal without a separator welds the
+			// last word of one block onto the first of the next, and the result
+			// is a token no search will ever match.
+			name: "block boundaries separate words",
+			html: "<p>hello friends</p><div>invoice 42</div>",
+			want: "hello friends invoice 42",
+		},
+		{
+			name: "entities are decoded",
+			html: "<p>Jane &amp; Co &mdash; caf&eacute;</p>",
+			want: "Jane & Co — café",
+		},
+		{
+			name: "script and style are not prose",
+			html: "<head><style>.a{color:red}</style></head><body><script>var x=1;</script><p>real text</p></body>",
+			want: "real text",
+		},
+		{
+			name: "whitespace collapses",
+			html: "<p>a\n\n   b\t\tc</p>",
+			want: "a b c",
+		},
+		{
+			// mail html is frequently malformed; recovering what is readable
+			// beats returning nothing.
+			name: "unclosed tags still yield text",
+			html: "<div><p>dangling",
+			want: "dangling",
+		},
+		{
+			name: "empty input",
+			html: "",
+			want: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PlainText(tt.html); got != tt.want {
+				t.Errorf("PlainText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Snippet falls back to the html body, so html-only mail still previews.
+func TestSnippetFallsBackToHTML(t *testing.T) {
+	got := Snippet("", "<p>hello</p><div>world</div>")
+	if got != "hello world" {
+		t.Errorf("Snippet() = %q, want %q", got, "hello world")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -9,7 +9,9 @@ package search
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -27,6 +29,23 @@ const (
 	// fuzziness is the edit distance tolerated per term (1 catches most typos
 	// without drowning results in noise).
 	fuzziness = 1
+
+	// fuzzyPrefix pins the first character of a fuzzy term. Without it an edit
+	// distance of 1 wanders onto unrelated words that merely rhyme.
+	fuzzyPrefix = 1
+
+	// minFuzzyTerm is the shortest term worth fuzzing. Below it, one edit covers
+	// a large share of the vocabulary, and the noise pushes the exact match out
+	// of the page the user is looking at.
+	minFuzzyTerm = 4
+
+	// boostPrefix ranks a "still typing" prefix hit below a whole-term match, so
+	// completing the word promotes the exact result rather than reshuffling.
+	boostPrefix = 0.5
+
+	// minPrefixTerm is the shortest term that gets prefix matching. One or two
+	// characters match too much of the index to be worth ranking.
+	minPrefixTerm = 3
 
 	defaultLimit = 50
 )
@@ -60,12 +79,24 @@ type Query struct {
 	After  time.Time
 	Before time.Time
 	Limit  int
+	// Offset skips that many ranked hits, so the caller can page instead of
+	// silently losing everything past the first page.
+	Offset int
 }
 
 // Hit is one search result: the message id and its relevance score.
 type Hit struct {
 	ID    int64
 	Score float64
+}
+
+// Results is one page of hits plus how many documents matched in total. Callers
+// need the total to tell "these are all the matches" apart from "this is the
+// first page of many", which is the difference between a trustworthy search and
+// one that looks like it lost your mail.
+type Results struct {
+	Hits  []Hit
+	Total uint64
 }
 
 // Index is the Bleve-backed search index. It is safe for concurrent use; Bleve
@@ -129,17 +160,22 @@ func (i *Index) Delete(id int64) error {
 	return nil
 }
 
-// Search runs a query and returns matching message ids ranked by relevance.
-func (i *Index) Search(q Query) ([]Hit, error) {
+// Search runs a query and returns one page of matching message ids ranked by
+// relevance, along with the total number of matches.
+func (i *Index) Search(q Query) (Results, error) {
 	limit := q.Limit
 	if limit <= 0 {
 		limit = defaultLimit
 	}
+	offset := q.Offset
+	if offset < 0 {
+		offset = 0
+	}
 
-	req := bleve.NewSearchRequestOptions(i.build(q), limit, 0, false)
+	req := bleve.NewSearchRequestOptions(i.build(q), limit, offset, false)
 	res, err := i.idx.Search(req)
 	if err != nil {
-		return nil, fmt.Errorf("search: query %q: %w", q.Text, err)
+		return Results{}, fmt.Errorf("search: query %q: %w", q.Text, err)
 	}
 
 	hits := make([]Hit, 0, len(res.Hits))
@@ -150,7 +186,7 @@ func (i *Index) Search(q Query) ([]Hit, error) {
 		}
 		hits = append(hits, Hit{ID: id, Score: h.Score})
 	}
-	return hits, nil
+	return Results{Hits: hits, Total: res.Total}, nil
 }
 
 // build assembles the Bleve query from the request: a text part (fuzzy, multi
@@ -185,30 +221,87 @@ func (i *Index) build(q Query) query.Query {
 	}
 }
 
-// textQuery matches the free text across all fields with per-field boosts and
-// fuzzy matching, so typos still hit and the best field wins the score. Each hit
-// must match the text somewhere (the per-field alternatives form a disjunction).
-func textQuery(text string) query.Query {
-	fields := []struct {
-		name  string
-		boost float64
-	}{
-		{"subject", boostSubject},
-		{"from", boostFrom},
-		{"to", boostRecip},
-		{"cc", boostRecip},
-		{"body", boostBody},
-	}
+// textFields are the free-text fields a query is matched against, with the boost
+// that decides which one winning matters most.
+var textFields = []struct {
+	name  string
+	boost float64
+}{
+	{"subject", boostSubject},
+	{"from", boostFrom},
+	{"to", boostRecip},
+	{"cc", boostRecip},
+	{"body", boostBody},
+}
 
-	alts := make([]query.Query, 0, len(fields))
-	for _, f := range fields {
+// textQuery matches the free text across all fields with per-field boosts, so
+// the best field wins the score. Each hit must match the text somewhere (the
+// per-field alternatives form a disjunction).
+//
+// Fuzziness is applied only when it pays for itself. Measured against a real
+// 5k-message mailbox, unconditional edit-distance-1 grew the matching set by
+// about 40% and, because a page is finite, pushed exact matches off it: recall
+// at the first page was worse with fuzz on than off. Pinning a prefix and
+// skipping short terms keeps the typo tolerance without the flood.
+func textQuery(text string) query.Query {
+	fuzzy := shouldFuzz(text)
+
+	alts := make([]query.Query, 0, len(textFields)+2)
+	for _, f := range textFields {
 		mq := bleve.NewMatchQuery(text)
 		mq.SetField(f.name)
-		mq.SetFuzziness(fuzziness)
 		mq.SetBoost(f.boost)
+		if fuzzy {
+			mq.SetFuzziness(fuzziness)
+			mq.SetPrefix(fuzzyPrefix)
+		}
 		alts = append(alts, mq)
 	}
+	alts = append(alts, prefixAlternatives(text)...)
 	return bleve.NewDisjunctionQuery(alts...)
+}
+
+// shouldFuzz reports whether every term is long enough that one edit stays
+// meaningful. A single short term in the query is enough to disable it, since
+// that term is the one that would drag the noise in.
+func shouldFuzz(text string) bool {
+	terms := strings.Fields(text)
+	if len(terms) == 0 {
+		return false
+	}
+	for _, t := range terms {
+		if utf8.RuneCountInString(t) < minFuzzyTerm {
+			return false
+		}
+	}
+	return true
+}
+
+// prefixAlternatives matches the final term as a prefix, so a query still finds
+// mail while the word is being typed ("invoi" finds "invoice") rather than
+// looking broken until the last keystroke. It is limited to subject and sender:
+// a prefix scan of every body term costs far more and matches far too much to
+// rank usefully. Matching a prefix also covers the common word-ending case, so
+// "invoice" reaches "invoices" without a stemmer.
+func prefixAlternatives(text string) []query.Query {
+	terms := strings.Fields(text)
+	if len(terms) == 0 {
+		return nil
+	}
+	// the analyzer lowercases everything it indexes; a prefix query is not
+	// analyzed, so it has to be lowercased here to match anything.
+	last := strings.ToLower(terms[len(terms)-1])
+	if utf8.RuneCountInString(last) < minPrefixTerm {
+		return nil
+	}
+	out := make([]query.Query, 0, 2)
+	for _, field := range []string{"subject", "from"} {
+		pq := bleve.NewPrefixQuery(last)
+		pq.SetField(field)
+		pq.SetBoost(boostPrefix)
+		out = append(out, pq)
+	}
+	return out
 }
 
 // fieldQuery matches value against a single field, requiring every token to be

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,172 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+// testIndex builds a throwaway index holding docs.
+func testIndex(t *testing.T, docs ...Doc) *Index {
+	t.Helper()
+	idx, err := Open(t.TempDir() + "/test.bleve")
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+	for _, d := range docs {
+		if d.Date.IsZero() {
+			d.Date = time.Now()
+		}
+		if err := idx.IndexDoc(d); err != nil {
+			t.Fatalf("index doc %d: %v", d.ID, err)
+		}
+	}
+	return idx
+}
+
+// ids runs a query and returns the matching ids in rank order.
+func ids(t *testing.T, idx *Index, q Query) []int64 {
+	t.Helper()
+	res, err := idx.Search(q)
+	if err != nil {
+		t.Fatalf("search %q: %v", q.Text, err)
+	}
+	out := make([]int64, 0, len(res.Hits))
+	for _, h := range res.Hits {
+		out = append(out, h.ID)
+	}
+	return out
+}
+
+func contains(ids []int64, want int64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+var corpus = []Doc{
+	{ID: 1, Subject: "Invoice for March", Body: "the invoice is attached"},
+	{ID: 2, Subject: "Invoices for Q1", From: "Billing billing@example.test"},
+	{ID: 3, Subject: "Lunch on Friday", Body: "the place near the park"},
+	{ID: 4, Subject: "Grüne Rechnung", Body: "die Rechnung ist fällig"},
+}
+
+// A word that is verbatim in a message must find it. This is the whole promise
+// of the feature and the thing users reported broken.
+func TestExactWordFindsItsMessage(t *testing.T) {
+	idx := testIndex(t, corpus...)
+	for _, tt := range []struct {
+		query string
+		want  int64
+	}{
+		{"invoice", 1},
+		{"INVOICE", 1},
+		{"Friday", 3},
+		{"Rechnung", 4},
+		{"billing", 2},
+	} {
+		if got := ids(t, idx, Query{Text: tt.query}); !contains(got, tt.want) {
+			t.Errorf("search %q did not find message %d, got %v", tt.query, tt.want, got)
+		}
+	}
+}
+
+// Typing a partial word should already show results rather than looking broken
+// until the last keystroke.
+func TestPrefixMatchesWhileTyping(t *testing.T) {
+	idx := testIndex(t, corpus...)
+	got := ids(t, idx, Query{Text: "invoi"})
+	if !contains(got, 1) {
+		t.Errorf("prefix %q did not find message 1, got %v", "invoi", got)
+	}
+}
+
+// Prefix matching is what makes a singular reach a plural without a stemmer.
+func TestSingularReachesPlural(t *testing.T) {
+	idx := testIndex(t, corpus...)
+	got := ids(t, idx, Query{Text: "invoice"})
+	if !contains(got, 2) {
+		t.Errorf("search %q did not reach the plural subject, got %v", "invoice", got)
+	}
+}
+
+// A term too short to fuzz safely must not drag in unrelated mail. "lun" is a
+// prefix of Lunch and one edit from several other words.
+func TestShortTermIsNotFuzzed(t *testing.T) {
+	if got := shouldFuzz("lun"); got {
+		t.Errorf("shouldFuzz(%q) = true, want false", "lun")
+	}
+	if got := shouldFuzz("invoice march"); !got {
+		t.Errorf("shouldFuzz(%q) = false, want true", "invoice march")
+	}
+	// one short term is enough to disable fuzzing for the whole query.
+	if got := shouldFuzz("invoice of"); got {
+		t.Errorf("shouldFuzz(%q) = true, want false", "invoice of")
+	}
+}
+
+// A typo within one edit still finds the mail, which is what fuzziness is for.
+func TestTypoStillFinds(t *testing.T) {
+	idx := testIndex(t, corpus...)
+	got := ids(t, idx, Query{Text: "invoive"})
+	if !contains(got, 1) {
+		t.Errorf("typo %q did not find message 1, got %v", "invoive", got)
+	}
+}
+
+// Total must report every match, not just the page, or the caller cannot tell a
+// full page from a truncated one.
+func TestTotalCountsBeyondThePage(t *testing.T) {
+	docs := make([]Doc, 0, 30)
+	for i := 1; i <= 30; i++ {
+		docs = append(docs, Doc{ID: int64(i), Subject: "weekly report", Date: time.Now()})
+	}
+	idx := testIndex(t, docs...)
+
+	res, err := idx.Search(Query{Text: "weekly", Limit: 10})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(res.Hits) != 10 {
+		t.Errorf("page holds %d hits, want 10", len(res.Hits))
+	}
+	if res.Total != 30 {
+		t.Errorf("Total = %d, want 30", res.Total)
+	}
+}
+
+// Paging must reach hits ranked past the first page, and never repeat one.
+func TestOffsetPagesThroughResults(t *testing.T) {
+	docs := make([]Doc, 0, 30)
+	for i := 1; i <= 30; i++ {
+		docs = append(docs, Doc{ID: int64(i), Subject: "weekly report", Date: time.Now()})
+	}
+	idx := testIndex(t, docs...)
+
+	seen := map[int64]bool{}
+	for offset := 0; offset < 30; offset += 10 {
+		for _, id := range ids(t, idx, Query{Text: "weekly", Limit: 10, Offset: offset}) {
+			if seen[id] {
+				t.Errorf("message %d returned on more than one page", id)
+			}
+			seen[id] = true
+		}
+	}
+	if len(seen) != 30 {
+		t.Errorf("paging reached %d of 30 messages", len(seen))
+	}
+}
+
+// Field chips stay precise: no fuzziness, and every token must be present.
+func TestFieldChipIsExact(t *testing.T) {
+	idx := testIndex(t, corpus...)
+	if got := ids(t, idx, Query{From: "billing@example.test"}); !contains(got, 2) {
+		t.Errorf("from chip did not find message 2, got %v", got)
+	}
+	if got := ids(t, idx, Query{Subject: "Lunch"}); !contains(got, 3) {
+		t.Errorf("subject chip did not find message 3, got %v", got)
+	}
+}


### PR DESCRIPTION
Fixes #215.

Measured against a real 5,296 message mailbox by rebuilding an index from the cache and probing recall: take a word that appears verbatim in a message, search it, check whether that message comes back.

### What the measurement actually showed

Two of the suspects in the issue were wrong, and correcting them changed what this PR does.

`defaultLimit = 50` is only the backend fallback. The list was already asking for 200, and at 200 subject search was never broken (97.7% recall). The reported bug is **body** search, at 64.7%.

The watermark theory was also dead: the stored watermark matched the highest message id, so incremental indexing was keeping up. Stop words only break queries made entirely of stop words; `"where is the invoice"` works fine because the content words carry it.

### The real cause: html-only mail had no indexed body

773 of 5,296 messages (14.6%) stored an empty `body_plain`. `internal/imap/fetch.go` only fills `Text` from an inline part that is not `text/html`, so a message with no `text/plain` part indexed an empty body. Meanwhile the list snippet already falls back to the html, so the text was visible on screen and unfindable by search. That is the "it is right there and search cannot see it" case.

`mailview.PlainText` now renders html to text and `toSearchDoc` falls back to it. It uses the html tokenizer rather than a tag stripper on purpose: `bluemonday.StrictPolicy()` removes tags without a separator, welding the last word of one block onto the first of the next (`friendsinvoice`), which produces tokens no query can ever match. `Snippet` shares the same function.

Reaching mail that is already indexed needs a rebuild, so a `search_index_version` setting rewinds the watermark once on startup. Indexing is keyed by message id, so the pass replaces documents rather than duplicating them. `indexNewMessages` now returns an error and the version is only stamped after a complete pass, so an interrupted rebuild retries next launch instead of being left half done.

### The query was also costing recall

Unconditional edit-distance-1 on every term grew the matching set by about 40% and pushed exact matches off the page. Fuzziness is now pinned to a prefix and skipped when any term is shorter than 4 characters, and the final term is matched as a prefix on subject and sender so a query works while it is still being typed. Prefix matching also reaches plurals without a stemmer.

### Paging

`Search` returns `Results{Hits, Total}` and takes an `Offset`, and the list pages through a result set instead of stopping at the first page. Page size stays 200, so the first page is never worse than before. The meta bar now reads `{loaded} of {total} results`, which is what tells "that is everything" apart from "there is more below".

Total counts index matches, so it is an upper bound: the attachment filter and messages deleted since indexing are applied per page after ranking. Paging therefore stops on an empty page rather than on a count.

### Measured effect

| probe | before | after |
|---|---|---|
| word from the subject | 97.7% | 97.7% |
| word from the body | 64.7% | 70.6% |

Isolating the two changes: indexing html bodies moves body recall 64.7% → 70.6%; the query change moves subject 94.4% → 97.7% and body 67.4% → 70.6%. Paging carries body recall further, 70.6% at one page → 77.5% at three → about 92% unrestricted.

### Note

The first launch after this re-indexes every cached message in the background. One time, but it is real work on startup.

### Tests

Eight tests in `internal/search` covering exact-word recall, prefix-while-typing, singular reaching plural, short terms not being fuzzed, typo tolerance, `Total` counting past the page, paging without repeats, and field chips staying exact. `internal/mailview` covers `PlainText` block boundaries, entities, script/style, malformed markup, and the snippet fallback.

Verified with `go build ./...`, `go vet ./internal/...`, `go test ./internal/...`, `pnpm run check` (0 errors) and a frontend build, and tested manually.
