### PR TITLE
fix: cmd+h hides the window with no way to reopen it on macos

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -63,7 +63,7 @@
   import { loadViews, editingView, closeViewEditor, openViewEditor, views as savedViews } from './stores/views'
   import { selectSavedView } from './stores/selection'
   import { isMac } from './lib/i18n'
-  import { Quit, WindowHide, WindowIsFullscreen, WindowFullscreen, WindowUnfullscreen } from '../wailsjs/runtime/runtime'
+  import { Quit, Hide, WindowIsFullscreen, WindowFullscreen, WindowUnfullscreen } from '../wailsjs/runtime/runtime'
   import { matchShortcut, comboHasModifier, type ShortcutAction } from './lib/shortcuts'
   import { bindings, recording, initShortcuts } from './stores/shortcuts'
   import { initMenuBar } from './stores/menubar'
@@ -554,7 +554,9 @@
         void toggleFullscreen()
         break
       case 'hide-window':
-        WindowHide()
+        // Hide, not WindowHide: on macOS ordering the window out strands it,
+        // because wails has no reopen handler for the dock icon to trigger.
+        Hide()
         break
       case 'quit':
         Quit()

--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -42,7 +42,10 @@ func (a *App) buildMenu() *menu.Menu {
 	appMenu.AddText(s.preferences, keys.CmdOrCtrl(","), a.menuAction("preferences"))
 	appMenu.AddSeparator()
 	appMenu.AddText(s.hide, keys.CmdOrCtrl("h"), func(_ *menu.CallbackData) {
-		wailsruntime.WindowHide(a.ctx)
+		// Hide, not WindowHide: see the note in beforeClose. Ordering the window
+		// out on macOS strands it, since wails has no reopen handler, so the
+		// dock icon cannot bring it back.
+		wailsruntime.Hide(a.ctx)
 	})
 	appMenu.AddText(s.quit, keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
 		a.quitApp()


### PR DESCRIPTION
Closes #254.

Cmd+H hid the window and the dock icon couldn't bring it back, so the app was gone for the rest of the session.

Both hide paths called `WindowHide`, which orders the window out. On macOS that leaves nothing for the dock to reopen, because wails has no reopen handler. `close.go:44` already spells this out, which is why the close button uses `Hide` and works fine. Only Cmd+H got it wrong, in two places: the native Hide menu item and the `hide-window` action behind the in-app menu bar.

Both now call `Hide`, which is `[NSApp hide:]`, matching what the close button already does. On Windows and Linux the two calls are the same thing, so nothing changes there.

Pre-existing, found while working on #242, not caused by any of the current native-feel branches.

go build, go vet, pnpm check 0/0. Worth checking on macOS that Cmd+H then clicking the dock icon actually brings the window back.
