### PR TITLE
feat: decrypt and verify received pgp mail

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -4,7 +4,7 @@ Pelton stores OpenPGP keys so it can sign the mail you send and read the encrypt
 
 !!! note
 
-    Key management is the first half of PGP support. Signing, encrypting and decrypting mail build on it and land separately.
+    Pelton can read the protected mail you receive. Sending signed or encrypted mail is not built yet.
 
 ## Where keys come from
 
@@ -64,6 +64,24 @@ With more than one key that can sign, **Signing keys** at the bottom of the pane
 Left on **Match by address**, Pelton looks for a private key whose user id carries that account's address. That is the right answer when each account has its own key. Pin one explicitly when it is not, for instance when several addresses share a single key.
 
 Deleting a key that an account was pinned to resets that account to matching by address, rather than leaving it pointing at a key that no longer exists.
+
+## Reading protected mail
+
+Encrypted mail is decrypted when you open it, using whichever imported private key it was sent to. If that key is locked, the reading pane asks for the passphrase there rather than sending you to this page, and keeps it until you quit.
+
+Three things can go wrong, and each says which:
+
+| What you see | What it means |
+| --- | --- |
+| **This message is encrypted** | A key that can open it is present but locked. Type the passphrase. |
+| **This message cannot be decrypted** | It was encrypted to a key you have not imported. Import the matching private key above. |
+| **This message could not be read** | It claims to be PGP protected but the data is damaged. View the source to see it as it arrived. |
+
+Signed mail shows the same badge S/MIME uses: **verified** when the signature checks out against a key you hold, **unverified** when the signing key is not in your keyring, and **failed** when the message was altered after signing. Checking happens each time you open a message, so importing someone's key today makes their older mail verify immediately, with nothing to re-sync.
+
+**The decrypted text is never written to disk.** What Pelton stores is the message exactly as it arrived, still encrypted, so it can be opened again offline. Closing the message discards the plaintext.
+
+That is also why encrypted mail is not searchable by default: the search index is an ordinary file, and indexing the text would put it there. If you want it searchable anyway, **Searching encrypted mail** below turns it on, and turning it back off rebuilds the index so what was written is removed. Messages whose key is locked at the time are skipped.
 
 ## S/MIME signatures
 

--- a/frontend/src/components/detail/MessageDetail.svelte
+++ b/frontend/src/components/detail/MessageDetail.svelte
@@ -6,6 +6,7 @@
   import DetailHeader from './DetailHeader.svelte'
   import ActionToolbar from './ActionToolbar.svelte'
   import MailBody from './MailBody.svelte'
+  import ProtectedNotice from './ProtectedNotice.svelte'
   import AttachmentList from './AttachmentList.svelte'
   import InfoModal from './InfoModal.svelte'
   import SourceModal from './SourceModal.svelte'
@@ -259,7 +260,17 @@ ${bodyHtml}
     <div class="scroll selectable" bind:this={scrollEl}>
       <DetailHeader {detail} />
       <div class="body-wrap">
-        <MailBody {detail} />
+        {#if detail.pgpState !== '' && detail.pgpState !== 'open'}
+          <!-- the body here is still the armor, so showing it would put
+               ciphertext in front of the reader. -->
+          <ProtectedNotice
+            state={detail.pgpState}
+            messageId={detail.id}
+            on:opened={() => void loadMessage(detail.id)}
+          />
+        {:else}
+          <MailBody {detail} />
+        {/if}
       </div>
       <AttachmentList messageId={detail.id} attachments={detail.attachments} />
     </div>

--- a/frontend/src/components/detail/ProtectedNotice.svelte
+++ b/frontend/src/components/detail/ProtectedNotice.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  // shown in place of the body when a protected message could not be opened.
+  // each state gets its own next step, because "locked" and "no key" need
+  // completely different things from the reader: one is a passphrase they know,
+  // the other is a key they have to import.
+  import { createEventDispatcher } from 'svelte'
+  import { IconLock, IconKeyOff, IconAlertTriangle } from '@tabler/icons-svelte'
+  import { unlockMessage } from '../../lib/api'
+  import { errorMessage } from '../../stores/toast'
+  import { t } from '../../lib/i18n'
+  import type { PGPState } from '../../lib/types'
+
+  export let state: PGPState
+  export let messageId: number
+
+  const dispatch = createEventDispatcher<{ opened: void }>()
+
+  let passphrase = ''
+  let busy = false
+  let failed = ''
+
+  // a new message clears whatever was typed for the previous one, so a
+  // passphrase never carries across to a message it was not meant for.
+  let seededFor = -1
+  $: if (messageId !== seededFor) {
+    seededFor = messageId
+    passphrase = ''
+    failed = ''
+    busy = false
+  }
+
+  async function unlock(): Promise<void> {
+    if (busy || passphrase === '') {
+      return
+    }
+    busy = true
+    failed = ''
+    try {
+      await unlockMessage(messageId, passphrase)
+      // clear it the moment it is no longer needed rather than leaving it in
+      // component state for the lifetime of the pane.
+      passphrase = ''
+      dispatch('opened')
+    } catch (err) {
+      failed = errorMessage(err)
+    } finally {
+      busy = false
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      void unlock()
+    }
+  }
+</script>
+
+<div class="notice">
+  <span class="icon">
+    {#if state === 'locked'}
+      <IconLock size={18} stroke={1.7} />
+    {:else if state === 'nokey'}
+      <IconKeyOff size={18} stroke={1.7} />
+    {:else}
+      <IconAlertTriangle size={18} stroke={1.7} />
+    {/if}
+  </span>
+
+  <div class="body">
+    <p class="headline">{$t(`detail.pgp.${state}.title`)}</p>
+    <p class="explain">{$t(`detail.pgp.${state}.body`)}</p>
+
+    {#if state === 'locked'}
+      <div class="unlock">
+        <input
+          type="password"
+          bind:value={passphrase}
+          on:keydown={onKeydown}
+          placeholder={$t('detail.pgp.passphrase')}
+          autocomplete="off"
+          spellcheck="false"
+          disabled={busy}
+        />
+        <button type="button" on:click={unlock} disabled={busy || passphrase === ''}>
+          {$t('detail.pgp.unlock')}
+        </button>
+      </div>
+      {#if failed !== ''}
+        <p class="failed">{failed}</p>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .notice {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-card);
+    background: var(--surface-sunken);
+  }
+
+  .icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    color: var(--text-tertiary);
+  }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .headline {
+    margin: 0;
+    font-size: var(--fz-body);
+    font-weight: var(--fw-medium);
+    color: var(--text-primary);
+  }
+
+  .explain {
+    margin: 0;
+    font-size: var(--fz-label);
+    color: var(--text-secondary);
+  }
+
+  .unlock {
+    display: flex;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+  }
+
+  .unlock input {
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-2) var(--space-3);
+    font-family: var(--font-ui);
+    font-size: var(--fz-body);
+    color: var(--text-primary);
+    background: var(--surface-raised);
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-control);
+  }
+  .unlock input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .unlock button {
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--fz-label);
+    font-weight: var(--fw-medium);
+    color: var(--accent-fg);
+    background: var(--accent);
+    border: none;
+    border-radius: var(--radius-control);
+    cursor: pointer;
+  }
+  .unlock button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .failed {
+    margin: 0;
+    font-size: var(--fz-meta);
+    color: var(--danger);
+  }
+</style>

--- a/frontend/src/components/settings/EncryptionSection.svelte
+++ b/frontend/src/components/settings/EncryptionSection.svelte
@@ -24,7 +24,11 @@
     forgetPGPPassphrase,
     getAccountPGPKey,
     setAccountPGPKey,
+    getSetting,
+    setSetting,
+    SettingKeys,
   } from '../../lib/api'
+  import ToggleSwitch from '../common/ToggleSwitch.svelte'
   import { sidebar } from '../../stores/accounts'
   import { openPassphrase } from '../../stores/passphrase'
   import { errorMessage, toastError, toastSuccess, toastInfo } from '../../stores/toast'
@@ -38,14 +42,39 @@
   // the signing key each account is pinned to, by account id. '' means the
   // address is matched against the keys' user ids instead.
   let accountKeys: Record<number, string> = {}
+  // whether search may look inside encrypted mail. read from the backend rather
+  // than the prefs store, since it is not a display preference.
+  let indexDecrypted = false
+  let searchBusy = false
 
   $: accounts = $sidebar.data?.accounts ?? []
   $: signingKeys = keys.filter((k) => k.hasPrivate)
 
   onMount(async () => {
     await reload()
+    try {
+      indexDecrypted = (await getSetting(SettingKeys.indexDecrypted)).value === 'true'
+    } catch {
+      // never set: the default is off, which is what the toggle already shows.
+    }
     loading = false
   })
+
+  // onIndexDecrypted rebuilds the search index in the background either way,
+  // so switching this off removes the plaintext already written rather than
+  // only stopping new mail from being added.
+  async function onIndexDecrypted(next: boolean): Promise<void> {
+    searchBusy = true
+    try {
+      await setSetting(SettingKeys.indexDecrypted, next ? 'true' : 'false')
+      indexDecrypted = next
+      toastInfo($t('encryption.searchRebuilding'))
+    } catch (err) {
+      toastError(errorMessage(err))
+    } finally {
+      searchBusy = false
+    }
+  }
 
   async function reload(): Promise<void> {
     try {
@@ -274,6 +303,18 @@
       </div>
     {/each}
   {/if}
+
+  <h4>{$t('encryption.searchTitle')}</h4>
+  <div class="account">
+    <span class="row-label">{$t('encryption.searchLabel')}</span>
+    <ToggleSwitch
+      checked={indexDecrypted}
+      label={$t('encryption.searchLabel')}
+      disabled={searchBusy}
+      on:change={(e) => void onIndexDecrypted(e.detail)}
+    />
+  </div>
+  <p class="hint">{$t('encryption.searchHint')}</p>
 </div>
 
 <style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -772,6 +772,9 @@ export const SettingKeys = {
   showDateTime: 'show_datetime',
   showPgp: 'show_pgp',
   showAuth: 'show_auth',
+  // lets search see inside encrypted mail, at the cost of writing the decrypted
+  // text into the on-disk index. off by default; toggling rebuilds the index.
+  indexDecrypted: 'search_index_decrypted',
   editorMode: 'editor_mode',
   toastPosition: 'toast_position',
   paneLocked: 'pane_locked',
@@ -878,6 +881,14 @@ export function unlockPGPKey(
   remember: boolean,
 ): Promise<void> {
   return App.UnlockPGPKey(fingerprint, passphrase, remember)
+}
+
+// unlockMessage tries a passphrase against one protected message and, if it
+// opens, holds the passphrase for the rest of the session. It does not offer to
+// store it in the keyring: that needs a specific key to file it under, which
+// the Encryption pane has and a message does not.
+export function unlockMessage(messageId: number, passphrase: string): Promise<void> {
+  return App.UnlockMessage(messageId, passphrase)
 }
 
 // forgetPGPPassphrase drops a passphrase from the session and the keyring.

--- a/frontend/src/lib/demo.ts
+++ b/frontend/src/lib/demo.ts
@@ -187,6 +187,8 @@ export function demoMessage(id: number): MessageDetail {
     bodyPlain: 'Hey, quick one about the potato shipment...',
     bodyHtmlSafe: sharedBodyHtml,
     unsubscribe: null,
+    // the demo mail is not protected, so there is nothing to decrypt.
+    pgpState: '',
     isHtml: true,
     hasRemoteContent: false,
     remoteAllowed: true,

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -485,6 +485,17 @@ const de: Record<string, string> = {
   'detail.attachments.noPreview': 'Keine In-App-Vorschau für diesen Dateityp.',
   'detail.attachments.saveInstead': 'Stattdessen speichern',
   'detail.noSubject': '(kein Betreff)',
+  'detail.pgp.locked.title': 'Diese Nachricht ist verschlüsselt',
+  'detail.pgp.locked.body':
+    'Gib die Passphrase deines Schlüssels ein, um sie zu lesen. Pelton behält sie bis zum Beenden, du wirst in dieser Sitzung nicht noch einmal gefragt.',
+  'detail.pgp.nokey.title': 'Diese Nachricht kann nicht entschlüsselt werden',
+  'detail.pgp.nokey.body':
+    'Sie wurde für einen Schlüssel verschlüsselt, den du nicht importiert hast. Füge den passenden privaten Schlüssel unter Einstellungen, Verschlüsselung hinzu und öffne die Nachricht erneut.',
+  'detail.pgp.failed.title': 'Diese Nachricht konnte nicht gelesen werden',
+  'detail.pgp.failed.body':
+    'Sie gibt an, PGP-geschützt zu sein, aber die Daten sind beschädigt oder in einer Form, die Pelton nicht versteht. Sieh dir den Quelltext an, um sie so zu sehen, wie sie ankam.',
+  'detail.pgp.passphrase': 'Passphrase',
+  'detail.pgp.unlock': 'Entsperren',
   'detail.header.to': 'an',
   'detail.header.cc': 'cc',
   'detail.infoModal.pgp.none': 'Keine PGP-Kennzeichnung',
@@ -1177,6 +1188,11 @@ const de: Record<string, string> = {
   'encryption.signingTitle': 'Signaturschlüssel',
   'encryption.signingHint': 'Mit welchem privaten Schlüssel jedes Konto signiert. Automatisch gleicht Pelton die Kontoadresse mit den vorhandenen Schlüsseln ab.',
   'encryption.signingAuto': 'Nach Adresse zuordnen',
+  'encryption.searchTitle': 'Verschlüsselte Mail durchsuchen',
+  'encryption.searchLabel': 'Suche darf in verschlüsselte Nachrichten sehen',
+  'encryption.searchHint':
+    'Standardmäßig aus. Verschlüsselte Mail ist normalerweise nur über Betreff, Absender und Datum auffindbar, denn ihren Text zu durchsuchen heißt, ihn in den Suchindex zu schreiben, in eine normale Datei auf diesem Rechner. Einschalten baut den Index neu auf; Ausschalten baut ihn erneut auf und entfernt das Geschriebene. Nachrichten mit gesperrtem Schlüssel werden übersprungen.',
+  'encryption.searchRebuilding': 'Suchindex wird im Hintergrund neu aufgebaut',
   'encryption.passphrase.title': 'Privaten Schlüssel entsperren',
   'encryption.passphrase.label': 'Passphrase',
   'encryption.passphrase.remember': 'Diese Passphrase merken',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -485,6 +485,17 @@ const en: Record<string, string> = {
   'detail.attachments.noPreview': 'No in-app preview for this file type.',
   'detail.attachments.saveInstead': 'Save it instead',
   'detail.noSubject': '(no subject)',
+  'detail.pgp.locked.title': 'This message is encrypted',
+  'detail.pgp.locked.body':
+    'Enter the passphrase for your key to read it. Pelton keeps it until you quit, so you will not be asked again this session.',
+  'detail.pgp.nokey.title': 'This message cannot be decrypted',
+  'detail.pgp.nokey.body':
+    'It was encrypted to a key you have not imported. Add the matching private key under Settings, Encryption, and open the message again.',
+  'detail.pgp.failed.title': 'This message could not be read',
+  'detail.pgp.failed.body':
+    'It claims to be PGP protected, but the data is damaged or in a form Pelton does not understand. View the source to see it as it arrived.',
+  'detail.pgp.passphrase': 'Passphrase',
+  'detail.pgp.unlock': 'Unlock',
   'detail.header.to': 'to',
   'detail.header.cc': 'cc',
   'detail.infoModal.pgp.none': 'No PGP markers',
@@ -1177,6 +1188,11 @@ const en: Record<string, string> = {
   'encryption.signingTitle': 'Signing keys',
   'encryption.signingHint': 'Which private key each account signs with. Left automatic, Pelton matches the account address against the keys it has.',
   'encryption.signingAuto': 'Match by address',
+  'encryption.searchTitle': 'Searching encrypted mail',
+  'encryption.searchLabel': 'Let search look inside encrypted messages',
+  'encryption.searchHint':
+    'Off by default. Encrypted mail is normally findable by subject, sender and date only, because searching its text means writing that text into the search index, in a plain file on this computer. Turning this on rebuilds the index; turning it off rebuilds it again and removes what was written. Messages whose key is locked are skipped.',
+  'encryption.searchRebuilding': 'Rebuilding the search index in the background',
   'encryption.passphrase.title': 'Unlock private key',
   'encryption.passphrase.label': 'Passphrase',
   'encryption.passphrase.remember': 'Remember this passphrase',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -485,6 +485,17 @@ const es: Record<string, string> = {
   'detail.attachments.noPreview': 'No hay vista previa en la aplicación para este tipo de archivo.',
   'detail.attachments.saveInstead': 'Guardarlo en su lugar',
   'detail.noSubject': '(sin asunto)',
+  'detail.pgp.locked.title': 'Este mensaje está cifrado',
+  'detail.pgp.locked.body':
+    'Introduce la frase de contraseña de tu clave para leerlo. Pelton la conserva hasta que cierres, así que no volverá a pedírtela en esta sesión.',
+  'detail.pgp.nokey.title': 'Este mensaje no se puede descifrar',
+  'detail.pgp.nokey.body':
+    'Se cifró para una clave que no has importado. Añade la clave privada correspondiente en Ajustes, Cifrado, y vuelve a abrir el mensaje.',
+  'detail.pgp.failed.title': 'No se ha podido leer este mensaje',
+  'detail.pgp.failed.body':
+    'Dice estar protegido con PGP, pero los datos están dañados o en un formato que Pelton no entiende. Consulta el código fuente para verlo tal como llegó.',
+  'detail.pgp.passphrase': 'Frase de contraseña',
+  'detail.pgp.unlock': 'Desbloquear',
   'detail.header.to': 'para',
   'detail.header.cc': 'cc',
   'detail.infoModal.pgp.none': 'Sin marcadores PGP',
@@ -1177,6 +1188,11 @@ const es: Record<string, string> = {
   'encryption.signingTitle': 'Claves de firma',
   'encryption.signingHint': 'Con qué clave privada firma cada cuenta. En automático, Pelton empareja la dirección de la cuenta con las claves que tiene.',
   'encryption.signingAuto': 'Emparejar por dirección',
+  'encryption.searchTitle': 'Buscar en el correo cifrado',
+  'encryption.searchLabel': 'Permitir que la búsqueda mire dentro de los mensajes cifrados',
+  'encryption.searchHint':
+    'Desactivado por defecto. El correo cifrado normalmente solo se encuentra por asunto, remitente y fecha, porque buscar en su texto significa escribir ese texto en el índice de búsqueda, un archivo normal en este equipo. Activarlo reconstruye el índice; desactivarlo lo reconstruye de nuevo y elimina lo escrito. Los mensajes cuya clave está bloqueada se omiten.',
+  'encryption.searchRebuilding': 'Reconstruyendo el índice de búsqueda en segundo plano',
   'encryption.passphrase.title': 'Desbloquear clave privada',
   'encryption.passphrase.label': 'Frase de contraseña',
   'encryption.passphrase.remember': 'Recordar esta frase de contraseña',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -485,6 +485,17 @@ const fr: Record<string, string> = {
   'detail.attachments.noPreview': 'Aucun aperçu disponible dans l\'application pour ce type de fichier.',
   'detail.attachments.saveInstead': 'Enregistre-le à la place',
   'detail.noSubject': '(sans objet)',
+  'detail.pgp.locked.title': 'Ce message est chiffré',
+  'detail.pgp.locked.body':
+    'Saisissez la phrase secrète de votre clé pour le lire. Pelton la conserve jusqu’à la fermeture, elle ne vous sera pas redemandée pendant cette session.',
+  'detail.pgp.nokey.title': 'Ce message ne peut pas être déchiffré',
+  'detail.pgp.nokey.body':
+    'Il a été chiffré pour une clé que vous n’avez pas importée. Ajoutez la clé privée correspondante dans Paramètres, Chiffrement, puis rouvrez le message.',
+  'detail.pgp.failed.title': 'Ce message n’a pas pu être lu',
+  'detail.pgp.failed.body':
+    'Il se présente comme protégé par PGP, mais les données sont endommagées ou dans une forme que Pelton ne comprend pas. Affichez la source pour le voir tel qu’il est arrivé.',
+  'detail.pgp.passphrase': 'Phrase secrète',
+  'detail.pgp.unlock': 'Déverrouiller',
   'detail.header.to': 'à',
   'detail.header.cc': 'cc',
   'detail.infoModal.pgp.none': 'Aucun marqueur PGP',
@@ -1177,6 +1188,11 @@ const fr: Record<string, string> = {
   'encryption.signingTitle': 'Clés de signature',
   'encryption.signingHint': "La clé privée avec laquelle chaque compte signe. En automatique, Pelton fait correspondre l'adresse du compte aux clés disponibles.",
   'encryption.signingAuto': 'Correspondre par adresse',
+  'encryption.searchTitle': 'Rechercher dans le courrier chiffré',
+  'encryption.searchLabel': 'Autoriser la recherche à lire les messages chiffrés',
+  'encryption.searchHint':
+    'Désactivé par défaut. Le courrier chiffré ne se trouve normalement que par objet, expéditeur et date, car rechercher dans son texte revient à écrire ce texte dans l’index de recherche, un simple fichier sur cet ordinateur. L’activer reconstruit l’index ; le désactiver le reconstruit à nouveau et efface ce qui y avait été écrit. Les messages dont la clé est verrouillée sont ignorés.',
+  'encryption.searchRebuilding': 'Reconstruction de l’index de recherche en arrière-plan',
   'encryption.passphrase.title': 'Déverrouiller la clé privée',
   'encryption.passphrase.label': 'Phrase secrète',
   'encryption.passphrase.remember': 'Mémoriser cette phrase secrète',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -485,6 +485,17 @@ const nl: Record<string, string> = {
   'detail.attachments.noPreview': 'Geen voorbeeld beschikbaar in de app voor dit bestandstype.',
   'detail.attachments.saveInstead': 'Sla het in plaats daarvan op',
   'detail.noSubject': '(geen onderwerp)',
+  'detail.pgp.locked.title': 'Dit bericht is versleuteld',
+  'detail.pgp.locked.body':
+    'Voer de wachtwoordzin van je sleutel in om het te lezen. Pelton bewaart die tot je afsluit, dus je wordt deze sessie niet opnieuw gevraagd.',
+  'detail.pgp.nokey.title': 'Dit bericht kan niet ontsleuteld worden',
+  'detail.pgp.nokey.body':
+    'Het is versleuteld voor een sleutel die je niet hebt geïmporteerd. Voeg de bijbehorende privésleutel toe bij Instellingen, Versleuteling en open het bericht opnieuw.',
+  'detail.pgp.failed.title': 'Dit bericht kon niet gelezen worden',
+  'detail.pgp.failed.body':
+    'Het zegt PGP-beveiligd te zijn, maar de gegevens zijn beschadigd of in een vorm die Pelton niet begrijpt. Bekijk de bron om het te zien zoals het aankwam.',
+  'detail.pgp.passphrase': 'Wachtwoordzin',
+  'detail.pgp.unlock': 'Ontgrendelen',
   'detail.header.to': 'aan',
   'detail.header.cc': 'cc',
   'detail.infoModal.pgp.none': 'Geen PGP-markeringen',
@@ -1177,6 +1188,11 @@ const nl: Record<string, string> = {
   'encryption.signingTitle': 'Ondertekeningssleutels',
   'encryption.signingHint': 'Met welke privésleutel elk account ondertekent. Automatisch koppelt Pelton het accountadres aan de aanwezige sleutels.',
   'encryption.signingAuto': 'Op adres koppelen',
+  'encryption.searchTitle': 'Versleutelde post doorzoeken',
+  'encryption.searchLabel': 'Zoeken mag in versleutelde berichten kijken',
+  'encryption.searchHint':
+    'Standaard uit. Versleutelde post is normaal alleen te vinden op onderwerp, afzender en datum, want de tekst doorzoeken betekent die tekst wegschrijven in de zoekindex, een gewoon bestand op deze computer. Aanzetten bouwt de index opnieuw op; uitzetten bouwt hem nogmaals op en verwijdert wat er geschreven was. Berichten met een vergrendelde sleutel worden overgeslagen.',
+  'encryption.searchRebuilding': 'Zoekindex wordt op de achtergrond opnieuw opgebouwd',
   'encryption.passphrase.title': 'Privésleutel ontgrendelen',
   'encryption.passphrase.label': 'Wachtwoordzin',
   'encryption.passphrase.remember': 'Deze wachtwoordzin onthouden',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -485,6 +485,17 @@ const pl: Record<string, string> = {
   'detail.attachments.noPreview': 'Brak podglądu w aplikacji dla tego typu pliku.',
   'detail.attachments.saveInstead': 'Zapisz go zamiast tego',
   'detail.noSubject': '(bez tematu)',
+  'detail.pgp.locked.title': 'Ta wiadomość jest zaszyfrowana',
+  'detail.pgp.locked.body':
+    'Podaj hasło do swojego klucza, aby ją przeczytać. Pelton zachowa je do zamknięcia programu, więc w tej sesji nie zapyta ponownie.',
+  'detail.pgp.nokey.title': 'Nie można odszyfrować tej wiadomości',
+  'detail.pgp.nokey.body':
+    'Zaszyfrowano ją dla klucza, którego nie zaimportowano. Dodaj odpowiedni klucz prywatny w Ustawieniach, Szyfrowanie, i otwórz wiadomość ponownie.',
+  'detail.pgp.failed.title': 'Nie udało się odczytać tej wiadomości',
+  'detail.pgp.failed.body':
+    'Deklaruje ochronę PGP, ale dane są uszkodzone lub w formie, której Pelton nie rozumie. Zobacz źródło, aby obejrzeć ją w postaci, w jakiej dotarła.',
+  'detail.pgp.passphrase': 'Hasło',
+  'detail.pgp.unlock': 'Odblokuj',
   'detail.header.to': 'do',
   'detail.header.cc': 'DW',
   'detail.infoModal.pgp.none': 'Brak znaczników PGP',
@@ -1177,6 +1188,11 @@ const pl: Record<string, string> = {
   'encryption.signingTitle': 'Klucze podpisujące',
   'encryption.signingHint': 'Którym kluczem prywatnym podpisuje każde konto. W trybie automatycznym Pelton dopasowuje adres konta do posiadanych kluczy.',
   'encryption.signingAuto': 'Dopasuj po adresie',
+  'encryption.searchTitle': 'Przeszukiwanie zaszyfrowanej poczty',
+  'encryption.searchLabel': 'Pozwól wyszukiwaniu zaglądać do zaszyfrowanych wiadomości',
+  'encryption.searchHint':
+    'Domyślnie wyłączone. Zaszyfrowaną pocztę można zwykle znaleźć tylko po temacie, nadawcy i dacie, bo przeszukiwanie jej treści oznacza zapisanie tej treści w indeksie wyszukiwania, w zwykłym pliku na tym komputerze. Włączenie przebudowuje indeks; wyłączenie przebudowuje go ponownie i usuwa to, co zapisano. Wiadomości z zablokowanym kluczem są pomijane.',
+  'encryption.searchRebuilding': 'Przebudowa indeksu wyszukiwania w tle',
   'encryption.passphrase.title': 'Odblokuj klucz prywatny',
   'encryption.passphrase.label': 'Hasło klucza',
   'encryption.passphrase.remember': 'Zapamiętaj to hasło',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -107,7 +107,13 @@ export interface MessageDetail extends MessageSummary {
   // account's smtp) or link (opened in the browser). null when none is on
   // record; the ui may still fall back to an unsubscribe link in the body.
   unsubscribe: UnsubscribeInfo | null
+  // pgpState is '' for ordinary mail. for protected mail it says what happened
+  // when it was opened, so the pane can offer the right next step rather than
+  // one generic error.
+  pgpState: PGPState
 }
+
+export type PGPState = '' | 'open' | 'locked' | 'nokey' | 'failed'
 
 export interface UnsubscribeInfo {
   kind: 'oneclick' | 'mailto' | 'link'

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -264,6 +264,8 @@ export function UnarchiveMessage(arg1:string,arg2:number):Promise<void>;
 
 export function UndoDelete(arg1:number):Promise<void>;
 
+export function UnlockMessage(arg1:number,arg2:string):Promise<void>;
+
 export function UnlockPGPKey(arg1:string,arg2:string,arg3:boolean):Promise<void>;
 
 export function UnmarkSenderVIP(arg1:number):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -526,6 +526,10 @@ export function UndoDelete(arg1) {
   return window['go']['desktop']['App']['UndoDelete'](arg1);
 }
 
+export function UnlockMessage(arg1, arg2) {
+  return window['go']['desktop']['App']['UnlockMessage'](arg1, arg2);
+}
+
 export function UnlockPGPKey(arg1, arg2, arg3) {
   return window['go']['desktop']['App']['UnlockPGPKey'](arg1, arg2, arg3);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -582,6 +582,26 @@ export namespace desktop {
 	        this.done = source["done"];
 	    }
 	}
+	export class SMIMEDTO {
+	    status: string;
+	    signer: string;
+	    email: string;
+	    issuer: string;
+	    detail: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SMIMEDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.status = source["status"];
+	        this.signer = source["signer"];
+	        this.email = source["email"];
+	        this.issuer = source["issuer"];
+	        this.detail = source["detail"];
+	    }
+	}
 	export class MessageDetailDTO {
 	    id: number;
 	    accountId: number;
@@ -612,6 +632,7 @@ export namespace desktop {
 	    remoteAllowed: boolean;
 	    remoteHosts: string[];
 	    attachments: AttachmentDTO[];
+	    pgpState: string;
 	    unsubscribe?: UnsubscribeDTO;
 	
 	    static createFrom(source: any = {}) {
@@ -649,6 +670,7 @@ export namespace desktop {
 	        this.remoteAllowed = source["remoteAllowed"];
 	        this.remoteHosts = source["remoteHosts"];
 	        this.attachments = this.convertValues(source["attachments"], AttachmentDTO);
+	        this.pgpState = source["pgpState"];
 	        this.unsubscribe = this.convertValues(source["unsubscribe"], UnsubscribeDTO);
 	    }
 	
@@ -719,7 +741,7 @@ export namespace desktop {
 	        this.senderVip = source["senderVip"];
 	        this.smime = this.convertValues(source["smime"], SMIMEDTO);
 	    }
-
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -923,26 +945,7 @@ export namespace desktop {
 	        this.hasPassword = source["hasPassword"];
 	    }
 	}
-	export class SMIMEDTO {
-	    status: string;
-	    signer: string;
-	    email: string;
-	    issuer: string;
-	    detail: string;
-
-	    static createFrom(source: any = {}) {
-	        return new SMIMEDTO(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.status = source["status"];
-	        this.signer = source["signer"];
-	        this.email = source["email"];
-	        this.issuer = source["issuer"];
-	        this.detail = source["detail"];
-	    }
-	}
+	
 	export class SaveThemeRequest {
 	    id: string;
 	    name: string;

--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -65,6 +65,29 @@ func (s *PGPKeyStore) SenderKey(email string) (*openpgp.Entity, error) {
 	return ent, nil
 }
 
+// PrivateKeys returns every private key in the store. Decryption needs all of
+// them rather than one looked up by address: a message names the key it was
+// encrypted to by key id, and that key may belong to any of the user's
+// identities, including an address the message was never sent to directly.
+func (s *PGPKeyStore) PrivateKeys() (openpgp.EntityList, error) {
+	return s.load(secringFile)
+}
+
+// PublicKeys returns every key that can check a signature: the public keyring,
+// plus the public halves of the user's own private keys so mail they signed
+// themselves still verifies.
+func (s *PGPKeyStore) PublicKeys() (openpgp.EntityList, error) {
+	pub, err := s.load(pubringFile)
+	if err != nil {
+		return nil, err
+	}
+	sec, err := s.load(secringFile)
+	if err != nil {
+		return nil, err
+	}
+	return append(pub, sec...), nil
+}
+
 // load reads and parses one armored keyring file. A missing file is reported as
 // an empty keyring so lookups fall through to the not-found errors with a clear
 // message rather than a confusing open error.

--- a/internal/crypto/open.go
+++ b/internal/crypto/open.go
@@ -1,0 +1,319 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	pgperrors "github.com/ProtonMail/go-crypto/openpgp/errors"
+)
+
+// Opening a received message is the mirror of Wrap, and the safety rule runs the
+// other way: a message that cannot be decrypted or whose signature does not
+// check out must never be presented as though it were fine. Every failure is
+// reported, and the caller shows the protected form rather than pretending.
+
+var (
+	// ErrNotProtected means the message carries no OpenPGP content to open.
+	ErrNotProtected = errors.New("crypto: message is not pgp protected")
+	// ErrNoDecryptionKey means none of the stored private keys can open the
+	// message: it was encrypted to somebody else, or to a key not imported yet.
+	ErrNoDecryptionKey = errors.New("crypto: no private key can decrypt this message")
+	// ErrMalformedArmor means the pgp block could not be read at all.
+	ErrMalformedArmor = errors.New("crypto: the pgp data is malformed")
+	// ErrWrongPassphrase means a private key was found but the passphrase given
+	// does not unlock it.
+	ErrWrongPassphrase = errors.New("crypto: the passphrase does not unlock the key")
+)
+
+// Opened is a received message after decryption and signature checking.
+type Opened struct {
+	// Body is the decrypted MIME entity for encrypted mail, the signed content
+	// for signed mail, or the plain text of a clearsigned block. It is never
+	// written to disk by this package.
+	Body []byte
+	// Encrypted records that Body had to be decrypted to be read, which decides
+	// whether the caller may cache it.
+	Encrypted bool
+	// Signature is the verdict on any signature found. A message may be
+	// encrypted without being signed, in which case Status is SigNone.
+	Signature Signature
+}
+
+// IsProtected reports whether a raw message carries OpenPGP content worth
+// keeping the source for. It is a cheap structural check run over every synced
+// message, so it looks at the content type and the armor headers rather than
+// attempting to parse anything.
+func IsProtected(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	headers, body, found := splitHeaders(raw)
+	if !found {
+		return false
+	}
+	mediaType, params := parseContentType(headers)
+	switch {
+	case mediaType == "multipart/encrypted" &&
+		strings.EqualFold(params["protocol"], "application/pgp-encrypted"):
+		return true
+	case mediaType == "multipart/signed" &&
+		strings.EqualFold(params["protocol"], "application/pgp-signature"):
+		return true
+	}
+	return bytes.Contains(body, []byte("-----BEGIN PGP MESSAGE-----")) ||
+		bytes.Contains(body, []byte("-----BEGIN PGP SIGNED MESSAGE-----"))
+}
+
+// Open decrypts and verifies a received message.
+//
+// raw is the complete RFC 822 message. passphrase unlocks a private key when
+// one is needed and may be nil for mail that is only signed. The four shapes
+// real mail uses are all handled: PGP/MIME encrypted and signed (RFC 3156), and
+// the inline armored and clearsigned forms that predate it and are still
+// common.
+func (p *PGP) Open(raw []byte, passphrase []byte) (*Opened, error) {
+	headers, body, found := splitHeaders(raw)
+	if !found {
+		return nil, ErrNotProtected
+	}
+	mediaType, params := parseContentType(headers)
+
+	switch {
+	case mediaType == "multipart/encrypted" &&
+		strings.EqualFold(params["protocol"], "application/pgp-encrypted"):
+		return p.openMIMEEncrypted(body, params["boundary"], passphrase)
+	case mediaType == "multipart/signed" &&
+		strings.EqualFold(params["protocol"], "application/pgp-signature"):
+		return p.openMIMESigned(body, params["boundary"])
+	}
+	return p.openInline(headers, body, passphrase)
+}
+
+// openMIMEEncrypted reads an RFC 3156 multipart/encrypted message. The first
+// part is the version marker, which carries nothing worth checking beyond its
+// presence; the second holds the armored ciphertext.
+func (p *PGP) openMIMEEncrypted(body []byte, boundary string, passphrase []byte) (*Opened, error) {
+	if boundary == "" {
+		return nil, ErrMalformedArmor
+	}
+	sections := splitOnBoundary(body, []byte("--"+boundary))
+	if len(sections) < 2 {
+		return nil, ErrMalformedArmor
+	}
+	_, ciphertext, ok := splitHeaders(sections[1])
+	if !ok {
+		return nil, ErrMalformedArmor
+	}
+	return p.decrypt(ciphertext, passphrase)
+}
+
+// openMIMESigned reads an RFC 3156 multipart/signed message. The signed part is
+// taken verbatim: the signature covers the bytes as transmitted, so parsing and
+// rebuilding the part would invalidate a signature that is perfectly good.
+func (p *PGP) openMIMESigned(body []byte, boundary string) (*Opened, error) {
+	if boundary == "" {
+		return nil, ErrMalformedArmor
+	}
+	sections := splitOnBoundary(body, []byte("--"+boundary))
+	if len(sections) < 2 {
+		return nil, ErrMalformedArmor
+	}
+	signed := sections[0]
+	_, sigArmor, ok := splitHeaders(sections[1])
+	if !ok {
+		return nil, ErrMalformedArmor
+	}
+	return &Opened{Body: signed, Signature: p.checkDetached(signed, sigArmor)}, nil
+}
+
+// openInline handles the pre-MIME forms: an armored message or a clearsigned
+// block sitting in an ordinary text body.
+func (p *PGP) openInline(headers, body []byte, passphrase []byte) (*Opened, error) {
+	text, err := decodeBody(headers, body)
+	if err != nil {
+		text = body
+	}
+	switch {
+	case bytes.Contains(text, []byte("-----BEGIN PGP MESSAGE-----")):
+		return p.decrypt(text, passphrase)
+	case bytes.Contains(text, []byte("-----BEGIN PGP SIGNED MESSAGE-----")):
+		return p.openClearsigned(text)
+	}
+	return nil, ErrNotProtected
+}
+
+// openClearsigned verifies an inline clearsigned block and returns the text it
+// covers, with the armor removed.
+func (p *PGP) openClearsigned(text []byte) (*Opened, error) {
+	block, _ := clearsign.Decode(text)
+	if block == nil {
+		return nil, ErrMalformedArmor
+	}
+	keyring, err := p.keys.PublicKeys()
+	if err != nil {
+		return nil, err
+	}
+	opened := &Opened{Body: block.Bytes}
+	if len(keyring) == 0 {
+		opened.Signature = unknownSigner()
+		return opened, nil
+	}
+	signer, err := openpgp.CheckDetachedSignature(
+		keyring, bytes.NewReader(block.Bytes), block.ArmoredSignature.Body, cryptoConfig())
+	opened.Signature = signatureVerdict(signer, err)
+	return opened, nil
+}
+
+// decrypt opens an armored OpenPGP message with whichever stored private key it
+// was encrypted to, reporting any signature carried inside it.
+func (p *PGP) decrypt(ciphertext, passphrase []byte) (*Opened, error) {
+	private, err := p.keys.PrivateKeys()
+	if err != nil {
+		return nil, err
+	}
+	if len(private) == 0 {
+		return nil, ErrNoDecryptionKey
+	}
+	// a signature inside an encrypted message is checked against the public
+	// keyring, so both rings go to the reader.
+	public, err := p.keys.PublicKeys()
+	if err != nil {
+		return nil, err
+	}
+	keyring := append(openpgp.EntityList{}, private...)
+	keyring = append(keyring, public...)
+
+	block, err := armor.Decode(bytes.NewReader(ciphertext))
+	if err != nil {
+		return nil, ErrMalformedArmor
+	}
+
+	// prompt is called once per candidate key. Returning an error rather than
+	// nil on the second call stops go-crypto retrying the same wrong passphrase
+	// against every key in the ring.
+	var asked bool
+	prompt := func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
+		if asked || len(passphrase) == 0 {
+			return nil, ErrPassphraseRequired
+		}
+		asked = true
+		return passphrase, nil
+	}
+
+	md, err := openpgp.ReadMessage(block.Body, keyring, prompt, cryptoConfig())
+	if err != nil {
+		return nil, decryptError(err)
+	}
+	plaintext, err := io.ReadAll(md.UnverifiedBody)
+	if err != nil {
+		return nil, decryptError(err)
+	}
+	// the signature state is only final once the body has been read to the end,
+	// which is why this is checked here rather than off md alone.
+	opened := &Opened{Body: plaintext, Encrypted: true}
+	switch {
+	case !md.IsSigned:
+		// encrypted but unsigned: confidential, with nothing establishing who
+		// wrote it.
+	case md.SignedBy == nil:
+		opened.Signature = unknownSigner()
+	default:
+		opened.Signature = signatureVerdict(md.SignedBy.Entity, md.SignatureError)
+	}
+	return opened, nil
+}
+
+// checkDetached verifies an armored detached signature over content.
+func (p *PGP) checkDetached(content, sigArmor []byte) Signature {
+	keyring, err := p.keys.PublicKeys()
+	if err != nil || len(keyring) == 0 {
+		return unknownSigner()
+	}
+	signer, err := openpgp.CheckArmoredDetachedSignature(
+		keyring, bytes.NewReader(content), bytes.NewReader(sigArmor), cryptoConfig())
+	if err == nil {
+		return signatureVerdict(signer, nil)
+	}
+	// mail that passed through something that rewrote its line endings would
+	// otherwise be reported as altered, so the canonical form gets a second try.
+	canonical := toCRLF(content)
+	if !bytes.Equal(canonical, content) {
+		if signer, retry := openpgp.CheckArmoredDetachedSignature(
+			keyring, bytes.NewReader(canonical), bytes.NewReader(sigArmor), cryptoConfig()); retry == nil {
+			return signatureVerdict(signer, nil)
+		}
+	}
+	return signatureVerdict(nil, err)
+}
+
+// signatureVerdict turns a verification outcome into the same three-state
+// verdict S/MIME reports, so the reading pane has one way to describe a
+// signature whatever produced it.
+func signatureVerdict(signer *openpgp.Entity, err error) Signature {
+	if err != nil {
+		if isUnknownIssuer(err) {
+			return unknownSigner()
+		}
+		return Signature{Status: SigInvalid, Detail: "the message was altered after it was signed"}
+	}
+	if signer == nil {
+		return unknownSigner()
+	}
+	name, email := identityOf(signer)
+	return Signature{
+		Status:      SigValid,
+		SignerName:  name,
+		SignerEmail: email,
+		Fingerprint: Fingerprint(signer),
+	}
+}
+
+// unknownSigner is the verdict for a signature made by a key that is not in the
+// keyring. The content may be untouched, but with no key there is no way to
+// establish that, so it is reported as unverified rather than good or bad.
+func unknownSigner() Signature {
+	return Signature{
+		Status: SigUntrusted,
+		Detail: "the signing key is not in your keyring, so the signature cannot be checked",
+	}
+}
+
+// isUnknownIssuer reports whether a verification failure was caused by a
+// missing key rather than by the content not matching.
+func isUnknownIssuer(err error) bool {
+	return errors.Is(err, pgperrors.ErrUnknownIssuer) ||
+		strings.Contains(err.Error(), "unknown issuer")
+}
+
+// identityOf reads a display name and address out of a key's primary user id.
+func identityOf(ent *openpgp.Entity) (name, email string) {
+	for _, id := range ent.Identities {
+		if id.UserId == nil {
+			continue
+		}
+		if email == "" && id.UserId.Email != "" {
+			name, email = id.UserId.Name, id.UserId.Email
+		}
+	}
+	return name, email
+}
+
+// decryptError maps a go-crypto failure onto the sentinel a caller can act on.
+func decryptError(err error) error {
+	switch {
+	case errors.Is(err, ErrPassphraseRequired):
+		return ErrPassphraseRequired
+	case errors.Is(err, pgperrors.ErrKeyIncorrect):
+		return ErrWrongPassphrase
+	case strings.Contains(err.Error(), "no suitable key"),
+		strings.Contains(err.Error(), "cannot decrypt"):
+		return ErrNoDecryptionKey
+	}
+	return fmt.Errorf("crypto: decrypt: %w", err)
+}

--- a/internal/crypto/open_test.go
+++ b/internal/crypto/open_test.go
@@ -1,0 +1,253 @@
+package crypto
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+// newOpenTestPGP builds an engine over a keyring holding pub and priv.
+func newOpenTestPGP(t *testing.T, pub, priv []*openpgp.Entity) *PGP {
+	t.Helper()
+	dir := t.TempDir()
+	writeKeyrings(t, dir, pub, priv)
+	return NewPGP(NewPGPKeyStore(dir))
+}
+
+// message wraps a crypto Part into the full RFC 822 message Open expects.
+func message(from string, part *Part) []byte {
+	return []byte("From: " + from + "\r\n" +
+		"Subject: test\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: " + part.ContentType + "\r\n" +
+		"\r\n" + string(part.Body))
+}
+
+// Anything Pelton can produce, Pelton must be able to read back.
+func TestOpenEncryptedRoundTrip(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+
+	part, err := p.Wrap([]byte(sampleEntity), ModeEncrypt, Options{
+		SenderEmail: "alice@example.test",
+		Recipients:  []string{"alice@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	opened, err := p.Open(message("alice@example.test", part), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !opened.Encrypted {
+		t.Error("Encrypted = false, want true")
+	}
+	if !strings.Contains(string(opened.Body), plaintextMarker) {
+		t.Errorf("decrypted body does not contain the plaintext: %q", opened.Body)
+	}
+}
+
+func TestOpenSignedRoundTrip(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+
+	part, err := p.Wrap([]byte(sampleEntity), ModeSign, Options{SenderEmail: "alice@example.test"})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	opened, err := p.Open(message("alice@example.test", part), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if opened.Encrypted {
+		t.Error("Encrypted = true for a signed-only message")
+	}
+	if opened.Signature.Status != SigValid {
+		t.Fatalf("Status = %q (%s), want %q", opened.Signature.Status, opened.Signature.Detail, SigValid)
+	}
+	if opened.Signature.SignerEmail != "alice@example.test" {
+		t.Errorf("SignerEmail = %q", opened.Signature.SignerEmail)
+	}
+	if opened.Signature.Fingerprint == "" {
+		t.Error("Fingerprint is empty, the ui needs it to identify the key")
+	}
+	if !strings.Contains(string(opened.Body), plaintextMarker) {
+		t.Errorf("signed body missing: %q", opened.Body)
+	}
+}
+
+// A signature riding inside an encrypted message must still be reported.
+func TestOpenSignedAndEncrypted(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+
+	part, err := p.Wrap([]byte(sampleEntity), ModeSignEncrypt, Options{
+		SenderEmail: "alice@example.test",
+		Recipients:  []string{"alice@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("sign+encrypt: %v", err)
+	}
+
+	opened, err := p.Open(message("alice@example.test", part), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !opened.Encrypted {
+		t.Error("Encrypted = false, want true")
+	}
+	if opened.Signature.Status != SigValid {
+		t.Errorf("Status = %q (%s), want %q", opened.Signature.Status, opened.Signature.Detail, SigValid)
+	}
+}
+
+// Mail encrypted to somebody else must fail plainly rather than half-open.
+func TestOpenWithNoDecryptionKey(t *testing.T) {
+	bob := newTestEntity(t, "bob@example.test")
+	sender := newOpenTestPGP(t, []*openpgp.Entity{bob}, []*openpgp.Entity{bob})
+	part, err := sender.Wrap([]byte(sampleEntity), ModeEncrypt, Options{
+		SenderEmail: "bob@example.test",
+		Recipients:  []string{"bob@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// a store holding no private keys at all.
+	reader := newOpenTestPGP(t, nil, nil)
+	if _, err := reader.Open(message("bob@example.test", part), nil); !errors.Is(err, ErrNoDecryptionKey) {
+		t.Errorf("Open() = %v, want ErrNoDecryptionKey", err)
+	}
+}
+
+// A signature from a key we do not hold is unverified, which is neither good
+// nor bad and must not be reported as either.
+func TestOpenSignedByUnknownKey(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	signer := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+	part, err := signer.Wrap([]byte(sampleEntity), ModeSign, Options{SenderEmail: "alice@example.test"})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// a reader who has never imported alice's key.
+	stranger := newTestEntity(t, "carol@example.test")
+	reader := newOpenTestPGP(t, []*openpgp.Entity{stranger}, []*openpgp.Entity{stranger})
+
+	opened, err := reader.Open(message("alice@example.test", part), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if opened.Signature.Status != SigUntrusted {
+		t.Fatalf("Status = %q, want %q", opened.Signature.Status, SigUntrusted)
+	}
+	if !strings.Contains(opened.Signature.Detail, "keyring") {
+		t.Errorf("Detail = %q, want it to say the key is missing", opened.Signature.Detail)
+	}
+}
+
+// The point of a signature: altering the signed part has to be caught.
+func TestOpenDetectsTamperedSignedContent(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+
+	part, err := p.Wrap([]byte(sampleEntity), ModeSign, Options{SenderEmail: "alice@example.test"})
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw := message("alice@example.test", part)
+	tampered := strings.Replace(string(raw), "eagle", "seagull", 1)
+	if tampered == string(raw) {
+		t.Fatal("the test did not alter anything")
+	}
+
+	opened, err := p.Open([]byte(tampered), nil)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if opened.Signature.Status != SigInvalid {
+		t.Errorf("Status = %q (%s), want %q", opened.Signature.Status, opened.Signature.Detail, SigInvalid)
+	}
+}
+
+// A locked key must ask for the passphrase rather than failing obscurely, so
+// the reading pane knows to prompt.
+func TestOpenLockedKeyAsksForPassphrase(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+	part, err := p.Wrap([]byte(sampleEntity), ModeEncrypt, Options{
+		SenderEmail: "alice@example.test",
+		Recipients:  []string{"alice@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	raw := message("alice@example.test", part)
+
+	locked := newTestEntity(t, "alice@example.test")
+	*locked = *alice
+	lockEntity(t, locked, []byte("correct horse"))
+	reader := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{locked})
+
+	if _, err := reader.Open(raw, nil); !errors.Is(err, ErrPassphraseRequired) {
+		t.Errorf("Open() with no passphrase = %v, want ErrPassphraseRequired", err)
+	}
+	if _, err := reader.Open(raw, []byte("wrong")); err == nil {
+		t.Error("Open() with the wrong passphrase succeeded")
+	}
+}
+
+func TestOpenUnprotectedMessage(t *testing.T) {
+	p := newOpenTestPGP(t, nil, nil)
+	raw := []byte("From: bob@example.test\r\nContent-Type: text/plain\r\n\r\nnothing to see\r\n")
+	if _, err := p.Open(raw, nil); !errors.Is(err, ErrNotProtected) {
+		t.Errorf("Open() = %v, want ErrNotProtected", err)
+	}
+}
+
+// Malformed input must be refused, never rendered as though it were fine.
+func TestOpenRejectsMalformedInput(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+
+	for _, tt := range []struct {
+		name string
+		raw  string
+	}{
+		{"empty", ""},
+		{"encrypted with no boundary", "Content-Type: multipart/encrypted; protocol=\"application/pgp-encrypted\"\r\n\r\nbody"},
+		{"signed with no parts", "Content-Type: multipart/signed; protocol=\"application/pgp-signature\"; boundary=\"x\"\r\n\r\nnothing"},
+		{"armor header but no block", "Content-Type: text/plain\r\n\r\n-----BEGIN PGP MESSAGE-----\r\nnot armor\r\n"},
+		{"clearsign header but no block", "Content-Type: text/plain\r\n\r\n-----BEGIN PGP SIGNED MESSAGE-----\r\ntruncated\r\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opened, err := p.Open([]byte(tt.raw), nil)
+			if err == nil && opened != nil && opened.Signature.Status == SigValid {
+				t.Error("malformed input reported a valid signature")
+			}
+		})
+	}
+}
+
+// lockEntity encrypts an entity's private key material so it needs a
+// passphrase, the state a key imported from gpg normally arrives in.
+func lockEntity(t *testing.T, ent *openpgp.Entity, passphrase []byte) {
+	t.Helper()
+	if ent.PrivateKey != nil {
+		if err := ent.PrivateKey.Encrypt(passphrase); err != nil {
+			t.Fatalf("lock primary key: %v", err)
+		}
+	}
+	for _, sub := range ent.Subkeys {
+		if sub.PrivateKey == nil {
+			continue
+		}
+		if err := sub.PrivateKey.Encrypt(passphrase); err != nil {
+			t.Fatalf("lock subkey: %v", err)
+		}
+	}
+}

--- a/internal/crypto/smime.go
+++ b/internal/crypto/smime.go
@@ -69,11 +69,14 @@ const (
 // safe to show: it is read out of the certificate, never invented.
 type Signature struct {
 	Status SignatureStatus
-	// SignerName is the certificate's common name, SignerEmail the address it
-	// was issued to, and Issuer the common name of the CA that issued it.
+	// SignerName is the display name the signature vouches for and SignerEmail
+	// the address. Issuer is the CA's common name for S/MIME and empty for PGP,
+	// which has no issuing authority; Fingerprint is the signing key's
+	// fingerprint for PGP and empty for S/MIME.
 	SignerName  string
 	SignerEmail string
 	Issuer      string
+	Fingerprint string
 	// Expires is when the signing certificate stops being valid.
 	Expires time.Time
 	// Detail explains a non-valid status in one sentence, for a tooltip. Empty

--- a/internal/desktop/bind_messages.go
+++ b/internal/desktop/bind_messages.go
@@ -113,6 +113,27 @@ func (a *App) GetMessage(id int64) (MessageDetailDTO, error) {
 		Unsubscribe:       a.unsubscribeInfo(m),
 	}
 	detail.BodyHTMLSafe = a.renderHTML(m.BodyHTML, atts, autoAllow)
+
+	// protected mail is decrypted here and only here: the plaintext replaces the
+	// armor for this response and is never written back. The stored body stays
+	// the ciphertext, so closing the message loses nothing that was not sent.
+	if body, isHTML, state, sig := a.openProtected(*m); state != "" {
+		detail.PGPState = state
+		detail.SMIME = smimeDTO(sig)
+		if state == pgpStateOpen {
+			if isHTML {
+				detail.IsHTML = true
+				detail.BodyPlain = ""
+				detail.BodyHTMLSafe = a.renderHTML(body, atts, autoAllow)
+				detail.HasRemoteContent = mailview.HasRemoteContent(body)
+				detail.RemoteHosts = mailview.RemoteHosts(body)
+			} else {
+				detail.IsHTML = false
+				detail.BodyPlain = body
+				detail.BodyHTMLSafe = ""
+			}
+		}
+	}
 	return detail, nil
 }
 

--- a/internal/desktop/bind_pgp_open.go
+++ b/internal/desktop/bind_pgp_open.go
@@ -1,0 +1,138 @@
+package desktop
+
+import (
+	"errors"
+
+	"github.com/TRC-Loop/Pelton/internal/crypto"
+	"github.com/TRC-Loop/Pelton/internal/mailview"
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+// Reading protected mail (#193). The ciphertext is kept by the sync layer and
+// decrypted here, in memory, every time a message is opened. Plaintext is never
+// written back to the database: caching it would undo the encryption it was
+// sent with.
+//
+// Verification runs on every open rather than once at sync, because the keyring
+// is local and changes. Import a correspondent's key today and yesterday's mail
+// from them starts verifying immediately, with nothing to re-sync.
+
+// protectedState describes why a protected message is not being shown as
+// plaintext, so the reading pane can offer the right next step instead of a
+// generic error.
+const (
+	// pgpStateOpen means the message was decrypted and is being shown.
+	pgpStateOpen = "open"
+	// pgpStateLocked means a key that can open it is present but locked, so the
+	// ui should ask for the passphrase.
+	pgpStateLocked = "locked"
+	// pgpStateNoKey means no imported private key can open it.
+	pgpStateNoKey = "nokey"
+	// pgpStateFailed means the pgp data could not be read at all.
+	pgpStateFailed = "failed"
+)
+
+// openProtected decrypts and verifies a stored protected message. It returns
+// the zero value for mail that is not protected, which is nearly all of it, so
+// the caller can apply it unconditionally.
+func (a *App) openProtected(m storage.Message) (body string, isHTML bool, state string, sig crypto.Signature) {
+	raw, err := a.store.MessagePGPSource(a.ctx, m.ID)
+	if err != nil {
+		// not protected, or cached before the source was kept.
+		return "", false, "", crypto.Signature{}
+	}
+	keys, err := a.keyStore()
+	if err != nil {
+		return "", false, pgpStateFailed, crypto.Signature{}
+	}
+
+	engine := crypto.NewPGP(keys)
+	opened, err := engine.Open(raw, a.anyPassphrase())
+	if err != nil {
+		return "", false, openFailureState(err), crypto.Signature{}
+	}
+
+	plain, html := splitOpenedBody(opened.Body)
+	if html != "" {
+		return html, true, pgpStateOpen, opened.Signature
+	}
+	return plain, false, pgpStateOpen, opened.Signature
+}
+
+// openFailureState maps a decryption failure to the state the ui acts on.
+func openFailureState(err error) string {
+	switch {
+	case errors.Is(err, crypto.ErrPassphraseRequired), errors.Is(err, crypto.ErrWrongPassphrase):
+		return pgpStateLocked
+	case errors.Is(err, crypto.ErrNoDecryptionKey), errors.Is(err, crypto.ErrSenderKeyNotFound):
+		return pgpStateNoKey
+	case errors.Is(err, crypto.ErrNotProtected):
+		return ""
+	}
+	return pgpStateFailed
+}
+
+// anyPassphrase returns a remembered passphrase to try. A message names the key
+// it was encrypted to by key id rather than by address, so there is nothing to
+// look up by: whichever keys the user has unlocked this session are the
+// candidates, and go-crypto stops at the first that works.
+//
+// Returning one passphrase rather than all of them is deliberate. Trying every
+// remembered passphrase against every key would turn a locked message into a
+// silent search across the user's keys, and the common case is a single key.
+func (a *App) anyPassphrase() []byte {
+	passphraseMu.Lock()
+	defer passphraseMu.Unlock()
+	for _, p := range passphrases {
+		return p
+	}
+	return nil
+}
+
+// splitOpenedBody separates the decrypted MIME entity into its text and html
+// parts. The decrypted payload is a MIME entity in its own right, so it is
+// parsed the same way any body would be rather than shown as raw source.
+func splitOpenedBody(entity []byte) (plain, html string) {
+	msg, err := mailview.ParseEntity(entity)
+	if err != nil {
+		// not a MIME entity: a clearsigned block is plain text as it stands.
+		return string(entity), ""
+	}
+	return msg.Text, msg.HTML
+}
+
+// sessionPassphraseKey labels a passphrase entered to read a message. A message
+// names the key it was encrypted to by key id, not by fingerprint, so there is
+// no fingerprint to file it under; this slot keeps it usable for the rest of
+// the session without pretending to know which key it belongs to.
+const sessionPassphraseKey = "reading-pane-session"
+
+// UnlockMessage tries a passphrase against a protected message and, if it
+// opens, holds the passphrase for the rest of the session so the reader is not
+// asked again for every message.
+//
+// It deliberately does not offer to store the passphrase in the os keyring.
+// Doing that needs a specific key to file it under, which the Encryption pane
+// has and a message does not, and silently persisting a passphrase in answer to
+// a prompt about reading one message would be a larger commitment than the
+// prompt asked for.
+func (a *App) UnlockMessage(messageID int64, passphrase string) error {
+	if err := a.ready(); err != nil {
+		return err
+	}
+	raw, err := a.store.MessagePGPSource(a.ctx, messageID)
+	if err != nil {
+		return err
+	}
+	keys, err := a.keyStore()
+	if err != nil {
+		return err
+	}
+	if _, err := crypto.NewPGP(keys).Open(raw, []byte(passphrase)); err != nil {
+		return err
+	}
+	passphraseMu.Lock()
+	passphrases[sessionPassphraseKey] = []byte(passphrase)
+	passphraseMu.Unlock()
+	return nil
+}

--- a/internal/desktop/bind_search.go
+++ b/internal/desktop/bind_search.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -93,7 +94,9 @@ func (a *App) indexNewMessages() error {
 
 		docs := make([]search.Doc, 0, len(msgs))
 		for _, m := range msgs {
-			docs = append(docs, toSearchDoc(m))
+			doc := toSearchDoc(m)
+			doc.Body = a.searchBody(m)
+			docs = append(docs, doc)
 			if m.ID > watermark {
 				watermark = m.ID
 			}
@@ -124,6 +127,62 @@ func (a *App) searchWatermark() int64 {
 
 // toSearchDoc projects a stored message into the search document. The sender name
 // and address are combined so a search for either finds the mail.
+// rebuildSearchIndex discards the index and builds it again from the cache.
+// Used when what gets indexed changes in a way that overwriting documents would
+// not undo, which is the case for decrypted text: a plaintext already written
+// has to actually leave the index, not merely stop being added.
+func (a *App) rebuildSearchIndex() {
+	if a.index == nil {
+		return
+	}
+	a.searchMu.Lock()
+	if err := a.index.Close(); err != nil {
+		a.log.Error("close search index for rebuild", "err", err)
+	}
+	path := filepath.Join(a.dataDir, indexFileName)
+	if err := os.RemoveAll(path); err != nil {
+		a.log.Error("remove search index for rebuild", "err", err)
+	}
+	idx, err := search.Open(path)
+	if err != nil {
+		a.log.Error("reopen search index after rebuild", "err", err)
+		a.searchMu.Unlock()
+		return
+	}
+	a.index = idx
+	if err := a.store.Set(a.ctx, settingSearchWatermark, "0"); err != nil {
+		a.log.Error("rewind search watermark for rebuild", "err", err)
+	}
+	a.searchMu.Unlock()
+
+	if err := a.indexNewMessages(); err != nil {
+		a.log.Error("rebuild search index", "err", err)
+	}
+}
+
+// searchBody returns the text search should index for a message. Encrypted mail
+// is indexed by its armor, which finds nothing, unless the user has opted in to
+// indexing the decrypted text and the key is available to produce it.
+//
+// A locked key means the message is indexed unopened. Nothing re-indexes it
+// when the key is later unlocked, which is a real limit rather than an
+// oversight: re-indexing on unlock would mean decrypting the whole mailbox at
+// the moment a passphrase is typed.
+func (a *App) searchBody(m storage.Message) string {
+	body := m.BodyPlain
+	if strings.TrimSpace(body) == "" {
+		body = mailview.PlainText(m.BodyHTML)
+	}
+	if !a.boolSetting(settingIndexDecrypted, false) {
+		return body
+	}
+	opened, _, state, _ := a.openProtected(m)
+	if state != pgpStateOpen {
+		return body
+	}
+	return opened
+}
+
 func toSearchDoc(m storage.Message) search.Doc {
 	// html-only mail carries no text/plain part, so indexing body_plain alone
 	// left roughly a seventh of a real mailbox with an empty body: the text

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -17,6 +17,12 @@ const (
 	settingShowBadge      = "show_mailbox_badge"
 	settingShowDateTime   = "show_datetime"
 	settingShowPGP        = "show_pgp"
+	// settingIndexDecrypted lets search see inside encrypted mail. Off by
+	// default: the search index is an ordinary file on disk, so indexing
+	// decrypted text writes the plaintext there and gives up much of what the
+	// encryption was for. Toggling it rebuilds the index either way, so turning
+	// it off actually removes the plaintext rather than merely stopping additions.
+	settingIndexDecrypted = "search_index_decrypted"
 	settingShowAuth       = "show_auth"
 	settingToastPosition  = "toast_position"
 	settingPaneLocked     = "pane_locked"
@@ -409,6 +415,12 @@ func (a *App) SetSetting(key, value string) error {
 	}
 	if key == settingLanguage || key == settingMenuBarInApp || key == settingMenuBarNativeMinimal {
 		a.RebuildMenu()
+	}
+	if key == settingIndexDecrypted {
+		// rebuilt from scratch rather than re-indexed in place: switching this
+		// off has to remove the plaintext already written, and overwriting
+		// documents would leave it in the index's older segments.
+		go a.rebuildSearchIndex()
 	}
 	return nil
 }

--- a/internal/desktop/dto.go
+++ b/internal/desktop/dto.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TRC-Loop/Pelton/internal/crypto"
 	"github.com/TRC-Loop/Pelton/internal/mailview"
 	"github.com/TRC-Loop/Pelton/internal/storage"
 )
@@ -91,6 +92,19 @@ type MessageSummaryDTO struct {
 	SMIME SMIMEDTO `json:"smime"`
 }
 
+// smimeDTO flattens a verified signature for the ui. It carries both PGP and
+// S/MIME verdicts: they answer the same question and the reading pane shows
+// them the same way, so one shape keeps that from being two code paths.
+func smimeDTO(sig crypto.Signature) SMIMEDTO {
+	return SMIMEDTO{
+		Status: string(sig.Status),
+		Signer: sig.SignerName,
+		Email:  sig.SignerEmail,
+		Issuer: sig.Issuer,
+		Detail: sig.Detail,
+	}
+}
+
 // SMIMEDTO is a message's s/mime signature verdict for display. Status is one
 // of "", "valid", "untrusted" or "invalid"; Detail explains anything that is
 // not valid, in a sentence written for the reader.
@@ -142,6 +156,12 @@ type MessageDetailDTO struct {
 	// the banner can show the user where.
 	RemoteHosts []string        `json:"remoteHosts"`
 	Attachments []AttachmentDTO `json:"attachments"`
+	// PGPState is empty for ordinary mail, and otherwise says what happened when
+	// the message was opened: "open" (decrypted, body below is the plaintext),
+	// "locked" (a passphrase is needed), "nokey" (no imported key can open it)
+	// or "failed" (the pgp data could not be read). The reading pane offers a
+	// different next step for each, rather than one generic error.
+	PGPState string `json:"pgpState"`
 	// Unsubscribe describes the unsubscribe mechanism the message advertises
 	// via its List-Unsubscribe headers, nil when it has none on record.
 	Unsubscribe *UnsubscribeDTO `json:"unsubscribe"`

--- a/internal/mailview/mailview.go
+++ b/internal/mailview/mailview.go
@@ -10,11 +10,16 @@
 package mailview
 
 import (
+	"bytes"
+	"fmt"
 	stdhtml "html"
+	"io"
 	"regexp"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/emersion/go-message"
+	"github.com/emersion/go-message/mail"
 	"github.com/microcosm-cc/bluemonday"
 	htmltok "golang.org/x/net/html"
 )
@@ -258,6 +263,61 @@ func DetectPGP(plain, html string) PGPStatus {
 	default:
 		return PGPNone
 	}
+}
+
+// Entity is the readable content of a MIME entity: its text and html bodies.
+type Entity struct {
+	Text string
+	HTML string
+}
+
+// ParseEntity reads a standalone MIME entity into its text and html parts.
+//
+// It exists for decrypted mail. The plaintext inside an encrypted message is a
+// MIME entity in its own right, with its own headers, parts and transfer
+// encodings, and showing it raw would put MIME source in front of the reader.
+// The bodies are returned rather than stored, since caching decrypted content
+// would undo the encryption.
+func ParseEntity(raw []byte) (Entity, error) {
+	reader, err := mail.CreateReader(bytes.NewReader(raw))
+	if err != nil && !message.IsUnknownCharset(err) {
+		return Entity{}, fmt.Errorf("mailview: read entity: %w", err)
+	}
+
+	var out Entity
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil && !message.IsUnknownCharset(err) {
+			// keep whatever was already recovered: a truncated multipart is
+			// better shown in part than discarded.
+			break
+		}
+		header, ok := part.Header.(*mail.InlineHeader)
+		if !ok {
+			continue
+		}
+		body, err := io.ReadAll(part.Body)
+		if err != nil {
+			break
+		}
+		contentType, _, _ := header.ContentType()
+		if strings.EqualFold(contentType, "text/html") {
+			if out.HTML == "" {
+				out.HTML = string(body)
+			}
+			continue
+		}
+		if out.Text == "" {
+			out.Text = string(body)
+		}
+	}
+	if out.Text == "" && out.HTML == "" {
+		return Entity{}, fmt.Errorf("mailview: entity has no readable body")
+	}
+	return out, nil
 }
 
 // skipTextIn are elements whose text content is markup rather than prose, so it

--- a/internal/storage/message_pgp.go
+++ b/internal/storage/message_pgp.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrNoPGPSource is returned when a message has no stored pgp source, either
+// because it is not protected or because it was cached before the source was
+// kept.
+var ErrNoPGPSource = errors.New("storage: no pgp source for message")
+
+// SetMessagePGPSource stores the raw rfc 822 source of a pgp protected message
+// so it can be decrypted and verified on demand. The bytes are the sender's
+// ciphertext; decrypted plaintext is never stored.
+func (d *DB) SetMessagePGPSource(ctx context.Context, messageID int64, raw []byte) error {
+	_, err := d.sql.ExecContext(ctx,
+		`INSERT INTO message_pgp (message_id, raw) VALUES (?, ?)
+         ON CONFLICT(message_id) DO UPDATE SET raw = excluded.raw`, messageID, raw)
+	if err != nil {
+		return fmt.Errorf("storage: store pgp source for message %d: %w", messageID, err)
+	}
+	return nil
+}
+
+// MessagePGPSource returns a message's stored pgp source, or ErrNoPGPSource.
+func (d *DB) MessagePGPSource(ctx context.Context, messageID int64) ([]byte, error) {
+	var raw []byte
+	err := d.sql.QueryRowContext(ctx,
+		`SELECT raw FROM message_pgp WHERE message_id = ?`, messageID).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNoPGPSource
+	}
+	if err != nil {
+		return nil, fmt.Errorf("storage: read pgp source for message %d: %w", messageID, err)
+	}
+	return raw, nil
+}

--- a/internal/storage/migrations/0019_message_pgp.sql
+++ b/internal/storage/migrations/0019_message_pgp.sql
@@ -1,0 +1,18 @@
+-- the raw rfc 822 source of pgp protected mail, kept so it can be decrypted and
+-- verified whenever it is opened.
+--
+-- Decryption needs the exact bytes the sender produced, and those are not
+-- otherwise cached: the source viewer refetches them over imap. Without this,
+-- encrypted mail would be unreadable offline and every open would cost a
+-- network round trip. What is stored is the ciphertext, already encrypted by
+-- the sender, so keeping it gives away nothing that the message did not already
+-- carry. The decrypted plaintext is never written anywhere.
+--
+-- A separate table rather than a column on messages: this is a blob, and the
+-- list queries select every message column, so putting it inline would drag the
+-- whole ciphertext through queries that only want a subject and a date. It also
+-- holds only the small minority of mail that is protected.
+CREATE TABLE message_pgp (
+    message_id INTEGER PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    raw        BLOB NOT NULL
+);

--- a/internal/sync/pull.go
+++ b/internal/sync/pull.go
@@ -94,6 +94,16 @@ func (e *Engine) fetchAndStore(ctx context.Context, folder storage.Folder, uid u
 	if err != nil {
 		return 0, fmt.Errorf("sync: store message uid %d: %w", uid, err)
 	}
+
+	// pgp mail keeps its source, since decrypting and verifying need the exact
+	// bytes and nothing else caches them. What is kept is the sender's
+	// ciphertext, so this stores nothing the message did not already carry. A
+	// failure here costs the ability to open that one message, not the sync.
+	if crypto.IsProtected(msg.Raw) {
+		if err := e.store.SetMessagePGPSource(ctx, id, msg.Raw); err != nil {
+			e.log.Error("store pgp source", "uid", uid, "err", err)
+		}
+	}
 	return id, nil
 }
 


### PR DESCRIPTION
Fixes #193. Part of #191.

Pelton can now read the protected mail it already receives, which the issue identified as the first genuinely shippable PGP milestone. Encrypted messages are decrypted and rendered; signed messages are verified and reported. Sending protected mail is still #194.

Nothing existed to build on: `internal/crypto` could only `Wrap` for sending, with no decryption and no signature checking, so this is new code rather than wiring.

### What gets cached

The issue asked this directly, and it decides everything else. Decryption needs the exact bytes the sender produced, and those were not cached: the source viewer refetches them over IMAP.

**The ciphertext is stored, the plaintext never is.** A new `message_pgp` table holds the raw source of protected mail only. Those bytes are already encrypted, so keeping them gives away nothing the message did not already carry, and encrypted mail stays readable offline. Decryption happens in memory on every open and the result is discarded with the view.

Storing the decrypted plaintext instead would have been simpler and searchable, and would have undone most of what the encryption was for.

### Verification runs on open

S/MIME verifies at sync (#225) because the platform trust store rarely changes. PGP is the opposite: the keyring is local and grows as the user imports keys. Verifying on open means importing a correspondent's key today makes their older mail verify immediately, with nothing to re-sync and no "re-check" affordance to discover. Since the raw bytes are stored anyway, it costs nothing.

### Four shapes, not two

PGP/MIME `multipart/encrypted` and `multipart/signed` (RFC 3156), plus the inline armored and clearsigned forms the issue flagged as still common. The signed part of a `multipart/signed` message is taken verbatim, because re-encoding it through a MIME writer would invalidate a signature that is perfectly good.

The decrypted payload is itself a MIME entity, so it is parsed as one (`mailview.ParseEntity`) rather than shown as raw source.

### Failure states

Each gets its own next step in the reading pane rather than one generic error:

| State | What the reader is shown |
| --- | --- |
| `locked` | A passphrase prompt, inline. Held for the session on success. |
| `nokey` | It was encrypted to a key that has not been imported. |
| `failed` | The PGP data is damaged; view the source to see it as it arrived. |

The prompt deliberately does not offer to store the passphrase in the OS keyring. That needs a specific key to file it under, which the Encryption pane has and a message does not, and quietly persisting a passphrase in answer to a prompt about reading one message would be a larger commitment than the prompt asked for.

Signature verdicts reuse the three-state shape S/MIME introduced, so the reading pane describes a signature one way whatever produced it. A signature from a key that is not in the keyring is **unverified**, not bad: the content may be untouched, but with no key there is no way to establish that.

### Searching encrypted mail

Off by default, with a toggle under Encryption. The search index is an ordinary file, so indexing decrypted text writes the plaintext into it.

Toggling **rebuilds the index from scratch in both directions**. Switching it off has to actually remove the plaintext already written, and overwriting documents would have left it in Bleve's older segments, which would make the setting a promise it does not keep.

Known limit, stated in the UI and the docs: a message whose key is locked at index time is indexed unopened, and nothing re-indexes it when the key is later unlocked. The alternative would be decrypting the whole mailbox at the moment a passphrase is typed.

### Tests

Nine in `internal/crypto/open_test.go`, all real round trips through actual encryption rather than fixtures: encrypt then open, sign then open, sign+encrypt, no decryption key, signature from an unknown key, tampered signed content, a locked key with both a missing and a wrong passphrase, unprotected mail, and five malformed inputs that must never report a valid signature.

Verified with `go build ./...`, `go vet ./internal/...`, `go test ./internal/...`, `pnpm run check` (0 errors) and a frontend build.

### Note

`internal/crypto` has still never been exercised against real mail from another client. The ciphertext is only stored at sync, so a message has to arrive after this lands before it can be opened.
