### PR TITLE
ci: rebuild the docs when the theme overrides change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,11 @@ on:
     paths:
       - "docs/**"
       - "zensical.toml"
+      # overrides/ is the theme: templates and the vendored icon set live there,
+      # so a change to it changes the built site as surely as a page does.
+      # Without this, adding an icon deploys nothing and the site keeps serving
+      # the last build, which is how a broken icon reference survived a fix.
+      - "overrides/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
The docs workflow watches `docs/**`, `zensical.toml` and its own file, but not `overrides/**`.

`overrides/` is the theme: `custom_dir = "overrides"`, and it holds the templates and the hand-vendored tabler icon set. A change there changes the built site as surely as a page does.

The consequence just played out. #232 added the missing `brand-discord.svg` and fixed the build locally, but touched only `overrides/`, so no deploy ran and docs.pelton.app kept serving the last good build with the failure still standing. Any future icon or template change would have gone the same way, silently.

Merging this also triggers the rebuild that #232 should have, since the workflow file is itself a watched path.