### PR TITLE
fix: no fullscreen shortcut when the native menu is reduced

### DIFF
--- a/internal/desktop/menu.go
+++ b/internal/desktop/menu.go
@@ -57,6 +57,11 @@ func (a *App) buildMenu() *menu.Menu {
 		// the reduced menu carries no message items; drop stale pointers so
 		// SetMailActionsEnabled does not update items of a discarded menu.
 		a.mailMenuItems = nil
+		// the view menu survives here, carrying only the fullscreen toggle, for
+		// the same reason the edit menu below does: the accelerator exists only
+		// while its item does. the in-app bar cannot pick it up either, since
+		// its combo grammar has no way to say ctrl on macOS.
+		a.addFullscreenItem(root.AddSubmenu(s.viewMenu), s)
 	} else {
 		// file menu: composing new mail and exporting the open message.
 		fileMenu := root.AddSubmenu(s.fileMenu)
@@ -95,13 +100,7 @@ func (a *App) buildMenu() *menu.Menu {
 		// view menu: a reliable fullscreen toggle (the native green button can
 		// be inconsistent in some setups) plus the low-power mode toggle.
 		viewMenu := root.AddSubmenu(s.viewMenu)
-		viewMenu.AddText(s.toggleFullscreen, keys.Combo("f", keys.CmdOrCtrlKey, keys.ControlKey), func(_ *menu.CallbackData) {
-			if wailsruntime.WindowIsFullscreen(a.ctx) {
-				wailsruntime.WindowUnfullscreen(a.ctx)
-			} else {
-				wailsruntime.WindowFullscreen(a.ctx)
-			}
-		})
+		a.addFullscreenItem(viewMenu, s)
 		viewMenu.AddSeparator()
 		viewMenu.AddText(s.lowPowerMode, nil, a.menuAction("toggle-low-power"))
 	}
@@ -113,6 +112,18 @@ func (a *App) buildMenu() *menu.Menu {
 	root.Append(menu.EditMenu())
 
 	return root
+}
+
+// addFullscreenItem adds the fullscreen toggle and its accelerator to a menu.
+// Shared so the reduced menu keeps the binding without duplicating the toggle.
+func (a *App) addFullscreenItem(m *menu.Menu, s menuStrings) {
+	m.AddText(s.toggleFullscreen, keys.Combo("f", keys.CmdOrCtrlKey, keys.ControlKey), func(_ *menu.CallbackData) {
+		if wailsruntime.WindowIsFullscreen(a.ctx) {
+			wailsruntime.WindowUnfullscreen(a.ctx)
+		} else {
+			wailsruntime.WindowFullscreen(a.ctx)
+		}
+	})
 }
 
 // RebuildMenu rebuilds and applies the native menubar in the current language


### PR DESCRIPTION
Closes #256.

With the in-app menu bar and the reduced native menu both on, Cmd+Ctrl+F did nothing. Two halves each assuming the other had it: the native View menu owns the accelerator and the reduced menu dropped View, while the frontend registry leaves `toggle-fullscreen` empty on macOS precisely because the native menu is meant to own it.

The in-app bar can't take over either. Combos are mod, alt and shift plus a key, mod being cmd on macOS, and `comboMatches` rejects ctrl there on purpose to keep combos unambiguous. Cmd+Ctrl+F isn't expressible in that grammar, so rebinding in Settings, Shortcuts wouldn't have helped.

So the reduced menu now keeps a View menu holding only the fullscreen toggle. Same argument it already makes for keeping the Edit menu: the accelerator exists only while its item does. The item moved into a small shared helper so the full menu and the reduced one can't drift apart.

Pre-existing, found while working on #242.

go build, go vet, go test pass. Needs a check on macOS with both menu-bar settings on: Cmd+Ctrl+F should work, and the native bar should show Pelton, View and Edit.
