### PR TITLE
chore: put PGPKeyDTO in the order the wails generator writes

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -809,6 +809,42 @@ export namespace desktop {
 	        this.createdAt = source["createdAt"];
 	    }
 	}
+	export class PGPKeyDTO {
+	    fingerprint: string;
+	    name: string;
+	    email: string;
+	    emails: string[];
+	    created: string;
+	    expires: string;
+	    expired: boolean;
+	    hasPrivate: boolean;
+	    locked: boolean;
+	    unlocked: boolean;
+	    remembered: boolean;
+	    algorithm: string;
+	    bits: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new PGPKeyDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.fingerprint = source["fingerprint"];
+	        this.name = source["name"];
+	        this.email = source["email"];
+	        this.emails = source["emails"];
+	        this.created = source["created"];
+	        this.expires = source["expires"];
+	        this.expired = source["expired"];
+	        this.hasPrivate = source["hasPrivate"];
+	        this.locked = source["locked"];
+	        this.unlocked = source["unlocked"];
+	        this.remembered = source["remembered"];
+	        this.algorithm = source["algorithm"];
+	        this.bits = source["bits"];
+	    }
+	}
 	export class PendingMailtoDTO {
 	    present: boolean;
 	    draft: MailtoDraft;
@@ -920,17 +956,17 @@ export namespace desktop {
 	export class SearchResultDTO {
 	    messages: MessageSummaryDTO[];
 	    total: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new SearchResultDTO(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.messages = this.convertValues(source["messages"], MessageSummaryDTO);
 	        this.total = source["total"];
 	    }
-
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -1408,43 +1444,6 @@ export namespace desktop {
 	        this.totalCount = source["totalCount"];
 	    }
 	}
-	export class PGPKeyDTO {
-	    fingerprint: string;
-	    name: string;
-	    email: string;
-	    emails: string[];
-	    created: string;
-	    expires: string;
-	    expired: boolean;
-	    hasPrivate: boolean;
-	    locked: boolean;
-	    unlocked: boolean;
-	    remembered: boolean;
-	    algorithm: string;
-	    bits: number;
-
-	    static createFrom(source: any = {}) {
-	        return new PGPKeyDTO(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.fingerprint = source["fingerprint"];
-	        this.name = source["name"];
-	        this.email = source["email"];
-	        this.emails = source["emails"];
-	        this.created = source["created"];
-	        this.expires = source["expires"];
-	        this.expired = source["expired"];
-	        this.hasPrivate = source["hasPrivate"];
-	        this.locked = source["locked"];
-	        this.unlocked = source["unlocked"];
-	        this.remembered = source["remembered"];
-	        this.algorithm = source["algorithm"];
-	        this.bits = source["bits"];
-	    }
-	}
-
 	export class VirusTotalConfigDTO {
 	    enabled: boolean;
 	    hasApiKey: boolean;


### PR DESCRIPTION
Fixes #223.

`wails dev` regenerates `frontend/wailsjs/go/models.ts` and writes `PGPKeyDTO` in alphabetical position, just before `PendingMailtoDTO`. The committed file had it near the end of the namespace, between `UnifiedViewDTO` and `VirusTotalConfigDTO`. Every `make run` therefore rewrote the file, `git status` showed it modified, and discarding it only held until the next run.

That is not just noise: `git add -A` sweeps the ~75 line move into whatever branch is open, where it reads in review as a real change to `PGPKeyDTO`. It had to be stripped out of #220 and #222 by hand, and #220 needed an amend after it had already been committed.

This moves the class to where the generator puts it, so the two agree and the file stops coming back dirty. Alphabetical is also the order the rest of the namespace already follows.

Five blank lines inside `PGPKeyDTO` and `SearchResultDTO` are normalized to the lone tab the generator writes, for the same reason.

Nothing else changes. Sorting both versions of the file and diffing them shows identical content apart from those blank lines, so this is a pure move: 39 insertions against 40 deletions, the one net line being a stray blank that followed the old block.

Applied by hand rather than by running `wails dev`, which downgrades `go.mod` and the runtime as a side effect. The ordering matches what the generator was observed to produce.

Verified with `pnpm run check` (0 errors) and a frontend build. The real confirmation is that a `make run` now leaves the tree clean.
