### PR TITLE
feat: use the platform's own scrollbars

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -81,23 +81,19 @@ a:hover {
   border-radius: var(--radius-control);
 }
 
-/* thin, theme-aware scrollbars. */
-::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-}
+/* scrollbars are the platform's own, not painted here: macOS fades its overlay
+   bars out when idle, Windows and Linux draw theirs. a 10px bar of our own
+   design, always visible, is a web page's scrollbar rather than a desktop
+   app's. light and dark come from color-scheme on the theme, already set.
 
-::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
-  border-radius: 999px;
-  border: 3px solid transparent;
-  background-clip: padding-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--text-tertiary);
-  background-clip: padding-box;
-  border: 3px solid transparent;
+   the one thing asked of them is a narrower width. macOS falls back to the wide
+   legacy scrollbar whenever a mouse is connected, whatever the "show scroll
+   bars" setting says, and that is wide enough to crowd the message list.
+   scrollbar-width leaves the system's own colors and behaviour alone, unlike
+   scrollbar-color, which would opt the scroller out of native rendering
+   entirely. it does not inherit, hence the universal selector. */
+* {
+  scrollbar-width: thin;
 }
 
 /* allow real text selection inside rendered mail bodies and editors. */


### PR DESCRIPTION
Closes #244.

`style.css` painted every scrollbar in the app: a 10px track with a rounded `--border-strong` thumb, always visible, on every scrollable pane. No desktop app does that, and it sits next to the message list where it shows constantly.

Deleting the three `::-webkit-scrollbar` rules hands them back to the platform: macOS draws the overlay bars that fade out when idle and follow the system "show scroll bars" setting, Windows and Linux draw their own.

Light and dark need no extra code. `color-scheme` is already declared on both theme blocks, so the platform picks the matching scrollbar on its own.

## Width

Unstyled alone was too wide in practice. macOS falls back to the wide legacy scrollbar whenever a mouse is connected, whatever the "show scroll bars" setting says, and next to the message list that crowds the layout.

`scrollbar-width: thin` narrows it without taking the scrollbar over: the system keeps its own colors and behaviour, and the property is ignored where it is unsupported, which degrades to what this branch already did. The universal selector is because it does not inherit.

What is deliberately *not* used is `scrollbar-color`, which was in the original plan to keep the theme tint. That one opts the scroller out of native rendering, which would have reintroduced a bar of our own design while looking like a fix.

Nothing is lost by dropping the tint. Scrollbars were never themeable: the allowlist in `docs/themes/format.md` covers surfaces, text, borders, accent, semantics, radii, fonts, type and elevation, and none of it reaches scroll chrome. `--border-strong` is still used by the accent picker and the rich editor, so the token stays.

## Verification

`pnpm run check` at 0 errors and 0 warnings, clean build.

Worth a look when testing, since I can only see macOS here: Windows 11 should give the thin fluent bar that widens on hover, and Linux gets whatever WebKitGTK draws by default, which is the one I am least sure reads as native.
