### PR TITLE
docs: link the discord invite directly and add it to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <img src="https://img.shields.io/badge/CalVer-YYYY.Q.INCR-22bfda?style=for-the-badge" alt="CalVer YYYY.Q.INCR">
   </a>
   <img src="https://img.shields.io/badge/Language-Go-00ADD8?style=for-the-badge&logo=go" alt="Written in Go">
-  <a href="https://arne.sh/discord">
+  <a href="https://discord.gg/UzPNGZYy6V">
     <img src="https://img.shields.io/badge/Discord-Join_Community-7289DA?style=for-the-badge&logo=discord&logoColor=white" alt="Discord">
   </a>
   <a href="https://github.com/TRC-Loop/Pelton/issues">
@@ -192,7 +192,7 @@ The first release of a quarter (INCR `0`) drops the trailing `.0`, so it reads a
 
 ## <img src="https://api.iconify.design/tabler/messages.svg?color=white" width="26" style="vertical-align: -4px;"> Contact & Community
 
-* **Discord:** Join the discussion at [arne.sh/discord](https://arne.sh/discord)
+* **Discord:** Join the discussion at [discord.gg/UzPNGZYy6V](https://discord.gg/UzPNGZYy6V)
 * **Email:** Reach out directly via [pelton@arne.sh](mailto:pelton@arne.sh)
 
 ## <img src="https://api.iconify.design/tabler/users.svg?color=white" width="26" style="vertical-align: -4px;"> Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,4 +32,8 @@ Pelton is a free, open source email client for macOS, Windows and Linux, built a
 
     The Pelton website, with screenshots and a feature tour.
 
+- **[Discord](https://discord.gg/UzPNGZYy6V)**
+
+    Ask questions, report oddities and follow what is being worked on.
+
 </div>

--- a/zensical.toml
+++ b/zensical.toml
@@ -83,6 +83,10 @@ icon = "tabler/brand-github"
 link = "https://github.com/TRC-Loop/Pelton"
 
 [[project.extra.social]]
+icon = "tabler/brand-discord"
+link = "https://discord.gg/UzPNGZYy6V"
+
+[[project.extra.social]]
 icon = "tabler/world"
 link = "https://pelton.app"
 


### PR DESCRIPTION
Fixes #229.

Points Discord at the invite directly instead of the `arne.sh/discord` redirect, and adds it to the documentation site, which did not link the community at all.

Targets `main` rather than `dev` so the README on GitHub and docs.pelton.app pick it up now rather than at the next release.

- `README.md` — the badge and the Contact line.
- `zensical.toml` — a `tabler/brand-discord` entry in the social links, which is what puts it in the docs site chrome.
- `docs/index.md` — a Discord card alongside Source code and Website, since the social icons in the header are easy to miss.

The invite is set to never expire, which is what makes it safe to put in places that are hard to change later.

### Not changed

`SECURITY.md` mentions Discord, and #229 suggested linking it. On reading it, that would be wrong: the line says to report vulnerabilities privately, **not** in Discord. Adding a link there would invite exactly the behaviour the paragraph is warning against, so it is left alone.

### Follow-up

`pelton.app` is a separate repository and is handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the README Discord badge and contact link.
- Added Discord to the documentation site social links.
- Added a Discord card to `docs/index.md`.
- Kept `SECURITY.md` unchanged because vulnerability reports require private handling.

## AI Assistance

AI assistance is **Probably** used. Confidence: **Probably**. The available summary includes AI-generated change descriptions, but there is no clear evidence that an AI agent made the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->