### PR TITLE
feat: unread badge on the dock icon

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -59,6 +59,7 @@
     openCrashReport,
     accountsNeedingPassword,
     titleBarDoubleClick,
+    setDockBadge,
   } from './lib/api'
   import { BrowserOpenURL } from '../wailsjs/runtime/runtime'
   import { liabilityAccepted } from './lib/liability'
@@ -174,6 +175,11 @@
   // the native Mail menu's message actions are only usable while a message is
   // open; keep them greyed in step with the open message.
   $: setMailActionsEnabled($openMessageId != null)
+
+  // the dock badge follows the unified inbox, which the sidebar already
+  // recomputes after a sync and after anything that changes read state, so
+  // there is no second count to keep in step.
+  $: setDockBadge($sidebar.data?.views?.find((v) => v.key === 'inbox')?.unreadCount ?? 0)
 
   // keep the native window title in sync with context: "Settings" while the
   // settings screen is open, the open message's subject when reading, otherwise

--- a/frontend/src/components/settings/SettingsPanel.svelte
+++ b/frontend/src/components/settings/SettingsPanel.svelte
@@ -48,6 +48,7 @@
     setMessageFontSize,
     setToastPosition,
     setNotifyNewMail,
+    setDockBadgeEnabled,
     setPaneLocked,
     setSendDelay,
     setFlagHighlight,
@@ -202,6 +203,7 @@
     { cat: 'signatures', label: $t('settingsPanel.category.signatures'), kw: 'signature footer' },
     { cat: 'notifications', label: $t('settings.toastPosition'), kw: 'notification position' },
     { cat: 'notifications', label: $t('vip.notifyNewMail'), kw: 'new mail notification' },
+    ...(isMac ? [{ cat: 'notifications', label: $t('settingsPanel.toggle.dockBadge'), kw: 'dock badge unread count icon' }] : []),
     { cat: 'notifications', label: $t('vip.manageLabel'), kw: 'vip senders' },
     { cat: 'gestures', label: $t('settingsPanel.toggle.swipeEnabled'), kw: 'swipe gesture' },
     { cat: 'gestures', label: $t('settingsPanel.label.swipeLeft'), kw: 'swipe left' },
@@ -1210,6 +1212,19 @@
               on:change={(e) => setNotifyNewMail(e.detail)}
             />
           </div>
+          <!-- only macOS has a dock tile to badge, so the row would be a dead
+               switch on Windows and Linux. -->
+          {#if isMac}
+            <div class="toggle">
+              <span class="row-label">{$t('settingsPanel.toggle.dockBadge')}</span>
+              <ToggleSwitch
+                checked={$prefs.dockBadge}
+                label={$t('settingsPanel.toggle.dockBadge')}
+                on:change={(e) => setDockBadgeEnabled(e.detail)}
+              />
+            </div>
+            <p class="hint">{$t('settingsPanel.hint.dockBadge')}</p>
+          {/if}
           <div class="field">
             <span class="row-label">{$t('vip.manageLabel')}</span>
             <p class="hint">{$t('vip.manageHint')}</p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -813,6 +813,11 @@ export function titleBarDoubleClick(): void {
   void App.TitleBarDoubleClick()
 }
 
+// setDockBadge puts the unread count on the dock icon. No-op off macOS.
+export function setDockBadge(unread: number): void {
+  void App.SetDockBadge(unread)
+}
+
 // setWindowTheme matches the native window chrome (the Windows caption bar) to
 // the resolved ui theme. No-op on macOS/Linux.
 export function setWindowTheme(dark: boolean): void {
@@ -910,6 +915,7 @@ export const SettingKeys = {
   timeFormat: 'time_format',
   reduceMotion: 'reduce_motion',
   handCursor: 'hand_cursor',
+  dockBadge: 'dock_badge',
   themeDarkStart: 'theme_dark_start',
   themeDarkEnd: 'theme_dark_end',
   bodyFont: 'body_font',

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -1137,6 +1137,8 @@ const de: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Schaltet Animationen und Übergänge der Oberfläche aus. Die Systemeinstellung für reduzierte Bewegung wird automatisch berücksichtigt.',
   'settingsPanel.toggle.handCursor': 'Handzeiger auf Schaltflächen',
   'settingsPanel.hint.handCursor': 'Zeigt über Schaltflächen, Zeilen und Tabs den Handzeiger statt des normalen Pfeils. Links behalten die Hand immer.',
+  'settingsPanel.toggle.dockBadge': 'Ungelesene im Dock-Symbol',
+  'settingsPanel.hint.dockBadge': 'Zeigt am App-Symbol im Dock, wie viele ungelesene Nachrichten im Posteingang liegen.',
   'settingsPanel.theme.schedule': 'Zeitgesteuert',
   'settingsPanel.label.darkFrom': 'Dunkel ab',
   'settingsPanel.label.darkUntil': 'Bis',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -1137,6 +1137,8 @@ const en: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Turns off interface animations and transitions. Also follows your system\'s reduced-motion preference automatically.',
   'settingsPanel.toggle.handCursor': 'Hand cursor on buttons',
   'settingsPanel.hint.handCursor': 'Shows the hand pointer over buttons, rows and tabs instead of the normal arrow. Links always keep the hand.',
+  'settingsPanel.toggle.dockBadge': 'Unread count on the dock icon',
+  'settingsPanel.hint.dockBadge': 'Shows how many unread messages your inbox holds, on the app icon in the dock.',
   'settingsPanel.theme.schedule': 'Scheduled',
   'settingsPanel.label.darkFrom': 'Dark from',
   'settingsPanel.label.darkUntil': 'Until',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -1137,6 +1137,8 @@ const es: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Desactiva las animaciones y transiciones de la interfaz. La preferencia del sistema de movimiento reducido también se sigue automáticamente.',
   'settingsPanel.toggle.handCursor': 'Cursor de mano en los botones',
   'settingsPanel.hint.handCursor': 'Muestra el cursor de mano sobre botones, filas y pestañas en lugar de la flecha normal. Los enlaces siempre conservan la mano.',
+  'settingsPanel.toggle.dockBadge': 'Número de no leídos en el icono del Dock',
+  'settingsPanel.hint.dockBadge': 'Muestra en el icono de la aplicación en el Dock cuántos mensajes sin leer hay en la bandeja de entrada.',
   'settingsPanel.theme.schedule': 'Programado',
   'settingsPanel.label.darkFrom': 'Oscuro desde',
   'settingsPanel.label.darkUntil': 'Hasta',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -1137,6 +1137,8 @@ const fr: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Désactive les animations et transitions de l\'interface. La préférence système de réduction des animations est aussi suivie automatiquement.',
   'settingsPanel.toggle.handCursor': 'Curseur main sur les boutons',
   'settingsPanel.hint.handCursor': 'Affiche le curseur main sur les boutons, les lignes et les onglets au lieu de la flèche habituelle. Les liens gardent toujours la main.',
+  'settingsPanel.toggle.dockBadge': 'Nombre de non lus sur l\'icône du Dock',
+  'settingsPanel.hint.dockBadge': 'Affiche sur l\'icône de l\'application dans le Dock le nombre de messages non lus dans la boîte de réception.',
   'settingsPanel.theme.schedule': 'Programmé',
   'settingsPanel.label.darkFrom': 'Sombre à partir de',
   'settingsPanel.label.darkUntil': 'Jusqu\'à',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -1137,6 +1137,8 @@ const nl: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Schakelt animaties en overgangen van de interface uit. De systeemvoorkeur voor verminderde beweging wordt ook automatisch gevolgd.',
   'settingsPanel.toggle.handCursor': 'Handcursor op knoppen',
   'settingsPanel.hint.handCursor': 'Toont de handcursor boven knoppen, rijen en tabbladen in plaats van de gewone pijl. Links houden altijd de hand.',
+  'settingsPanel.toggle.dockBadge': 'Aantal ongelezen op het Dock-pictogram',
+  'settingsPanel.hint.dockBadge': 'Toont op het app-pictogram in het Dock hoeveel ongelezen berichten in je postvak IN staan.',
   'settingsPanel.theme.schedule': 'Gepland',
   'settingsPanel.label.darkFrom': 'Donker vanaf',
   'settingsPanel.label.darkUntil': 'Tot',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -1090,6 +1090,8 @@ const pl: Record<string, string> = {
   'settingsPanel.hint.reduceMotion': 'Wyłącza animacje i przejścia interfejsu. Podąża też automatycznie za systemowym ustawieniem ograniczenia ruchu.',
   'settingsPanel.toggle.handCursor': 'Kursor dłoni na przyciskach',
   'settingsPanel.hint.handCursor': 'Pokazuje kursor dłoni nad przyciskami, wierszami i kartami zamiast zwykłej strzałki. Odnośniki zawsze zachowują dłoń.',
+  'settingsPanel.toggle.dockBadge': 'Liczba nieprzeczytanych na ikonie w Docku',
+  'settingsPanel.hint.dockBadge': 'Pokazuje na ikonie aplikacji w Docku, ile nieprzeczytanych wiadomości jest w skrzynce odbiorczej.',
   'settingsPanel.theme.schedule': 'Zaplanowany',
   'settingsPanel.label.darkFrom': 'Ciemny od',
   'settingsPanel.label.darkUntil': 'Do',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -358,6 +358,8 @@ export interface UIPrefs {
   // handCursor shows the browser hand over clickable chrome instead of the
   // native arrow. Hyperlinks keep the hand regardless.
   handCursor: boolean
+  // dockBadge shows the unread count on the dock icon (macOS only for now).
+  dockBadge: boolean
   // themeDarkStart/themeDarkEnd bound the dark window ("HH:MM") for the
   // schedule theme mode.
   themeDarkStart: string

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -70,6 +70,7 @@ const defaults: UIPrefs = {
   timeFormat: 'auto',
   reduceMotion: false,
   handCursor: false,
+  dockBadge: true,
   themeDarkStart: '19:00',
   themeDarkEnd: '07:00',
   bodyFont: 'default',
@@ -423,6 +424,13 @@ export function setHandCursor(value: boolean): void {
   prefs.update((p) => ({ ...p, handCursor: value }))
   applyHandCursor(value)
   void setSetting(SettingKeys.handCursor, String(value))
+}
+
+// setDockBadgeEnabled toggles the unread count on the dock icon. The backend
+// re-applies or clears the badge itself when this setting lands.
+export function setDockBadgeEnabled(value: boolean): void {
+  prefs.update((p) => ({ ...p, dockBadge: value }))
+  void setSetting(SettingKeys.dockBadge, String(value))
 }
 
 // setUIFont / setMonoFont override the interface and monospace font tokens,

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -250,6 +250,8 @@ export function SetAccountSignatures(arg1:number,arg2:number,arg3:number):Promis
 
 export function SetDefaultMailClient():Promise<void>;
 
+export function SetDockBadge(arg1:number):Promise<void>;
+
 export function SetFlagColor(arg1:number,arg2:number):Promise<void>;
 
 export function SetFlagged(arg1:number,arg2:boolean):Promise<void>;

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -498,6 +498,10 @@ export function SetDefaultMailClient() {
   return window['go']['desktop']['App']['SetDefaultMailClient']();
 }
 
+export function SetDockBadge(arg1) {
+  return window['go']['desktop']['App']['SetDockBadge'](arg1);
+}
+
 export function SetFlagColor(arg1, arg2) {
   return window['go']['desktop']['App']['SetFlagColor'](arg1, arg2);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1383,6 +1383,7 @@ export namespace desktop {
 	    timeFormat: string;
 	    reduceMotion: boolean;
 	    handCursor: boolean;
+	    dockBadge: boolean;
 	    themeDarkStart: string;
 	    themeDarkEnd: string;
 	    bodyFont: string;
@@ -1460,6 +1461,7 @@ export namespace desktop {
 	        this.timeFormat = source["timeFormat"];
 	        this.reduceMotion = source["reduceMotion"];
 	        this.handCursor = source["handCursor"];
+	        this.dockBadge = source["dockBadge"];
 	        this.themeDarkStart = source["themeDarkStart"];
 	        this.themeDarkEnd = source["themeDarkEnd"];
 	        this.bodyFont = source["bodyFont"];

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -104,6 +104,12 @@ type App struct {
 	// mailto holds a mailto: draft the app was launched with (or received from a
 	// second launch) until the frontend consumes it. See mailto.go.
 	mailto mailtoState
+
+	// badgeMu guards unreadBadge, the last unread count the frontend reported
+	// for the dock icon. Kept so toggling the setting can re-apply it without
+	// waiting for the next sidebar refresh.
+	badgeMu     sync.Mutex
+	unreadBadge int
 }
 
 // IsDemoMode reports whether the app was launched in the cosmetic demo mode. The

--- a/internal/desktop/bind_dockbadge.go
+++ b/internal/desktop/bind_dockbadge.go
@@ -1,0 +1,30 @@
+package desktop
+
+// SetDockBadge puts the unread count on the dock icon. The frontend calls it
+// whenever the unified inbox count changes, which already covers syncing, marking
+// read and deleting, so there is no second count to keep in step here.
+//
+// A no-op anywhere without a dock tile; see dockbadge_other.go.
+func (a *App) SetDockBadge(unread int) {
+	if unread < 0 {
+		unread = 0
+	}
+	a.badgeMu.Lock()
+	a.unreadBadge = unread
+	a.badgeMu.Unlock()
+	a.applyDockBadge()
+}
+
+// applyDockBadge pushes the remembered count to the platform, or clears the
+// badge when the setting is off. Also called when that setting changes, so
+// turning it back on does not wait for the next sidebar refresh.
+func (a *App) applyDockBadge() {
+	a.badgeMu.Lock()
+	unread := a.unreadBadge
+	a.badgeMu.Unlock()
+
+	if !a.boolSetting(settingDockBadge, true) {
+		unread = 0
+	}
+	setPlatformBadge(unread)
+}

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -85,6 +85,8 @@ const (
 	// show the browser hand over clickable chrome instead of the native arrow.
 	// hyperlinks keep the hand either way.
 	settingHandCursor = "hand_cursor"
+	// show the unread count on the dock icon (macOS only for now).
+	settingDockBadge = "dock_badge"
 	// dark window bounds ("HH:MM") for the schedule theme mode.
 	settingThemeDarkStart = "theme_dark_start"
 	settingThemeDarkEnd   = "theme_dark_end"
@@ -295,6 +297,8 @@ type UIPrefsDTO struct {
 	// HandCursor shows the browser hand over clickable chrome instead of the
 	// native arrow.
 	HandCursor bool `json:"handCursor"`
+	// DockBadge shows the unread count on the dock icon.
+	DockBadge bool `json:"dockBadge"`
 	// ThemeDarkStart/ThemeDarkEnd bound the dark window ("HH:MM") for the
 	// schedule theme mode.
 	ThemeDarkStart string `json:"themeDarkStart"`
@@ -398,6 +402,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 		TimeFormat:                 a.stringSetting(settingTimeFormat, "auto"),
 		ReduceMotion:               a.boolSetting(settingReduceMotion, false),
 		HandCursor:                 a.boolSetting(settingHandCursor, false),
+		DockBadge:                  a.boolSetting(settingDockBadge, true),
 		ThemeDarkStart:             a.stringSetting(settingThemeDarkStart, "19:00"),
 		ThemeDarkEnd:               a.stringSetting(settingThemeDarkEnd, "07:00"),
 		BodyFont:                   a.stringSetting(settingBodyFont, "default"),
@@ -449,6 +454,9 @@ func (a *App) SetSetting(key, value string) error {
 	}
 	if key == settingLogToFile || key == settingLogLevel || key == settingLogMessageMetadata || key == settingCrashLogs {
 		a.applyLogSettings()
+	}
+	if key == settingDockBadge {
+		a.applyDockBadge()
 	}
 	if key == settingIndexDecrypted {
 		// rebuilt from scratch rather than re-indexed in place: switching this

--- a/internal/desktop/dockbadge_darwin.go
+++ b/internal/desktop/dockbadge_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+
+package desktop
+
+/*
+// the preamble is Objective-C, not C: cgo compiles it as C unless told
+// otherwise, and AppKit's headers do not parse that way.
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#include <stdlib.h>
+#import <Cocoa/Cocoa.h>
+
+// peltonSetDockBadge writes label onto the dock tile, or clears it when label
+// is empty. AppKit is main-thread only and bound methods run on their own
+// goroutine, hence the hop onto the main queue.
+static void peltonSetDockBadge(const char *label) {
+    NSString *text = label == NULL || label[0] == '\0'
+        ? nil
+        : [NSString stringWithUTF8String:label];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSApp dockTile] setBadgeLabel:text];
+    });
+}
+*/
+import "C"
+
+import (
+	"strconv"
+	"unsafe"
+)
+
+// badgeCap is where the badge stops counting. Past it the dock shows "999+",
+// the way Mail does, rather than a number too wide for the tile.
+const badgeCap = 999
+
+// setPlatformBadge puts the unread count on the dock tile. Zero clears it.
+func setPlatformBadge(count int) {
+	label := ""
+	switch {
+	case count > badgeCap:
+		label = strconv.Itoa(badgeCap) + "+"
+	case count > 0:
+		label = strconv.Itoa(count)
+	}
+	c := C.CString(label)
+	defer C.free(unsafe.Pointer(c))
+	C.peltonSetDockBadge(c)
+}

--- a/internal/desktop/dockbadge_other.go
+++ b/internal/desktop/dockbadge_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package desktop
+
+// Only macOS has a dock tile to badge. Windows wants a taskbar overlay icon
+// through ITaskbarList3, which needs COM and an icon rendered per count, and
+// Linux has no convention that works across desktops; both are their own
+// problem rather than a stub away.
+func setPlatformBadge(_ int) {}


### PR DESCRIPTION
Closes #252.

Unread count from the unified inbox on the dock icon, capped at 999+ so it stays a badge. Toggle under Notifications, on by default, only shown on macOS since a switch that does nothing is worse than no switch.

The frontend pushes the count whenever the sidebar recomputes it, which already happens after a sync and after anything that changes read state. No new query and no second source of truth for the same number. The backend keeps the last count so flipping the setting back on re-applies it instead of waiting for the next sidebar refresh.

Two things worth knowing about the cgo side. The preamble needs `#cgo CFLAGS: -x objective-c`, because cgo compiles it as C otherwise and AppKit's headers don't parse that way. The existing darwin file in this package is plain CoreFoundation, so it never hit that. And AppKit is main thread only while bound methods run on their own goroutine, so the badge is set inside a dispatch_async onto the main queue.

macOS only. Windows and Linux aren't stubs away, so #252 keeps them as separate work: Windows needs ITaskbarList3, so COM plus an icon rendered per count, and Linux's only real option is the Unity launcher DBus API, which works on KDE but needs an extension on GNOME.

go build, go vet, go test pass. Cross compiles clean for GOOS=windows and GOOS=linux, which is what actually proves the !darwin stub covers them. pnpm check 0/0, clean frontend build.

Tested by running: no. Worth checking that the badge appears and clears, that the cap reads right, and that the toggle takes effect immediately rather than on the next sync.
