### PR TITLE
feat: native window frame, cursors and calmer setup flow

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -58,6 +58,7 @@
     getLogStatus,
     openCrashReport,
     accountsNeedingPassword,
+    titleBarDoubleClick,
   } from './lib/api'
   import { BrowserOpenURL } from '../wailsjs/runtime/runtime'
   import { liabilityAccepted } from './lib/liability'
@@ -147,6 +148,29 @@
   // created there); on macOS the native bar stays and the in-app one is opt-in.
   $: showMenuBar = !isMac || $prefs.menuBarInApp
 
+  // the macOS window has no native title bar (mac.TitleBarHiddenInset), so the
+  // ui paints to the top edge and keeps a strip clear for the traffic lights.
+  // fullscreen hides the lights, and the strip goes with them.
+  let fullscreen = false
+  $: macTitlebar = isMac && !fullscreen
+  $: applyTitlebar(macTitlebar)
+  function applyTitlebar(on: boolean): void {
+    if (on) {
+      document.documentElement.dataset.titlebar = 'mac'
+    } else {
+      delete document.documentElement.dataset.titlebar
+    }
+  }
+
+  // only a window resize can change fullscreen state, and only the window layer
+  // knows the answer: wkwebview reports nothing useful about the frame.
+  async function refreshFullscreen(): Promise<void> {
+    if (!isMac) {
+      return
+    }
+    fullscreen = await WindowIsFullscreen().catch(() => false)
+  }
+
   // the native Mail menu's message actions are only usable while a message is
   // open; keep them greyed in step with the open message.
   $: setMailActionsEnabled($openMessageId != null)
@@ -211,6 +235,8 @@
     // data before anything loads, so the whole ui fills with the potato inbox.
     const demo = await isDemoMode().catch(() => false)
     setDemoActive(demo)
+
+    void refreshFullscreen()
 
     // a nightly warns before anything else is on screen. demo mode is only used
     // for screenshots, so the dialog would just be in the way there.
@@ -1097,11 +1123,27 @@
   }
 </script>
 
-<svelte:window on:keydown={onKeydown} on:contextmenu={onContextMenu} />
+<svelte:window on:keydown={onKeydown} on:contextmenu={onContextMenu} on:resize={refreshFullscreen} />
 
-<div class="shell" class:with-menubar={showMenuBar}>
+<!-- macOS with no in-app menu bar: an empty top row for the traffic lights, and
+     a matching strip above every overlay so the window can still be dragged
+     while settings or onboarding is open. with the menu bar on, the bar itself
+     is that row and handles both. -->
+{#if macTitlebar && !showMenuBar}
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class="titlebar-drag"
+    style="--wails-draggable:drag"
+    aria-hidden="true"
+    on:dblclick={titleBarDoubleClick}
+  ></div>
+{/if}
+
+<div class="shell" class:with-topbar={showMenuBar || macTitlebar}>
   {#if showMenuBar}
     <MenuBar on:action={(e) => handleMenu(e.detail)} />
+  {:else if macTitlebar}
+    <div class="titlebar-space" aria-hidden="true"></div>
   {/if}
   <div class="columns" style={`grid-template-columns: ${sidebarW}px 0 ${listW}px 0 1fr`}>
     <Sidebar
@@ -1205,9 +1247,24 @@
     overflow: hidden;
   }
 
-  /* with the in-app menu bar the shell gains a top auto row for it. */
-  .shell.with-menubar {
+  /* the menu bar, or the macOS traffic-light row, takes a top auto row. */
+  .shell.with-topbar {
     grid-template-rows: auto minmax(0, 1fr) auto;
+  }
+
+  .titlebar-space {
+    height: var(--titlebar-lights);
+  }
+
+  /* above every overlay: a window with no native title bar has nothing else to
+     drag it by, and settings or onboarding being open is no reason to lose
+     that. only rendered without the menu bar, which would otherwise have its
+     titles buried under this. */
+  .titlebar-drag {
+    position: fixed;
+    inset: 0 0 auto 0;
+    height: var(--titlebar-lights);
+    z-index: 700;
   }
 
   /* the two zero-width tracks hold the resizer handles, which overhang via

--- a/frontend/src/components/common/ColorPicker.svelte
+++ b/frontend/src/components/common/ColorPicker.svelte
@@ -244,7 +244,7 @@
     position: relative;
     height: 12px;
     border-radius: 999px;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     touch-action: none;
     background: linear-gradient(
       to right,

--- a/frontend/src/components/common/CommandPalette.svelte
+++ b/frontend/src/components/common/CommandPalette.svelte
@@ -377,7 +377,7 @@
     gap: var(--space-3);
     padding: var(--space-2) var(--space-2);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     color: var(--text-primary);
   }
   .row[data-active='true'] {

--- a/frontend/src/components/common/ContextMenu.svelte
+++ b/frontend/src/components/common/ContextMenu.svelte
@@ -129,7 +129,7 @@
     border: none;
     background: transparent;
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-label);
     border-radius: var(--radius-control);
@@ -177,7 +177,7 @@
     border-radius: 999px;
     border: var(--hairline) solid var(--border-default);
     background: var(--sw, transparent);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 0;
     display: inline-flex;
     align-items: center;

--- a/frontend/src/components/common/DateTimePicker.svelte
+++ b/frontend/src/components/common/DateTimePicker.svelte
@@ -476,7 +476,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-sunken);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-list);
     width: 100%;
   }
@@ -535,7 +535,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -555,7 +555,7 @@
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }
@@ -581,7 +581,7 @@
     background: transparent;
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -620,7 +620,7 @@
     background: transparent;
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -688,7 +688,7 @@
     background: transparent;
     color: var(--link);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }
@@ -706,7 +706,7 @@
     color: var(--accent-fg);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .confirm-btn:disabled {

--- a/frontend/src/components/common/ErrorState.svelte
+++ b/frontend/src/components/common/ErrorState.svelte
@@ -48,7 +48,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .retry:hover {

--- a/frontend/src/components/common/IconButton.svelte
+++ b/frontend/src/components/common/IconButton.svelte
@@ -34,7 +34,7 @@
     border-radius: var(--radius-control);
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .icon-btn:hover:not(:disabled) {

--- a/frontend/src/components/common/LanguageSelect.svelte
+++ b/frontend/src/components/common/LanguageSelect.svelte
@@ -83,7 +83,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
   }
 

--- a/frontend/src/components/common/LiabilityDialog.svelte
+++ b/frontend/src/components/common/LiabilityDialog.svelte
@@ -92,7 +92,7 @@
     font-family: inherit;
     font-size: var(--fz-body);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .primary:disabled {
     opacity: 0.5;

--- a/frontend/src/components/common/LiabilityNotice.svelte
+++ b/frontend/src/components/common/LiabilityNotice.svelte
@@ -42,7 +42,7 @@
     color: var(--link);
     font-family: inherit;
     font-size: var(--fz-body);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .ack {
     display: flex;
@@ -52,7 +52,7 @@
     font-size: var(--fz-body);
     color: var(--text-primary);
     line-height: 1.5;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .ack input {
     margin: 2px 0 0;

--- a/frontend/src/components/common/MenuBar.svelte
+++ b/frontend/src/components/common/MenuBar.svelte
@@ -13,7 +13,8 @@
   import MenuGlyph from './MenuGlyph.svelte'
   import MenuBarEditor from './MenuBarEditor.svelte'
   import { IconChevronRight } from '@tabler/icons-svelte'
-  import { t, shortcutLabel } from '../../lib/i18n'
+  import { t, shortcutLabel, isMac } from '../../lib/i18n'
+  import { titleBarDoubleClick } from '../../lib/api'
   import { prefs } from '../../stores/prefs'
   import { bindings } from '../../stores/shortcuts'
   import { openMessageId } from '../../stores/selection'
@@ -102,6 +103,24 @@
     openSub = null
   }
 
+  // the scrim that dismisses an open menu sits below the bar, so a click on the
+  // bar's own empty space never reaches it. that space is wide on macOS, where
+  // the bar spans the title bar, so dismiss from here too.
+  function onBarClick(event: MouseEvent): void {
+    if (event.target === barEl) {
+      close()
+    }
+  }
+
+  // on macOS this bar is the window's title bar, so a double-click on its empty
+  // space has to do what double-clicking a title bar does. the guard keeps it to
+  // the bar itself, never a menu title.
+  function onBarDblClick(event: MouseEvent): void {
+    if (isMac && event.target === barEl) {
+      titleBarDoubleClick()
+    }
+  }
+
   function onBarKeydown(event: KeyboardEvent): void {
     if (openKey === null) {
       return
@@ -139,7 +158,15 @@
   {/if}
 
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <nav class="menubar" class:raised={openKey !== null} aria-label="Pelton" bind:this={barEl} on:keydown={onBarKeydown}>
+  <nav
+    class="menubar"
+    class:raised={openKey !== null}
+    aria-label="Pelton"
+    bind:this={barEl}
+    on:keydown={onBarKeydown}
+    on:click={onBarClick}
+    on:dblclick={onBarDblClick}
+  >
     {#each menus as m (m.id)}
       {@const label = m.labelKey ? $t(m.labelKey) : (m.label ?? '')}
       <div class="menu-wrap">
@@ -253,11 +280,16 @@
     align-items: center;
     gap: var(--space-1);
     height: 30px;
-    padding: 0 var(--space-2);
+    /* on macOS this bar is the top row of a window with no native title bar, so
+       it starts past the traffic lights and doubles as the drag handle rather
+       than sitting below a second, empty strip. the inset token is zero on
+       every other platform, where the padding stays symmetric. */
+    padding: 0 var(--space-2) 0 max(var(--space-2), var(--titlebar-inset));
     background: var(--surface-sunken);
     border-bottom: var(--hairline) solid var(--border-subtle);
     user-select: none;
     position: relative;
+    --wails-draggable: drag;
   }
 
   /* only while a menu is open: above the scrim, so the other titles still
@@ -266,6 +298,10 @@
      overlays like the settings screen. */
   .menubar.raised {
     z-index: 220;
+    /* with a menu open the bar stops being a window drag handle: a press there
+       has to dismiss the menu, and handing it to the window drag instead eats
+       the click and leaves the menu stuck open. */
+    --wails-draggable: no-drag;
   }
 
   .menu-wrap {
@@ -274,12 +310,19 @@
 
   .title {
     padding: var(--space-1) var(--space-3);
+    /* lifts the labels off the bar's centre line so they line up with the
+       traffic lights on macOS. zero elsewhere, where the bar centres normally.
+       only the labels move, not the bar or its dropdowns, which anchor to the
+       wrapper. */
+    position: relative;
+    top: calc(-1 * var(--titlebar-nudge));
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    font-size: var(--fz-label);
+    font-size: var(--fz-list);
     border-radius: var(--radius-control);
     cursor: default;
+    --wails-draggable: no-drag;
   }
 
   .title:hover,
@@ -305,6 +348,7 @@
     border-radius: var(--radius-card);
     background: var(--surface-overlay);
     box-shadow: var(--shadow-overlay);
+    --wails-draggable: no-drag;
   }
 
   .sub-wrap {
@@ -333,7 +377,7 @@
     border: none;
     background: transparent;
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-label);
     border-radius: var(--radius-control);

--- a/frontend/src/components/common/MenuBarEditor.svelte
+++ b/frontend/src/components/common/MenuBarEditor.svelte
@@ -486,7 +486,7 @@
     color: var(--text-primary);
     font-size: var(--fz-label);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .add-chip {
@@ -496,7 +496,7 @@
     background: transparent;
     color: var(--text-secondary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .add-chip:hover {
@@ -519,7 +519,7 @@
     color: var(--text-secondary);
     font-size: var(--fz-meta);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .txt-btn:hover {
@@ -625,7 +625,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .icon-btn {
@@ -635,7 +635,7 @@
     background: transparent;
     color: var(--text-secondary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .icon-btn:hover,
@@ -682,7 +682,7 @@
     color: var(--text-secondary);
     font-size: var(--fz-meta);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .icon-choose:hover,

--- a/frontend/src/components/common/NightlyDialog.svelte
+++ b/frontend/src/components/common/NightlyDialog.svelte
@@ -106,7 +106,7 @@
     font-size: var(--fz-body);
     color: var(--text-primary);
     line-height: 1.5;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .ack input {
     margin: 2px 0 0;
@@ -130,7 +130,7 @@
     font-family: inherit;
     font-size: var(--fz-body);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .primary:disabled {
     opacity: 0.5;

--- a/frontend/src/components/common/OutboxPanel.svelte
+++ b/frontend/src/components/common/OutboxPanel.svelte
@@ -219,7 +219,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -335,7 +335,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/common/StatusBar.svelte
+++ b/frontend/src/components/common/StatusBar.svelte
@@ -257,7 +257,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 1px;
     border-radius: var(--radius-control);
   }
@@ -274,7 +274,7 @@
     background: transparent;
     color: var(--text-secondary);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }
@@ -321,7 +321,7 @@
     background: transparent;
     color: var(--warning, var(--text-secondary));
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/common/Toasts.svelte
+++ b/frontend/src/components/common/Toasts.svelte
@@ -61,20 +61,22 @@
   }
 
   /* anchoring. the stack only occupies its corner; toasts capture pointer events
-     themselves so the rest of the app stays clickable. */
+     themselves so the rest of the app stays clickable. the top anchors start
+     below the macOS traffic lights, which are drawn over the webview and would
+     otherwise land on a top-left toast; zero on every other platform. */
   .stack.top-left {
-    top: 0;
+    top: var(--titlebar-lights);
     left: 0;
     align-items: flex-start;
   }
   .stack.top-center {
-    top: 0;
+    top: var(--titlebar-lights);
     left: 50%;
     transform: translateX(-50%);
     align-items: center;
   }
   .stack.top-right {
-    top: 0;
+    top: var(--titlebar-lights);
     right: 0;
     align-items: flex-end;
   }
@@ -140,7 +142,7 @@
     color: var(--accent);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .action:hover {
@@ -152,7 +154,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
     flex-shrink: 0;

--- a/frontend/src/components/common/ToggleSwitch.svelte
+++ b/frontend/src/components/common/ToggleSwitch.svelte
@@ -43,7 +43,7 @@
     border: var(--hairline) solid var(--text-tertiary);
     border-radius: 999px;
     background: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     transition: background 0.14s ease, border-color 0.14s ease;
   }
 

--- a/frontend/src/components/common/VerdictBadge.svelte
+++ b/frontend/src/components/common/VerdictBadge.svelte
@@ -82,7 +82,7 @@
     /* unknown and any other unhandled state: deliberately neutral, since it is
        not a statement about the target either way. */
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     vertical-align: middle;
   }
 

--- a/frontend/src/components/compose/AddressFields.svelte
+++ b/frontend/src/components/compose/AddressFields.svelte
@@ -113,7 +113,7 @@
     background: transparent;
     color: var(--text-tertiary);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/compose/AttachmentPicker.svelte
+++ b/frontend/src/components/compose/AttachmentPicker.svelte
@@ -131,7 +131,7 @@
     background: var(--surface-raised);
     color: var(--text-secondary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .attach:hover {
@@ -209,7 +209,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
     flex-shrink: 0;

--- a/frontend/src/components/compose/ChipInput.svelte
+++ b/frontend/src/components/compose/ChipInput.svelte
@@ -214,7 +214,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 1px;
     border-radius: 999px;
     flex-shrink: 0;
@@ -265,7 +265,7 @@
     flex-direction: column;
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .suggest-item.active {
     background: var(--surface-hover);

--- a/frontend/src/components/compose/Compose.svelte
+++ b/frontend/src/components/compose/Compose.svelte
@@ -580,6 +580,9 @@
   .compose.fullscreen {
     position: fixed;
     inset: 24px;
+    /* clears the macOS traffic lights, which the 24px inset alone runs into;
+       zero on every other platform. */
+    top: calc(24px + var(--titlebar-lights));
     width: auto;
     height: auto;
     max-height: none;
@@ -630,7 +633,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -750,7 +753,7 @@
     color: var(--text-secondary);
     font-size: var(--fz-label);
     padding: var(--space-1) var(--space-2);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .send,
@@ -763,7 +766,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
   }
 
@@ -797,7 +800,7 @@
     border-radius: 0 var(--radius-control) var(--radius-control) 0;
     background: var(--surface-raised);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .send-caret:hover:not(:disabled) {
@@ -851,7 +854,7 @@
     border-radius: var(--radius-control);
     background: transparent;
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-label);
   }
@@ -934,7 +937,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
   }
 

--- a/frontend/src/components/compose/EditorModeSwitch.svelte
+++ b/frontend/src/components/compose/EditorModeSwitch.svelte
@@ -46,7 +46,7 @@
     color: var(--text-secondary);
     padding: var(--space-1) var(--space-3);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-right: var(--hairline) solid var(--border-subtle);
   }
 

--- a/frontend/src/components/compose/EditorToolbar.svelte
+++ b/frontend/src/components/compose/EditorToolbar.svelte
@@ -64,7 +64,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/compose/RichEditor.svelte
+++ b/frontend/src/components/compose/RichEditor.svelte
@@ -158,7 +158,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/detail/AttachmentList.svelte
+++ b/frontend/src/components/detail/AttachmentList.svelte
@@ -188,7 +188,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-meta);
   }
   .save-all:hover {
@@ -229,7 +229,7 @@
     border: none;
     background: transparent;
     text-align: left;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .card-main:hover {
     background: var(--surface-hover);
@@ -245,7 +245,7 @@
     border-left: var(--hairline) solid var(--border-subtle);
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .dl-btn:hover {
     background: var(--surface-hover);

--- a/frontend/src/components/detail/AttachmentPreview.svelte
+++ b/frontend/src/components/detail/AttachmentPreview.svelte
@@ -218,7 +218,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -251,7 +251,7 @@
     border: none;
     background: transparent;
     color: var(--accent);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font: inherit;
     text-decoration: underline;
   }

--- a/frontend/src/components/detail/DetailHeader.svelte
+++ b/frontend/src/components/detail/DetailHeader.svelte
@@ -211,7 +211,7 @@
     background: none;
     border-radius: var(--radius-sm);
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .vip-toggle:hover {
@@ -266,7 +266,7 @@
     background: transparent;
     color: var(--text-secondary);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .unsub:hover:not(:disabled) {

--- a/frontend/src/components/detail/InfoModal.svelte
+++ b/frontend/src/components/detail/InfoModal.svelte
@@ -170,7 +170,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -219,7 +219,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -251,7 +251,7 @@
     color: var(--accent-fg);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .primary:hover {

--- a/frontend/src/components/detail/MailBody.svelte
+++ b/frontend/src/components/detail/MailBody.svelte
@@ -620,7 +620,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .remote-btn:hover {
@@ -792,6 +792,6 @@
   .plain-link {
     color: var(--accent);
     text-decoration: underline;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 </style>

--- a/frontend/src/components/detail/MoveDialog.svelte
+++ b/frontend/src/components/detail/MoveDialog.svelte
@@ -150,7 +150,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -195,7 +195,7 @@
     border: none;
     background: transparent;
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     border-radius: var(--radius-control);
     font-size: var(--fz-label);

--- a/frontend/src/components/detail/ProtectedNotice.svelte
+++ b/frontend/src/components/detail/ProtectedNotice.svelte
@@ -158,7 +158,7 @@
     background: var(--accent);
     border: none;
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .unlock button:disabled {
     opacity: 0.5;

--- a/frontend/src/components/detail/SnoozeDialog.svelte
+++ b/frontend/src/components/detail/SnoozeDialog.svelte
@@ -225,7 +225,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -249,7 +249,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     transition: border-color 0.1s ease, background 0.1s ease;
   }
@@ -299,7 +299,7 @@
     border-radius: var(--radius-control);
     background: var(--accent);
     color: #fff;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-weight: var(--fw-medium);
   }
   .go:disabled {
@@ -313,6 +313,6 @@
     gap: var(--space-2);
     font-size: var(--fz-label);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 </style>

--- a/frontend/src/components/detail/SourceModal.svelte
+++ b/frontend/src/components/detail/SourceModal.svelte
@@ -122,7 +122,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/list/MessageList.svelte
+++ b/frontend/src/components/list/MessageList.svelte
@@ -688,7 +688,7 @@
     background: var(--surface-sunken);
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .load-older-btn:hover {
@@ -724,7 +724,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/list/MessageRow.svelte
+++ b/frontend/src/components/list/MessageRow.svelte
@@ -293,7 +293,7 @@
     gap: var(--space-3);
     padding: var(--row-pad-y) var(--row-pad-x);
     border-bottom: var(--hairline) solid var(--border-subtle);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     background: var(--surface-raised);
   }
 

--- a/frontend/src/components/list/SearchBar.svelte
+++ b/frontend/src/components/list/SearchBar.svelte
@@ -375,7 +375,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 1px;
     border-radius: var(--radius-control);
   }
@@ -398,7 +398,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 2px;
     border-radius: var(--radius-control);
   }
@@ -438,7 +438,7 @@
     width: 100%;
     border: none;
     background: transparent;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     padding: var(--space-2);
     border-radius: var(--radius-control);
@@ -471,7 +471,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-sunken);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .filter-btn:hover {
     background: var(--surface-hover);
@@ -532,6 +532,6 @@
     background: var(--accent);
     color: var(--accent-fg);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 </style>

--- a/frontend/src/components/onboarding/Onboarding.svelte
+++ b/frontend/src/components/onboarding/Onboarding.svelte
@@ -6,8 +6,8 @@
   // affordance is always available. completion is persisted by the parent so this
   // only ever shows once, with a settings action to run it again.
   import { createEventDispatcher, onMount } from 'svelte'
-  import { fly, fade, scale } from 'svelte/transition'
-  import { quintOut, backOut } from 'svelte/easing'
+  import { fade, scale } from 'svelte/transition'
+  import { backOut } from 'svelte/easing'
   import {
     IconArrowRight,
     IconArrowLeft,
@@ -211,14 +211,11 @@
       next()
     }
   }
-  // direction drives the slide of the step transition (forward vs back).
-  let dir = 1
 
   let showWizard = false
   let skippedMailbox = false
 
   function next(): void {
-    dir = 1
     index = Math.min(index + 1, order.length - 1)
   }
 
@@ -236,7 +233,6 @@
   }
 
   function back(): void {
-    dir = -1
     index = Math.max(index - 1, 0)
   }
 
@@ -281,7 +277,6 @@
   function onMailboxAdded(event: CustomEvent<Account>): void {
     showWizard = false
     dispatch('added', event.detail)
-    dir = 1
     index = order.indexOf('done')
   }
 
@@ -294,9 +289,6 @@
     skippedMailbox = true
     next()
   }
-
-  // slide params: enter from the side we are moving toward, leave to the other.
-  $: enterX = dir * 36
 </script>
 
 <div class="screen" role="dialog" aria-modal="true" aria-label="Welcome to Pelton">
@@ -309,15 +301,18 @@
 
   <div class="stage" class:wide={step === 'extras'}>
     {#key step}
-      <div class="step" in:fly={{ x: enterX, y: 8, duration: 380, easing: quintOut, delay: 90 }} out:fade={{ duration: 120 }}>
+      <!-- fade only, and no out transition: the previous step leaves at once so
+           the stage resizes while the new one is still transparent, instead of
+           shifting the content under the pointer part way through. -->
+      <div class="step" in:fade={{ duration: 120 }}>
         {#if step === 'welcome'}
           <div class="welcome">
             <img class="logo" src={logo} alt="Pelton" in:scale={{ start: 0.7, duration: 600, easing: backOut }} />
-            <h1 in:fly={{ y: 12, duration: 500, delay: 160, easing: quintOut }}>{$t('onboarding.welcome')}</h1>
-            <p class="lede" in:fly={{ y: 12, duration: 500, delay: 260, easing: quintOut }}>
+            <h1>{$t('onboarding.welcome')}</h1>
+            <p class="lede">
               {$t('onboarding.welcomeLede')}
             </p>
-            <button class="primary big" on:click={next} in:fly={{ y: 12, duration: 500, delay: 380, easing: quintOut }}>
+            <button class="primary big" on:click={next}>
               {$t('onboarding.getStarted')} <IconArrowRight size={18} stroke={1.8} />
             </button>
           </div>
@@ -346,8 +341,8 @@
           <div class="features">
             <h2>{$t('onboarding.featuresTitle')}</h2>
             <ul>
-              {#each features as f, i}
-                <li in:fly={{ y: 16, duration: 460, delay: 120 + i * 90, easing: quintOut }}>
+              {#each features as f}
+                <li>
                   <span class="f-icon"><svelte:component this={f.icon} size={22} stroke={1.6} /></span>
                   <span class="f-text">
                     <span class="f-title">{f.title}</span>
@@ -669,15 +664,15 @@
             <span class="done-mark" in:scale={{ start: 0.5, duration: 600, easing: backOut }}>
               <IconSparkles size={40} stroke={1.5} />
             </span>
-            <h1 in:fly={{ y: 12, duration: 500, delay: 160, easing: quintOut }}>{$t('onboarding.doneTitle')}</h1>
-            <p class="lede" in:fly={{ y: 12, duration: 500, delay: 260, easing: quintOut }}>
+            <h1>{$t('onboarding.doneTitle')}</h1>
+            <p class="lede">
               {#if skippedMailbox}
                 {$t('onboarding.doneLedeSkippedBefore')} <kbd>{addMailboxHint}</kbd> {$t('onboarding.doneLedeSkippedAfter')}
               {:else}
                 {$t('onboarding.doneLedeDefault')}
               {/if}
             </p>
-            <button class="primary big" on:click={finish} in:fly={{ y: 12, duration: 500, delay: 380, easing: quintOut }}>
+            <button class="primary big" on:click={finish}>
               {$t('onboarding.startUsing')}
             </button>
           </div>
@@ -724,6 +719,9 @@
     justify-content: center;
     background: var(--surface-base);
     overflow: hidden;
+    /* covers the whole window, so it has to keep the macOS traffic lights clear
+       itself; zero on every other platform. */
+    padding-top: var(--titlebar-lights);
   }
 
   .skip {
@@ -734,7 +732,7 @@
     background: transparent;
     color: var(--text-tertiary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-control);
   }
@@ -749,7 +747,6 @@
     max-width: 560px;
     padding: 0 var(--space-6);
     display: grid;
-    transition: max-width 0.3s ease;
   }
 
   /* the extras step needs more room for its two columns. */
@@ -757,7 +754,8 @@
     max-width: 760px;
   }
 
-  /* every step occupies the same grid cell so transitions cross-fade in place. */
+  /* every step occupies the same grid cell so one fades in exactly where the
+     last one was. */
   .step {
     grid-area: 1 / 1;
   }
@@ -974,7 +972,7 @@
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-card);
     background: var(--surface-raised);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .style-card.active {
     border-color: var(--accent);
@@ -1069,7 +1067,7 @@
     border-radius: var(--radius-card);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     transition: border-color 0.15s ease, transform 0.15s ease;
   }
 
@@ -1128,7 +1126,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     text-align: left;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     transition: border-color 0.15s ease, transform 0.15s ease;
   }
 
@@ -1212,7 +1210,7 @@
     border: 2px solid transparent;
     background: var(--sw);
     color: #fff;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1235,7 +1233,7 @@
     border-radius: 999px;
     border: var(--hairline) dashed var(--border-strong, var(--border-default));
     overflow: hidden;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1287,7 +1285,7 @@
     color: var(--accent-fg);
     font-size: var(--fz-body);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .dm-cta:hover {
@@ -1317,7 +1315,7 @@
     border-radius: var(--radius-card);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     transition: border-color 0.15s ease, transform 0.15s ease;
   }
 
@@ -1399,7 +1397,7 @@
     border-radius: var(--radius-control);
     font-size: var(--fz-body);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border: var(--hairline) solid var(--border-default);
   }
 

--- a/frontend/src/components/settings/AboutSection.svelte
+++ b/frontend/src/components/settings/AboutSection.svelte
@@ -375,7 +375,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .links button:hover {
@@ -442,7 +442,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     white-space: nowrap;
   }
 
@@ -498,7 +498,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/settings/AccentPicker.svelte
+++ b/frontend/src/components/settings/AccentPicker.svelte
@@ -97,7 +97,7 @@
     height: 26px;
     border-radius: var(--radius-control);
     border: var(--hairline) solid var(--border-strong);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/frontend/src/components/settings/AddressBookSection.svelte
+++ b/frontend/src/components/settings/AddressBookSection.svelte
@@ -103,7 +103,7 @@
     background: var(--surface-raised);
     font: inherit;
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .confirm .danger {
     border-color: var(--danger);
@@ -203,7 +203,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
     flex-shrink: 0;

--- a/frontend/src/components/settings/ColorPicker.svelte
+++ b/frontend/src/components/settings/ColorPicker.svelte
@@ -260,7 +260,7 @@
       linear-gradient(45deg, #cccccc 25%, transparent 25%, transparent 75%, #cccccc 75%);
     background-size: 8px 8px;
     background-position: 0 0, 4px 4px;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .swatch {
@@ -307,7 +307,7 @@
     position: relative;
     height: 12px;
     border-radius: 999px;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     touch-action: none;
   }
 

--- a/frontend/src/components/settings/EncryptionSection.svelte
+++ b/frontend/src/components/settings/EncryptionSection.svelte
@@ -354,7 +354,7 @@
     background: var(--accent);
     border: none;
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .primary:disabled {
     opacity: 0.5;
@@ -453,7 +453,7 @@
     background: transparent;
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .ghost:hover {
     background: var(--surface-hover);

--- a/frontend/src/components/settings/ExportModal.svelte
+++ b/frontend/src/components/settings/ExportModal.svelte
@@ -196,7 +196,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -224,7 +224,7 @@
     gap: var(--space-2);
     font-size: var(--fz-label);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .check input {
     accent-color: var(--accent);
@@ -285,7 +285,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .action-btn:hover {
     background: var(--surface-hover);

--- a/frontend/src/components/settings/ExternalSection.svelte
+++ b/frontend/src/components/settings/ExternalSection.svelte
@@ -385,7 +385,7 @@
     border: var(--hairline) solid var(--border-default);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
     white-space: nowrap;
   }
@@ -436,7 +436,7 @@
     background: none;
     color: var(--link);
     font-size: inherit;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-decoration: underline;
   }
 </style>

--- a/frontend/src/components/settings/IconPicker.svelte
+++ b/frontend/src/components/settings/IconPicker.svelte
@@ -135,7 +135,7 @@
     color: var(--text-secondary);
     font-size: var(--fz-meta);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .clear:hover {
@@ -171,7 +171,7 @@
     background: transparent;
     color: var(--text-secondary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .cell:hover {

--- a/frontend/src/components/settings/ImageAllowlistModal.svelte
+++ b/frontend/src/components/settings/ImageAllowlistModal.svelte
@@ -154,7 +154,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -226,7 +226,7 @@
     padding: 0;
     color: var(--text-tertiary);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
   }
   .example:hover {
@@ -243,7 +243,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/settings/ImportExportSection.svelte
+++ b/frontend/src/components/settings/ImportExportSection.svelte
@@ -299,7 +299,7 @@
     gap: var(--space-2);
     font-size: var(--fz-label);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .check.disabled {
     color: var(--text-tertiary);
@@ -320,7 +320,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .action-btn:hover {
     background: var(--surface-hover);

--- a/frontend/src/components/settings/LicensesView.svelte
+++ b/frontend/src/components/settings/LicensesView.svelte
@@ -107,7 +107,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .program span {
@@ -138,7 +138,7 @@
     background: transparent;
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/settings/MailboxesSection.svelte
+++ b/frontend/src/components/settings/MailboxesSection.svelte
@@ -245,7 +245,7 @@
     color: var(--accent-fg);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .add-btn:hover {
     filter: brightness(1.05);
@@ -312,7 +312,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
     flex-shrink: 0;
@@ -406,7 +406,7 @@
     border-radius: var(--radius-control);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border: var(--hairline) solid var(--border-default);
   }
   .primary {

--- a/frontend/src/components/settings/NetworkSection.svelte
+++ b/frontend/src/components/settings/NetworkSection.svelte
@@ -205,7 +205,7 @@
     padding: var(--space-2) var(--space-5);
     border-radius: var(--radius-control);
     border: var(--hairline) solid var(--border-default);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
   }
 

--- a/frontend/src/components/settings/PassphraseDialog.svelte
+++ b/frontend/src/components/settings/PassphraseDialog.svelte
@@ -176,7 +176,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -232,7 +232,7 @@
     gap: var(--space-2);
     font-size: var(--fz-meta);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .remember small {
@@ -253,7 +253,7 @@
     background: transparent;
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .cancel:hover {
     background: var(--surface-hover);
@@ -268,7 +268,7 @@
     background: var(--accent);
     border: none;
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .go:disabled {
     opacity: 0.5;

--- a/frontend/src/components/settings/SegmentedSetting.svelte
+++ b/frontend/src/components/settings/SegmentedSetting.svelte
@@ -54,7 +54,7 @@
     color: var(--text-secondary);
     padding: var(--space-2) var(--space-4);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   button:last-child {

--- a/frontend/src/components/settings/SettingsPanel.svelte
+++ b/frontend/src/components/settings/SettingsPanel.svelte
@@ -92,6 +92,7 @@
     setMenuBarIcons,
     setTimeFormat,
     setReduceMotion,
+    setHandCursor,
     setThemeDarkTimes,
     setBodyFont,
     setUIFont,
@@ -165,6 +166,7 @@
     { cat: 'appearance', label: $t('settingsPanel.label.corners'), kw: 'rounded square' },
     { cat: 'appearance', label: $t('settingsPanel.label.interfaceScale'), kw: 'zoom scale size' },
     { cat: 'appearance', label: $t('settingsPanel.toggle.reduceMotion'), kw: 'animation' },
+    { cat: 'appearance', label: $t('settingsPanel.toggle.handCursor'), kw: 'cursor pointer mouse arrow hand' },
     { cat: 'appearance', label: $t('settingsPanel.label.emptyStateImage'), kw: 'background image empty' },
     { cat: 'menubar', label: $t('settingsPanel.toggle.menuBarInApp'), kw: 'menu bar' },
     { cat: 'menubar', label: $t('settingsPanel.toggle.menuBarNativeMinimal'), kw: 'menu bar native' },
@@ -810,6 +812,15 @@
             />
           </div>
           <p class="hint">{$t('settingsPanel.hint.reduceMotion')}</p>
+          <div class="toggle">
+            <span class="row-label">{$t('settingsPanel.toggle.handCursor')}</span>
+            <ToggleSwitch
+              checked={$prefs.handCursor}
+              label={$t('settingsPanel.toggle.handCursor')}
+              on:change={(e) => setHandCursor(e.detail)}
+            />
+          </div>
+          <p class="hint">{$t('settingsPanel.hint.handCursor')}</p>
 
           <div class="field">
             <span class="row-label">{$t('settingsPanel.label.emptyStateImage')}</span>
@@ -1581,6 +1592,9 @@
     display: flex;
     flex-direction: column;
     background: var(--surface-base);
+    /* covers the whole window, so it has to keep the macOS traffic lights clear
+       itself; zero on every other platform. */
+    padding-top: var(--titlebar-lights);
   }
 
   .head {
@@ -1603,7 +1617,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }
@@ -1664,7 +1678,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 0;
   }
 
@@ -1701,7 +1715,7 @@
     background: transparent;
     border-radius: var(--radius-control);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-list);
   }
@@ -1842,7 +1856,7 @@
     background: var(--surface-raised);
     border-radius: var(--radius-control);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
   }
 
@@ -1869,7 +1883,7 @@
     color: var(--text-primary);
     font-size: var(--fz-label);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .edit-menubar:hover {
@@ -1908,7 +1922,7 @@
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-card);
     background: var(--surface-raised);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .style-card:hover {
@@ -1938,7 +1952,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .action-btn:hover {
@@ -2013,7 +2027,7 @@
     padding: var(--space-2) var(--space-4);
     border-radius: var(--radius-control);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border: var(--hairline) solid var(--border-default);
   }
 
@@ -2034,7 +2048,7 @@
     justify-content: space-between;
     gap: var(--space-4);
     padding: var(--space-2) 0;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .toggle.disabled {
@@ -2053,7 +2067,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font: inherit;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .download-row {
@@ -2081,7 +2095,7 @@
     background: var(--surface-raised);
     color: var(--text-secondary);
     font-size: var(--fz-meta);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .preset-btn:hover {
@@ -2112,7 +2126,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .lang-tool-btn:hover {

--- a/frontend/src/components/settings/ShortcutSettings.svelte
+++ b/frontend/src/components/settings/ShortcutSettings.svelte
@@ -164,7 +164,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 2px;
   }
 
@@ -179,7 +179,7 @@
     background: var(--surface-raised);
     color: var(--text-secondary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .reset-all:hover {
@@ -245,7 +245,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-meta);
   }
 

--- a/frontend/src/components/settings/SignaturesSection.svelte
+++ b/frontend/src/components/settings/SignaturesSection.svelte
@@ -265,7 +265,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -290,7 +290,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .add:hover {
@@ -349,7 +349,7 @@
     border-radius: var(--radius-control);
     border: var(--hairline) solid var(--border-default);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .ghost {

--- a/frontend/src/components/settings/StepSlider.svelte
+++ b/frontend/src/components/settings/StepSlider.svelte
@@ -86,7 +86,7 @@
     height: 4px;
     border-radius: 999px;
     background: var(--surface-hover);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   input[type='range']:focus-visible {

--- a/frontend/src/components/settings/TechToggles.svelte
+++ b/frontend/src/components/settings/TechToggles.svelte
@@ -53,7 +53,7 @@
     justify-content: space-between;
     gap: var(--space-4);
     padding: var(--space-2) 0;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .text {

--- a/frontend/src/components/settings/ThemeEditorModal.svelte
+++ b/frontend/src/components/settings/ThemeEditorModal.svelte
@@ -353,7 +353,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -416,7 +416,7 @@
     background: transparent;
     color: var(--text-secondary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .segmented button.on {
@@ -476,7 +476,7 @@
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .css {
@@ -522,7 +522,7 @@
     background: transparent;
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .ghost-btn:hover {
@@ -536,7 +536,7 @@
     background: var(--accent);
     color: var(--accent-fg);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .primary-btn:disabled {

--- a/frontend/src/components/settings/ThemeImportModal.svelte
+++ b/frontend/src/components/settings/ThemeImportModal.svelte
@@ -201,7 +201,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -279,7 +279,7 @@
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
     color: var(--text-secondary);
   }
@@ -348,7 +348,7 @@
     padding: var(--space-1) 0;
     font-size: var(--fz-label);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .parts {
@@ -387,7 +387,7 @@
     background: transparent;
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .ghost-btn:hover {
@@ -401,7 +401,7 @@
     background: var(--accent);
     color: var(--accent-fg);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .primary-btn:disabled {

--- a/frontend/src/components/settings/ThemesSection.svelte
+++ b/frontend/src/components/settings/ThemesSection.svelte
@@ -297,7 +297,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .action-btn:hover {
@@ -322,7 +322,7 @@
   }
 
   button.card {
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .card.active {
@@ -336,7 +336,7 @@
     border: none;
     background: none;
     padding: 0;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
   }
 
@@ -426,7 +426,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/settings/ToastPositionPicker.svelte
+++ b/frontend/src/components/settings/ToastPositionPicker.svelte
@@ -76,7 +76,7 @@
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
     background: var(--surface-sunken);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 4px;
   }
 

--- a/frontend/src/components/settings/VIPSendersModal.svelte
+++ b/frontend/src/components/settings/VIPSendersModal.svelte
@@ -152,7 +152,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -192,7 +192,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .add-btn:hover:not(:disabled) {
     background: var(--surface-hover);
@@ -247,7 +247,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2);
     border-radius: var(--radius-control);
   }

--- a/frontend/src/components/settings/ViewEditorModal.svelte
+++ b/frontend/src/components/settings/ViewEditorModal.svelte
@@ -307,7 +307,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
     padding: var(--space-1);
   }
@@ -395,7 +395,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: 0;
   }
 
@@ -443,7 +443,7 @@
     background: transparent;
     color: var(--text-secondary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .icon-cell:hover {
@@ -467,7 +467,7 @@
     border-radius: 999px;
     border: 2px solid transparent;
     background: var(--sw);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .swatch.on {
@@ -486,7 +486,7 @@
     gap: var(--space-2);
     font-size: var(--fz-label);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .btn {
@@ -494,7 +494,7 @@
     border-radius: var(--radius-control);
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border: var(--hairline) solid var(--border-default);
   }
 

--- a/frontend/src/components/sidebar/AccountTree.svelte
+++ b/frontend/src/components/sidebar/AccountTree.svelte
@@ -121,7 +121,7 @@
     padding: var(--space-2) var(--space-3);
     border: none;
     background: transparent;
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     border-radius: var(--radius-control);
   }
@@ -141,7 +141,7 @@
     background: transparent;
     color: var(--text-tertiary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     opacity: 0;
   }
 

--- a/frontend/src/components/sidebar/FolderDialog.svelte
+++ b/frontend/src/components/sidebar/FolderDialog.svelte
@@ -267,7 +267,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-1);
     border-radius: var(--radius-control);
   }
@@ -314,7 +314,7 @@
     gap: var(--space-2);
     padding: var(--space-2) var(--space-3);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .role:hover {
     background: var(--surface-hover);
@@ -371,7 +371,7 @@
     background: transparent;
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .cancel:hover {
     background: var(--surface-hover);
@@ -386,7 +386,7 @@
     background: var(--accent);
     border: none;
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
   .go.danger {
     color: var(--text-inverse);

--- a/frontend/src/components/sidebar/SavedViews.svelte
+++ b/frontend/src/components/sidebar/SavedViews.svelte
@@ -155,7 +155,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-list);
     line-height: 1.2;
@@ -215,7 +215,7 @@
     background: transparent;
     color: var(--text-tertiary);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .act:hover {
@@ -238,7 +238,7 @@
     color: var(--text-tertiary);
     font-size: var(--fz-list);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .new:hover {

--- a/frontend/src/components/sidebar/Sidebar.svelte
+++ b/frontend/src/components/sidebar/Sidebar.svelte
@@ -145,7 +145,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-weight: var(--fw-medium);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .compose-btn:hover {
@@ -162,7 +162,7 @@
     border-radius: var(--radius-control);
     background: var(--surface-raised);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .sync-btn:hover {
@@ -211,7 +211,7 @@
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
     border-radius: var(--radius-control);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .tabs button:hover {
@@ -235,7 +235,7 @@
     background: var(--surface-raised);
     color: var(--text-primary);
     font-size: var(--fz-label);
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .add-mailbox:hover {

--- a/frontend/src/components/sidebar/SidebarRow.svelte
+++ b/frontend/src/components/sidebar/SidebarRow.svelte
@@ -128,7 +128,7 @@
     border: none;
     background: transparent;
     color: var(--text-tertiary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -150,7 +150,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
     font-size: var(--fz-list);
     line-height: 1.2;

--- a/frontend/src/components/wizard/AddMailboxWizard.svelte
+++ b/frontend/src/components/wizard/AddMailboxWizard.svelte
@@ -480,6 +480,9 @@
     display: flex;
     flex-direction: column;
     background: var(--surface-base);
+    /* covers the whole window, so it has to keep the macOS traffic lights clear
+       itself; zero on every other platform. */
+    padding-top: var(--titlebar-lights);
   }
 
   .head {
@@ -504,7 +507,7 @@
     border: none;
     background: transparent;
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     border-radius: var(--radius-control);
   }
 
@@ -573,7 +576,7 @@
     font-size: var(--fz-label);
     font-weight: var(--fw-medium);
     text-decoration: underline;
-    cursor: pointer;
+    cursor: var(--cursor-action);
   }
 
   .field {
@@ -619,7 +622,7 @@
     border: none;
     background: transparent;
     color: var(--accent);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
     padding: var(--space-1) 0;
     margin-bottom: var(--space-2);
@@ -658,7 +661,7 @@
     border: none;
     background: var(--surface-raised);
     color: var(--text-secondary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     padding: var(--space-2) var(--space-4);
     font-size: var(--fz-label);
   }
@@ -691,7 +694,7 @@
     padding: var(--space-2) var(--space-5);
     border-radius: var(--radius-control);
     border: var(--hairline) solid var(--border-default);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     font-size: var(--fz-label);
   }
 

--- a/frontend/src/components/wizard/WizardProviders.svelte
+++ b/frontend/src/components/wizard/WizardProviders.svelte
@@ -69,7 +69,7 @@
     border-radius: var(--radius-card);
     background: var(--surface-raised);
     color: var(--text-primary);
-    cursor: pointer;
+    cursor: var(--cursor-action);
     text-align: left;
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -806,6 +806,13 @@ export function closeWindow(): void {
   void App.CloseWindow()
 }
 
+// titleBarDoubleClick runs the system's title-bar double-click action (zoom,
+// minimise or nothing). Needed because the app draws its own title bar on
+// macOS, so the window server never sees the click.
+export function titleBarDoubleClick(): void {
+  void App.TitleBarDoubleClick()
+}
+
 // setWindowTheme matches the native window chrome (the Windows caption bar) to
 // the resolved ui theme. No-op on macOS/Linux.
 export function setWindowTheme(dark: boolean): void {
@@ -902,6 +909,7 @@ export const SettingKeys = {
   menuBarNewItems: 'menu_bar_new_items',
   timeFormat: 'time_format',
   reduceMotion: 'reduce_motion',
+  handCursor: 'hand_cursor',
   themeDarkStart: 'theme_dark_start',
   themeDarkEnd: 'theme_dark_end',
   bodyFont: 'body_font',

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -1135,6 +1135,8 @@ const de: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24 Stunden',
   'settingsPanel.toggle.reduceMotion': 'Bewegung reduzieren',
   'settingsPanel.hint.reduceMotion': 'Schaltet Animationen und Übergänge der Oberfläche aus. Die Systemeinstellung für reduzierte Bewegung wird automatisch berücksichtigt.',
+  'settingsPanel.toggle.handCursor': 'Handzeiger auf Schaltflächen',
+  'settingsPanel.hint.handCursor': 'Zeigt über Schaltflächen, Zeilen und Tabs den Handzeiger statt des normalen Pfeils. Links behalten die Hand immer.',
   'settingsPanel.theme.schedule': 'Zeitgesteuert',
   'settingsPanel.label.darkFrom': 'Dunkel ab',
   'settingsPanel.label.darkUntil': 'Bis',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -1135,6 +1135,8 @@ const en: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24-hour',
   'settingsPanel.toggle.reduceMotion': 'Reduce motion',
   'settingsPanel.hint.reduceMotion': 'Turns off interface animations and transitions. Also follows your system\'s reduced-motion preference automatically.',
+  'settingsPanel.toggle.handCursor': 'Hand cursor on buttons',
+  'settingsPanel.hint.handCursor': 'Shows the hand pointer over buttons, rows and tabs instead of the normal arrow. Links always keep the hand.',
   'settingsPanel.theme.schedule': 'Scheduled',
   'settingsPanel.label.darkFrom': 'Dark from',
   'settingsPanel.label.darkUntil': 'Until',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -1135,6 +1135,8 @@ const es: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24 horas',
   'settingsPanel.toggle.reduceMotion': 'Reducir el movimiento',
   'settingsPanel.hint.reduceMotion': 'Desactiva las animaciones y transiciones de la interfaz. La preferencia del sistema de movimiento reducido también se sigue automáticamente.',
+  'settingsPanel.toggle.handCursor': 'Cursor de mano en los botones',
+  'settingsPanel.hint.handCursor': 'Muestra el cursor de mano sobre botones, filas y pestañas en lugar de la flecha normal. Los enlaces siempre conservan la mano.',
   'settingsPanel.theme.schedule': 'Programado',
   'settingsPanel.label.darkFrom': 'Oscuro desde',
   'settingsPanel.label.darkUntil': 'Hasta',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -1135,6 +1135,8 @@ const fr: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24 heures',
   'settingsPanel.toggle.reduceMotion': 'Réduire les animations',
   'settingsPanel.hint.reduceMotion': 'Désactive les animations et transitions de l\'interface. La préférence système de réduction des animations est aussi suivie automatiquement.',
+  'settingsPanel.toggle.handCursor': 'Curseur main sur les boutons',
+  'settingsPanel.hint.handCursor': 'Affiche le curseur main sur les boutons, les lignes et les onglets au lieu de la flèche habituelle. Les liens gardent toujours la main.',
   'settingsPanel.theme.schedule': 'Programmé',
   'settingsPanel.label.darkFrom': 'Sombre à partir de',
   'settingsPanel.label.darkUntil': 'Jusqu\'à',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -1135,6 +1135,8 @@ const nl: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24 uur',
   'settingsPanel.toggle.reduceMotion': 'Beweging verminderen',
   'settingsPanel.hint.reduceMotion': 'Schakelt animaties en overgangen van de interface uit. De systeemvoorkeur voor verminderde beweging wordt ook automatisch gevolgd.',
+  'settingsPanel.toggle.handCursor': 'Handcursor op knoppen',
+  'settingsPanel.hint.handCursor': 'Toont de handcursor boven knoppen, rijen en tabbladen in plaats van de gewone pijl. Links houden altijd de hand.',
   'settingsPanel.theme.schedule': 'Gepland',
   'settingsPanel.label.darkFrom': 'Donker vanaf',
   'settingsPanel.label.darkUntil': 'Tot',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -1088,6 +1088,8 @@ const pl: Record<string, string> = {
   'settingsPanel.timeFormat.h24': '24-godzinny',
   'settingsPanel.toggle.reduceMotion': 'Ogranicz ruch',
   'settingsPanel.hint.reduceMotion': 'Wyłącza animacje i przejścia interfejsu. Podąża też automatycznie za systemowym ustawieniem ograniczenia ruchu.',
+  'settingsPanel.toggle.handCursor': 'Kursor dłoni na przyciskach',
+  'settingsPanel.hint.handCursor': 'Pokazuje kursor dłoni nad przyciskami, wierszami i kartami zamiast zwykłej strzałki. Odnośniki zawsze zachowują dłoń.',
   'settingsPanel.theme.schedule': 'Zaplanowany',
   'settingsPanel.label.darkFrom': 'Ciemny od',
   'settingsPanel.label.darkUntil': 'Do',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -355,6 +355,9 @@ export interface UIPrefs {
   timeFormat: string
   // reduceMotion disables ui transitions and animations.
   reduceMotion: boolean
+  // handCursor shows the browser hand over clickable chrome instead of the
+  // native arrow. Hyperlinks keep the hand regardless.
+  handCursor: boolean
   // themeDarkStart/themeDarkEnd bound the dark window ("HH:MM") for the
   // schedule theme mode.
   themeDarkStart: string

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -7,7 +7,7 @@
 import { writable } from 'svelte/store'
 import type { UIPrefs, ThemePref, DensityPref, EditorMode, ViewsPlacement, CloseAction, LogLevel } from '../lib/types'
 import { getUIPrefs, setSetting, SettingKeys, systemColorScheme, setWindowTheme, getThemeApply } from '../lib/api'
-import { applyTheme, applyDensity, applyAccent, applyScale, applyReduceMotion, setThemeSchedule, applyUIFont, applyMonoFont, applyCorners, watchSystemTheme, setSystemSchemeOverride, resolveTheme } from '../theme/theme'
+import { applyTheme, applyDensity, applyAccent, applyScale, applyReduceMotion, applyHandCursor, setThemeSchedule, applyUIFont, applyMonoFont, applyCorners, watchSystemTheme, setSystemSchemeOverride, resolveTheme } from '../theme/theme'
 import { applyUserTheme } from '../theme/usertheme'
 import { uiFontStack, monoFontStack } from '../lib/fonts'
 import { setLocale } from '../lib/i18n'
@@ -69,6 +69,7 @@ const defaults: UIPrefs = {
   menuBarIcons: false,
   timeFormat: 'auto',
   reduceMotion: false,
+  handCursor: false,
   themeDarkStart: '19:00',
   themeDarkEnd: '07:00',
   bodyFont: 'default',
@@ -103,6 +104,7 @@ function applyAll(p: UIPrefs): void {
   applyAccent(p.accent)
   applyScale(p.uiScale)
   applyReduceMotion(p.reduceMotion)
+  applyHandCursor(p.handCursor)
   applyUIFont(uiFontStack(p.uiFont))
   applyMonoFont(monoFontStack(p.monoFont))
   applyCorners(p.cornerStyle)
@@ -413,6 +415,14 @@ export function setReduceMotion(value: boolean): void {
   prefs.update((p) => ({ ...p, reduceMotion: value }))
   applyReduceMotion(value)
   void setSetting(SettingKeys.reduceMotion, String(value))
+}
+
+// setHandCursor switches clickable chrome between the native arrow and the
+// browser hand.
+export function setHandCursor(value: boolean): void {
+  prefs.update((p) => ({ ...p, handCursor: value }))
+  applyHandCursor(value)
+  void setSetting(SettingKeys.handCursor, String(value))
 }
 
 // setUIFont / setMonoFont override the interface and monospace font tokens,

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -130,6 +130,17 @@ export function applyReduceMotion(on: boolean): void {
   }
 }
 
+// applyHandCursor switches the cursor shown over buttons, rows and other
+// clickable chrome from the native arrow to the browser hand. Hyperlinks keep
+// the hand either way, so the two stay distinguishable.
+export function applyHandCursor(on: boolean): void {
+  if (on) {
+    document.documentElement.setAttribute('data-cursor', 'hand')
+  } else {
+    document.documentElement.removeAttribute('data-cursor')
+  }
+}
+
 // applyScale zooms the whole interface by a string multiplier ("1" = 100%).
 // zoom (rather than a root font-size) scales the px-based tokens and layout
 // together, and is supported in both WKWebView and WebView2. an invalid or

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -63,6 +63,20 @@
   /* borders are hairlines throughout. */
   --hairline: 0.5px;
 
+  /* cursor shown over anything clickable that is not a hyperlink. native
+     desktop apps use the arrow there, browsers use the hand; the appearance
+     setting flips this on the root, see :root[data-cursor="hand"] below. */
+  --cursor-action: default;
+
+  /* how much room the macos traffic lights need at the top left of a window
+     with no native title bar: --titlebar-lights vertically, --titlebar-inset
+     from the left edge. zero everywhere else, see :root[data-titlebar="mac"]. */
+  --titlebar-lights: 0px;
+  --titlebar-inset: 0px;
+  /* how far the menu bar's labels lift off their centre line to sit level with
+     the traffic lights, which the system draws slightly above it. */
+  --titlebar-nudge: 0px;
+
   /* accent. --accent and --accent-fg are overwritten at runtime by accent.ts.
      the derivations below stay in css so they track whatever accent is set. */
   --accent: #465af2;
@@ -197,4 +211,21 @@
 :root[data-corners="round"] {
   --radius-control: 10px;
   --radius-card: 12px;
+}
+
+/* cursor variant. the default is the arrow on every platform, matching native
+   apps; this brings back the browser hand for anyone who prefers it. */
+:root[data-cursor="hand"] {
+  --cursor-action: pointer;
+}
+
+/* macos only, set by App.svelte: the window has no native title bar, so the ui
+   leaves room for the traffic lights at the top left. the lights are drawn by
+   the system at a fixed size, so both values are divided by the interface scale
+   to cancel out the css zoom applyScale puts on the root; without that they
+   would overshoot above 100% and slide under the lights below it. */
+:root[data-titlebar="mac"] {
+  --titlebar-lights: calc(28px / var(--ui-scale, 1));
+  --titlebar-inset: calc(78px / var(--ui-scale, 1));
+  --titlebar-nudge: calc(3px / var(--ui-scale, 1));
 }

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -290,6 +290,8 @@ export function TestConnection(arg1:desktop.TestConnectionRequest):Promise<void>
 
 export function TestProxy(arg1:desktop.ProxyConfigDTO):Promise<void>;
 
+export function TitleBarDoubleClick():Promise<void>;
+
 export function TriggerSync():Promise<void>;
 
 export function TrustSenderImages(arg1:number):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -578,6 +578,10 @@ export function TestProxy(arg1) {
   return window['go']['desktop']['App']['TestProxy'](arg1);
 }
 
+export function TitleBarDoubleClick() {
+  return window['go']['desktop']['App']['TitleBarDoubleClick']();
+}
+
 export function TriggerSync() {
   return window['go']['desktop']['App']['TriggerSync']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1382,6 +1382,7 @@ export namespace desktop {
 	    menuBarIcons: boolean;
 	    timeFormat: string;
 	    reduceMotion: boolean;
+	    handCursor: boolean;
 	    themeDarkStart: string;
 	    themeDarkEnd: string;
 	    bodyFont: string;
@@ -1458,6 +1459,7 @@ export namespace desktop {
 	        this.menuBarIcons = source["menuBarIcons"];
 	        this.timeFormat = source["timeFormat"];
 	        this.reduceMotion = source["reduceMotion"];
+	        this.handCursor = source["handCursor"];
 	        this.themeDarkStart = source["themeDarkStart"];
 	        this.themeDarkEnd = source["themeDarkEnd"];
 	        this.bodyFont = source["bodyFont"];

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -82,6 +82,9 @@ const (
 	// disable ui transitions and animations (the os-level preference is
 	// honored by the frontend css regardless).
 	settingReduceMotion = "reduce_motion"
+	// show the browser hand over clickable chrome instead of the native arrow.
+	// hyperlinks keep the hand either way.
+	settingHandCursor = "hand_cursor"
 	// dark window bounds ("HH:MM") for the schedule theme mode.
 	settingThemeDarkStart = "theme_dark_start"
 	settingThemeDarkEnd   = "theme_dark_end"
@@ -289,6 +292,9 @@ type UIPrefsDTO struct {
 	TimeFormat string `json:"timeFormat"`
 	// ReduceMotion disables ui transitions and animations.
 	ReduceMotion bool `json:"reduceMotion"`
+	// HandCursor shows the browser hand over clickable chrome instead of the
+	// native arrow.
+	HandCursor bool `json:"handCursor"`
 	// ThemeDarkStart/ThemeDarkEnd bound the dark window ("HH:MM") for the
 	// schedule theme mode.
 	ThemeDarkStart string `json:"themeDarkStart"`
@@ -391,6 +397,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 		MenuBarIcons:               a.boolSetting(settingMenuBarIcons, false),
 		TimeFormat:                 a.stringSetting(settingTimeFormat, "auto"),
 		ReduceMotion:               a.boolSetting(settingReduceMotion, false),
+		HandCursor:                 a.boolSetting(settingHandCursor, false),
 		ThemeDarkStart:             a.stringSetting(settingThemeDarkStart, "19:00"),
 		ThemeDarkEnd:               a.stringSetting(settingThemeDarkEnd, "07:00"),
 		BodyFont:                   a.stringSetting(settingBodyFont, "default"),

--- a/internal/desktop/bind_window.go
+++ b/internal/desktop/bind_window.go
@@ -11,3 +11,19 @@ func (a *App) SetWindowTitle(title string) {
 	}
 	runtime.WindowSetTitle(a.ctx, title)
 }
+
+// TitleBarDoubleClick runs the system's title-bar double-click action. On macOS
+// the app draws its own title bar, so the window server never sees the click
+// and cannot act on it; the frontend forwards it here instead. A no-op on every
+// other platform, where the native frame handles it.
+func (a *App) TitleBarDoubleClick() {
+	if a.ctx == nil {
+		return
+	}
+	switch titleBarDoubleClickAction() {
+	case "maximize":
+		runtime.WindowToggleMaximise(a.ctx)
+	case "minimize":
+		runtime.WindowMinimise(a.ctx)
+	}
+}

--- a/internal/desktop/run.go
+++ b/internal/desktop/run.go
@@ -107,6 +107,15 @@ func Run(cfg Config) error {
 			},
 		},
 		Mac: &mac.Options{
+			// draw the ui all the way to the top of the window instead of under an
+			// opaque native title bar, which never matches the theme. the frontend
+			// keeps the top strip clear of the traffic lights and makes it draggable
+			// (see the mac-titlebar handling in App.svelte).
+			//
+			// hidden, not hidden-inset: the inset variant asks for an NSToolbar,
+			// and the toolbar makes the title bar taller, which drops the traffic
+			// lights below the middle of the 30px menu bar row they share.
+			TitleBar: mac.TitleBarHidden(),
 			About: &mac.AboutInfo{
 				Title:   title,
 				Message: aboutMessage(cfg.Channel, cfg.Version),

--- a/internal/desktop/titlebaraction_darwin.go
+++ b/internal/desktop/titlebaraction_darwin.go
@@ -1,0 +1,41 @@
+//go:build darwin
+
+package desktop
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation
+#include <stdlib.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+// peltonDoubleClickAction copies the global AppleActionOnDoubleClick preference
+// into buf, returning 1 on success and 0 when the key is unset or not a string.
+// The setting lives in the global domain, hence kCFPreferencesAnyApplication.
+static int peltonDoubleClickAction(char *buf, int len) {
+    CFPropertyListRef v = CFPreferencesCopyAppValue(CFSTR("AppleActionOnDoubleClick"),
+                                                    kCFPreferencesAnyApplication);
+    if (v == NULL) {
+        return 0;
+    }
+    int ok = 0;
+    if (CFGetTypeID(v) == CFStringGetTypeID()) {
+        ok = CFStringGetCString((CFStringRef)v, buf, len, kCFStringEncodingUTF8) ? 1 : 0;
+    }
+    CFRelease(v);
+    return ok;
+}
+*/
+import "C"
+
+import "strings"
+
+// titleBarDoubleClickAction reports what System Settings' "double-click a
+// window's title bar to" is set to, lowercased: "maximize", "minimize" or
+// "none". macOS leaves the key unset until it is changed, and unset means
+// Maximize.
+func titleBarDoubleClickAction() string {
+	var buf [32]C.char
+	if C.peltonDoubleClickAction(&buf[0], C.int(len(buf))) == 0 {
+		return "maximize"
+	}
+	return strings.ToLower(C.GoString(&buf[0]))
+}

--- a/internal/desktop/titlebaraction_other.go
+++ b/internal/desktop/titlebaraction_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package desktop
+
+// Only macOS has the app draw its own title bar, and only macOS has a system
+// setting for what double-clicking one does. Everywhere else the window keeps
+// its native frame and the system handles the click itself.
+
+func titleBarDoubleClickAction() string {
+	return "none"
+}


### PR DESCRIPTION
Closes #234.

Three separate complaints in that issue, plus one regression this branch created and then fixed.

## Window frame

`run.go` sets `mac.TitleBarHidden()`, so the app draws to the top edge instead of sitting under an opaque grey bar that never matched the theme.

Not `TitleBarHiddenInset()`, which was the first attempt: the inset variant sets `UseToolbar: true`, and the toolbar makes the title bar taller, which drops the traffic lights below the middle of the row they share with the menu bar. Hidden keeps the standard 28px frame, so the lights line up and the reserved strip matches the frame they are drawn in.

Two tokens carry it, both `0px` off macOS so nothing else changes: `--titlebar-lights` for the vertical strip and `--titlebar-inset` for how far the lights reach in from the left. Both are divided by `--ui-scale`, since the lights are drawn by the system at a fixed size while everything else follows the interface-scale zoom. Without that they overshoot above 100% and slide under the lights below it.

Where the strip comes from depends on the menu bar:

- **Menu bar on**: the bar is the title bar. It starts past the lights and is the drag handle, with `no-drag` on the titles and dropdowns. No second empty strip above it.
- **Menu bar off** (the macOS default): an empty row in the shell, plus a fixed drag strip above every overlay, so the window is still draggable while settings or onboarding is open.

Full-window surfaces reserve the strip themselves, because `position: fixed` resolves against the viewport and ignores any padding further up: `SettingsPanel`, `AddMailboxWizard`, `Onboarding`, fullscreen compose, and the three top-anchored toast positions.

Fullscreen hides the traffic lights, so the strip goes with them. Wails has no hook for entering or leaving fullscreen, so this checks `WindowIsFullscreen()` on window resize, which is the only event that can accompany the change.

## Setup animations

The jump was the old step fading out over 120ms against the new one flying in from `x: ±36` after a 90ms delay, on a stage that was animating its own `max-width` underneath. Now one 120ms fade in and no out transition, so the stage resizes while the incoming step is still transparent. The per-element fly stagger on the welcome and done text and on the features list is gone, along with the `max-width` transition. The logo and the done checkmark keep their scale-in; those are transforms and move no layout.

## Cursors

New `--cursor-action` token: `default` normally, `pointer` under `:root[data-cursor="hand"]`. 184 `cursor: pointer` declarations across 66 components now reference it.

Default is the arrow on every platform, which is what Finder, Explorer and GTK apps all use. `Hand cursor on buttons` in Appearance brings the old behaviour back. There are no `<a>` elements in the app chrome (external links go through `BrowserOpenURL` on buttons), so this only ever affects chrome; links inside rendered mail keep the hand from the browser default.

## Double-click to zoom

A regression this branch introduced: the drag strip replaced the native title bar, and Wails' drag handler bails on `e.detail !== 1` with no double-click handling anywhere in the runtime, so the click was swallowed.

`TitleBarDoubleClick()` reads the real `AppleActionOnDoubleClick` setting through `CFPreferencesCopyAppValue` rather than assuming zoom, so Minimize and Do Nothing are honoured too. Unset means Maximize, which is macOS's own default. Wired to the drag strip and to the menu bar's empty space.

While a menu is open the bar stops being a drag handle, and a click on its own empty space dismisses the menu. The dismiss scrim sits below the bar, so it never saw those clicks, and that space is wide now that the bar spans the title bar.

## Verification

`go build`, `go vet`, `go test ./internal/...`, `pnpm run check` at 0 errors and 0 warnings, and a clean frontend build.

Not verifiable from here, and worth a look on Windows and Linux: both keep a native frame and every new token is `0px` there, but the cursor change and the menu bar's 12px to 13px label bump apply everywhere.
