### PR TITLE
feat: remember the window size and position across launches

### DIFF
--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -146,6 +146,10 @@ func (a *App) startup(ctx context.Context) {
 	a.loadProxy()
 	close(a.storeReady)
 
+	// as early as the store allows, so the window settles at its remembered size
+	// before the frontend has painted anything into it.
+	a.restoreGeometry()
+
 	// the Windows tray icon (no-op elsewhere). started after the store is up
 	// so its menu labels can follow the language setting.
 	a.startTray()
@@ -206,6 +210,8 @@ func (a *App) domReady(ctx context.Context) {
 // shutdown is the wails OnShutdown hook. It closes the store so the sqlite wal
 // is checkpointed cleanly.
 func (a *App) shutdown(ctx context.Context) {
+	// before the store closes, and before anything else can fail on the way out.
+	a.saveGeometry()
 	a.stopTray()
 	a.stopMCP()
 	if a.index != nil {

--- a/internal/desktop/geometry.go
+++ b/internal/desktop/geometry.go
@@ -1,0 +1,177 @@
+package desktop
+
+import (
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// window geometry remembered across launches, so Pelton reopens at the size it
+// was left at rather than the same default every time.
+const (
+	settingWindowWidth     = "window_width"
+	settingWindowHeight    = "window_height"
+	settingWindowX         = "window_x"
+	settingWindowY         = "window_y"
+	settingWindowMaximised = "window_maximised"
+)
+
+// the window defaults, also the fallback whenever nothing usable is stored.
+const (
+	defaultWindowWidth  = 1280
+	defaultWindowHeight = 820
+	minWindowWidth      = 900
+	minWindowHeight     = 600
+)
+
+// onScreenMargin is how much of the window has to land on the screen for a
+// remembered position to be worth restoring. Enough that the title bar stays
+// grabbable rather than the window sitting one pixel inside the corner.
+const onScreenMargin = 120
+
+// geometry is a remembered window frame. Placed is false when no position was
+// stored or the stored one is not usable, in which case the platform picks.
+type geometry struct {
+	Width     int
+	Height    int
+	X         int
+	Y         int
+	Placed    bool
+	Maximised bool
+}
+
+// fitGeometry clamps a remembered frame to something the current screen can
+// actually show. Size is bounded by the app's minimum and the screen; position
+// is dropped, rather than corrected, when it would put the window somewhere the
+// user cannot reach it.
+//
+// The position check is deliberately conservative. Wails' ScreenGetAll reports
+// each screen's size but not where it sits in the desktop's coordinate space,
+// so there is no way to tell whether an off-primary position belongs to a
+// monitor that is still attached. Rather than risk restoring a window onto a
+// display that has been unplugged, anything outside the current screen is
+// treated as not usable and the platform places the window instead. The cost is
+// that a window left on a second monitor comes back on the first one.
+func fitGeometry(g geometry, screenW, screenH int) geometry {
+	out := g
+
+	if screenW <= 0 || screenH <= 0 {
+		// no usable screen reading: keep the size, drop the position.
+		out.Placed = false
+		out.Width = clamp(out.Width, minWindowWidth, defaultWindowWidth)
+		out.Height = clamp(out.Height, minWindowHeight, defaultWindowHeight)
+		return out
+	}
+
+	out.Width = clamp(out.Width, minWindowWidth, screenW)
+	out.Height = clamp(out.Height, minWindowHeight, screenH)
+
+	if !out.Placed {
+		return out
+	}
+	// far enough onto the screen in both directions to be grabbable, and not
+	// past its edges. negative coordinates mean another monitor, which is the
+	// case this cannot verify.
+	if out.X < 0 || out.Y < 0 ||
+		out.X > screenW-onScreenMargin || out.Y > screenH-onScreenMargin {
+		out.Placed = false
+	}
+	return out
+}
+
+// clamp bounds v to [lo, hi], falling back to lo when the range is inverted
+// (a screen smaller than the app's own minimum).
+func clamp(v, lo, hi int) int {
+	if hi < lo {
+		return lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// savedGeometry reads the remembered frame. A zero width or height means
+// nothing usable is stored, so the caller leaves the window alone.
+func (a *App) savedGeometry() geometry {
+	g := geometry{
+		Width:     a.intSetting(settingWindowWidth, 0),
+		Height:    a.intSetting(settingWindowHeight, 0),
+		Maximised: a.boolSetting(settingWindowMaximised, false),
+	}
+	x := a.intSetting(settingWindowX, -1)
+	y := a.intSetting(settingWindowY, -1)
+	if x >= 0 && y >= 0 {
+		g.X, g.Y, g.Placed = x, y, true
+	}
+	return g
+}
+
+// restoreGeometry applies the remembered frame to the window. Called from
+// startup, once the store is open, so the window is already on screen: the size
+// change is visible as a brief resize on launch, which is the price of the
+// settings table being the single source of truth for everything the app
+// remembers.
+func (a *App) restoreGeometry() {
+	if a.ctx == nil {
+		return
+	}
+	g := a.savedGeometry()
+	if g.Width <= 0 || g.Height <= 0 {
+		return
+	}
+
+	screenW, screenH := 0, 0
+	if screens, err := wailsruntime.ScreenGetAll(a.ctx); err == nil {
+		for _, s := range screens {
+			if s.IsCurrent {
+				screenW, screenH = s.Size.Width, s.Size.Height
+				break
+			}
+		}
+	}
+
+	g = fitGeometry(g, screenW, screenH)
+	wailsruntime.WindowSetSize(a.ctx, g.Width, g.Height)
+	if g.Placed {
+		wailsruntime.WindowSetPosition(a.ctx, g.X, g.Y)
+	} else {
+		wailsruntime.WindowCenter(a.ctx)
+	}
+	// after the size, so unmaximising lands on the remembered frame.
+	if g.Maximised {
+		wailsruntime.WindowMaximise(a.ctx)
+	}
+}
+
+// saveGeometry records the current frame. Called on shutdown, which covers
+// quitting and closing the window, since a maximised window's own size is not
+// worth storing (unmaximising would then restore to the full screen).
+func (a *App) saveGeometry() {
+	if a.ctx == nil || a.store == nil {
+		return
+	}
+	maximised := wailsruntime.WindowIsMaximised(a.ctx)
+	if err := a.store.SetBool(a.ctx, settingWindowMaximised, maximised); err != nil {
+		a.log.Error("save window maximised", "err", err)
+	}
+	if maximised {
+		return
+	}
+	w, h := wailsruntime.WindowGetSize(a.ctx)
+	x, y := wailsruntime.WindowGetPosition(a.ctx)
+	if w <= 0 || h <= 0 {
+		return
+	}
+	for key, value := range map[string]int{
+		settingWindowWidth:  w,
+		settingWindowHeight: h,
+		settingWindowX:      x,
+		settingWindowY:      y,
+	} {
+		if err := a.store.SetInt(a.ctx, key, value); err != nil {
+			a.log.Error("save window geometry", "key", key, "err", err)
+		}
+	}
+}

--- a/internal/desktop/geometry_test.go
+++ b/internal/desktop/geometry_test.go
@@ -1,0 +1,80 @@
+package desktop
+
+import "testing"
+
+func TestFitGeometry(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               geometry
+		screenW, screenH int
+		want             geometry
+	}{
+		{
+			name:    "a frame that fits is left alone",
+			in:      geometry{Width: 1000, Height: 700, X: 100, Y: 80, Placed: true},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: 1000, Height: 700, X: 100, Y: 80, Placed: true},
+		},
+		{
+			name:    "a window larger than the screen shrinks to it",
+			in:      geometry{Width: 3000, Height: 2000, X: 0, Y: 0, Placed: true},
+			screenW: 1440, screenH: 900,
+			want: geometry{Width: 1440, Height: 900, X: 0, Y: 0, Placed: true},
+		},
+		{
+			name:    "a window smaller than the minimum grows to it",
+			in:      geometry{Width: 200, Height: 100},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: minWindowWidth, Height: minWindowHeight},
+		},
+		{
+			// the unplugged-second-monitor case: a position further right than
+			// this screen goes cannot be verified, so it is dropped.
+			name:    "a position off the right of the screen is dropped",
+			in:      geometry{Width: 1000, Height: 700, X: 2400, Y: 100, Placed: true},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: 1000, Height: 700, X: 2400, Y: 100, Placed: false},
+		},
+		{
+			name:    "a negative position is dropped",
+			in:      geometry{Width: 1000, Height: 700, X: -1200, Y: 40, Placed: true},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: 1000, Height: 700, X: -1200, Y: 40, Placed: false},
+		},
+		{
+			name:    "a position too low to leave the title bar grabbable is dropped",
+			in:      geometry{Width: 1000, Height: 700, X: 100, Y: 1040, Placed: true},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: 1000, Height: 700, X: 100, Y: 1040, Placed: false},
+		},
+		{
+			name:    "an unreadable screen keeps the size and drops the position",
+			in:      geometry{Width: 1100, Height: 700, X: 10, Y: 10, Placed: true},
+			screenW: 0, screenH: 0,
+			want: geometry{Width: 1100, Height: 700, X: 10, Y: 10, Placed: false},
+		},
+		{
+			// a screen smaller than the app's own minimum: the minimum wins, so
+			// the window stays usable even if it overflows.
+			name:    "a screen below the minimum size still yields the minimum",
+			in:      geometry{Width: 1000, Height: 700},
+			screenW: 640, screenH: 480,
+			want: geometry{Width: minWindowWidth, Height: minWindowHeight},
+		},
+		{
+			name:    "the maximised flag survives clamping",
+			in:      geometry{Width: 1000, Height: 700, Maximised: true},
+			screenW: 1920, screenH: 1080,
+			want: geometry{Width: 1000, Height: 700, Maximised: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fitGeometry(tt.in, tt.screenW, tt.screenH)
+			if got != tt.want {
+				t.Errorf("fitGeometry() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/desktop/run.go
+++ b/internal/desktop/run.go
@@ -68,10 +68,12 @@ func Run(cfg Config) error {
 
 	return wails.Run(&options.App{
 		Title:     title,
-		Width:     1280,
-		Height:    820,
-		MinWidth:  900,
-		MinHeight: 600,
+		// the window opens at the default and startup resizes it to whatever was
+		// remembered, once the store is open. see geometry.go.
+		Width:     defaultWindowWidth,
+		Height:    defaultWindowHeight,
+		MinWidth:  minWindowWidth,
+		MinHeight: minWindowHeight,
 		AssetServer: &assetserver.Options{
 			Assets: cfg.Assets,
 		},


### PR DESCRIPTION
Closes #248.

Window opened at a hardcoded 1280x820 every launch. Now width, height, position and maximised go in the settings table, so they ride config export/import instead of sitting in their own file.

Saved on shutdown, restored on startup. Maximised stores only the flag, because keeping the fullscreen size would make unmaximising restore to the whole screen.

Off-screen guard: a saved position can point at a monitor that's gone. Wails' ScreenGetAll gives screen sizes but not origins, so I can't tell whether an off-primary position is still attached. Anything outside the current screen gets dropped and the window centres instead.

That means a window left on a second monitor comes back on the primary one. Safe direction to fail, but not a real answer. Doing it properly needs screen origins, so platform code.

Sizes clamped to the app minimum and the current screen. run.go's literals are now shared constants so the default and the clamp can't drift apart. fitGeometry is pure, table test covers the edge cases.

Rough edge: the window is created at the default size and resized once the store is open, so launch shows a brief resize. Avoiding it means knowing the geometry before wails.Run, and the store opens in the startup hook. StartHidden would show a blank screen through migrations on the first launch after an update, and a separate geometry file would skip export/import. If the resize is worse than it sounds, the fix is opening the store earlier, which is a bigger change than this branch should make.

go build, go vet, go test ./internal/... pass.

Not tested by running: the restore itself and the multi-monitor case. Unplug a display between launches, it should centre on the remaining screen rather than vanish.
