### PR TITLE
fix: starttls cannot be used with custom imap and smtp ports

### DIFF
--- a/frontend/src/components/settings/MailboxesSection.svelte
+++ b/frontend/src/components/settings/MailboxesSection.svelte
@@ -9,7 +9,7 @@
   import { listAccounts, updateAccount, deleteAccount, getLogStatus, deleteLogs, accountsNeedingPassword } from '../../lib/api'
   import { refreshSidebar } from '../../stores/accounts'
   import { errorMessage, toastError, pushAction } from '../../stores/toast'
-  import type { Account } from '../../lib/types'
+  import type { Account, TLSMode } from '../../lib/types'
   import { t } from '../../lib/i18n'
 
   let accounts: Account[] = []
@@ -52,8 +52,25 @@
   function startEdit(account: Account): void {
     confirmingId = null
     editingId = account.id
+    // the backend already reports the security an account actually connects
+    // with, resolving the empty value an older account carries, so the control
+    // shows the truth and saving pins it.
     draft = { ...account }
     passwordDraft = ''
+  }
+
+  // the security setters take the null check out of the template: inside an
+  // event handler the draft's narrowing from the enclosing block is lost.
+  function setIMAPTLS(mode: TLSMode): void {
+    if (draft) {
+      draft.imapTls = mode
+    }
+  }
+
+  function setSMTPTLS(mode: TLSMode): void {
+    if (draft) {
+      draft.smtpTls = mode
+    }
   }
 
   function cancelEdit(): void {
@@ -77,6 +94,8 @@
         smtpHost: draft.smtpHost,
         smtpPort: draft.smtpPort,
         password: passwordDraft,
+        imapTls: draft.imapTls as TLSMode,
+        smtpTls: draft.smtpTls as TLSMode,
       })
       accounts = accounts.map((a) => (a.id === updated.id ? updated : a))
       if (passwordDraft !== '') {
@@ -166,8 +185,26 @@
               <label class="field narrow"><span>{$t('wizard.field.port')}</span><input type="number" bind:value={draft.imapPort} /></label>
             </div>
             <div class="servers">
+              <span class="field">
+                <span>{$t('wizard.advanced.imapSecurity')}</span>
+                <div class="seg" role="radiogroup" aria-label={$t('wizard.advanced.imapSecurity')}>
+                  <button type="button" class:on={draft.imapTls === 'ssl'} on:click={() => setIMAPTLS('ssl')}>SSL / TLS</button>
+                  <button type="button" class:on={draft.imapTls === 'starttls'} on:click={() => setIMAPTLS('starttls')}>STARTTLS</button>
+                </div>
+              </span>
+            </div>
+            <div class="servers">
               <label class="field"><span>{$t('wizard.field.smtpHost')}</span><input type="text" bind:value={draft.smtpHost} /></label>
               <label class="field narrow"><span>{$t('wizard.field.port')}</span><input type="number" bind:value={draft.smtpPort} /></label>
+            </div>
+            <div class="servers">
+              <span class="field">
+                <span>{$t('wizard.advanced.smtpSecurity')}</span>
+                <div class="seg" role="radiogroup" aria-label={$t('wizard.advanced.smtpSecurity')}>
+                  <button type="button" class:on={draft.smtpTls === 'ssl'} on:click={() => setSMTPTLS('ssl')}>SSL / TLS</button>
+                  <button type="button" class:on={draft.smtpTls === 'starttls'} on:click={() => setSMTPTLS('starttls')}>STARTTLS</button>
+                </div>
+              </span>
             </div>
             <label class="field">
               <span>{$t('wizard.field.password')}</span>
@@ -378,6 +415,30 @@
   }
   .servers .field {
     flex: 1;
+  }
+
+  /* the security picker, matching the one in the add-mailbox wizard. */
+  .seg {
+    display: inline-flex;
+    align-self: flex-start;
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-control);
+    overflow: hidden;
+  }
+  .seg button {
+    border: none;
+    background: var(--surface-raised);
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--fz-label);
+  }
+  .seg button + button {
+    border-left: var(--hairline) solid var(--border-default);
+  }
+  .seg button.on {
+    background: var(--accent);
+    color: var(--accent-fg);
   }
   .servers .field.narrow {
     flex: 0 0 88px;

--- a/frontend/src/components/wizard/AddMailboxWizard.svelte
+++ b/frontend/src/components/wizard/AddMailboxWizard.svelte
@@ -13,7 +13,7 @@
   import { discoverConfig, testConnection, addPasswordAccount, addOAuthAccount } from '../../lib/api'
   import { errorMessage } from '../../stores/toast'
   import { providerPresets, type ProviderPreset } from '../../lib/providers'
-  import type { AddAccountRequest, Account } from '../../lib/types'
+  import type { AddAccountRequest, Account, TLSMode } from '../../lib/types'
   import { t } from '../../lib/i18n'
 
   const dispatch = createEventDispatcher<{ close: void; added: Account }>()
@@ -54,6 +54,8 @@
       imapPort: 993,
       smtpHost: '',
       smtpPort: 465,
+      imapTls: 'ssl',
+      smtpTls: 'ssl',
       password: '',
       provider: '',
       clientId: '',
@@ -64,31 +66,40 @@
   // whether the advanced section (tls mode, oauth secret) is expanded.
   let showAdvanced = false
 
-  // the imap transport, derived from the port: 143 is STARTTLS, anything else is
-  // implicit TLS. selecting a mode sets the conventional port, which the backend
-  // reads to choose the transport.
-  $: imapTLS = draft.imapPort === 143 ? 'starttls' : 'ssl'
+  // the transport is its own field, not read back off the port. deriving it
+  // meant STARTTLS only existed on 143 and 587, so a server on any other port
+  // could not be reached at all (#237).
+  //
+  // picking a mode still fills in that mode's usual port, but only when the
+  // current one is the other mode's default, so it never overwrites a port the
+  // user typed. changing the port never touches the mode.
+  const imapPorts: Record<string, number> = { ssl: 993, starttls: 143 }
+  const smtpPorts: Record<string, number> = { ssl: 465, starttls: 587 }
 
-  function setTLS(mode: string): void {
-    draft.imapPort = mode === 'starttls' ? 143 : 993
+  function setTLS(mode: TLSMode): void {
+    if (draft.imapPort === imapPorts[draft.imapTls]) {
+      draft.imapPort = imapPorts[mode]
+    }
+    draft.imapTls = mode
   }
 
-  // the smtp transport, derived the same way: 587 is STARTTLS submission,
-  // anything else (conventionally 465) is implicit TLS. selecting a mode sets
-  // the conventional port, which the backend reads to choose the transport.
-  $: smtpTLS = draft.smtpPort === 587 ? 'starttls' : 'ssl'
-
-  function setSMTPTLS(mode: string): void {
-    draft.smtpPort = mode === 'starttls' ? 587 : 465
+  function setSMTPTLS(mode: TLSMode): void {
+    if (draft.smtpPort === smtpPorts[draft.smtpTls]) {
+      draft.smtpPort = smtpPorts[mode]
+    }
+    draft.smtpTls = mode
   }
+
 
   function selectPreset(p: ProviderPreset): void {
     preset = p
     draft = blankDraft()
     if (p.imapHost) draft.imapHost = p.imapHost
     if (p.imapPort) draft.imapPort = p.imapPort
+    if (p.imapTls) draft.imapTls = p.imapTls
     if (p.smtpHost) draft.smtpHost = p.smtpHost
     if (p.smtpPort) draft.smtpPort = p.smtpPort
+    if (p.smtpTls) draft.smtpTls = p.smtpTls
     if (p.oauthProvider) draft.provider = p.oauthProvider
     testOk = null
     error = ''
@@ -121,6 +132,10 @@
       draft.imapPort = d.imapPort
       draft.smtpHost = d.smtpHost
       draft.smtpPort = d.smtpPort
+      // autoconfig states the security outright; empty means it said nothing
+      // usable, so the current choice stands rather than being overwritten.
+      if (d.imapTls) draft.imapTls = d.imapTls as TLSMode
+      if (d.smtpTls) draft.smtpTls = d.smtpTls as TLSMode
     } catch {
       // leave fields for manual entry; discovery is best effort.
     }
@@ -136,6 +151,7 @@
         username: draft.username,
         imapHost: draft.imapHost,
         imapPort: draft.imapPort,
+        imapTls: draft.imapTls,
         password: draft.password,
       })
       testOk = true
@@ -208,6 +224,7 @@
     draft.username
     draft.imapHost
     draft.imapPort
+    draft.imapTls
     draft.password
     testOk = null
   }
@@ -311,14 +328,14 @@
 
             <span class="adv-label">{$t('wizard.advanced.imapSecurity')}</span>
             <div class="seg" role="radiogroup" aria-label={$t('wizard.advanced.imapSecurity')}>
-              <button type="button" class:on={imapTLS === 'ssl'} on:click={() => setTLS('ssl')}>SSL / TLS</button>
-              <button type="button" class:on={imapTLS === 'starttls'} on:click={() => setTLS('starttls')}>STARTTLS</button>
+              <button type="button" class:on={draft.imapTls === 'ssl'} on:click={() => setTLS('ssl')}>SSL / TLS</button>
+              <button type="button" class:on={draft.imapTls === 'starttls'} on:click={() => setTLS('starttls')}>STARTTLS</button>
             </div>
 
             <span class="adv-label">{$t('wizard.advanced.smtpSecurity')}</span>
             <div class="seg" role="radiogroup" aria-label={$t('wizard.advanced.smtpSecurity')}>
-              <button type="button" class:on={smtpTLS === 'ssl'} on:click={() => setSMTPTLS('ssl')}>SSL / TLS</button>
-              <button type="button" class:on={smtpTLS === 'starttls'} on:click={() => setSMTPTLS('starttls')}>STARTTLS</button>
+              <button type="button" class:on={draft.smtpTls === 'ssl'} on:click={() => setSMTPTLS('ssl')}>SSL / TLS</button>
+              <button type="button" class:on={draft.smtpTls === 'starttls'} on:click={() => setSMTPTLS('starttls')}>STARTTLS</button>
             </div>
             <p class="adv-hint">
               {$t('wizard.advanced.tlsHint')}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   Discovered,
   AddAccountRequest,
   TestConnectionRequest,
+  TLSMode,
   Signature,
   AccountSignatures,
   AddressBookEntry,
@@ -112,6 +113,8 @@ export function updateAccount(req: {
   smtpHost: string
   smtpPort: number
   password: string
+  imapTls: TLSMode
+  smtpTls: TLSMode
 }): Promise<Account> {
   return App.UpdateAccount(new desktop.UpdateAccountRequest(req))
 }

--- a/frontend/src/lib/demo.ts
+++ b/frontend/src/lib/demo.ts
@@ -43,6 +43,8 @@ const accounts: Account[] = [
     smtpHost: 'smtp.pelton.email',
     smtpPort: 465,
     local: false,
+    imapTls: 'ssl',
+    smtpTls: 'ssl',
   },
   {
     id: 2,
@@ -54,6 +56,8 @@ const accounts: Account[] = [
     smtpHost: 'smtp.pelton-potato.island',
     smtpPort: 465,
     local: false,
+    imapTls: 'ssl',
+    smtpTls: 'ssl',
   },
 ]
 

--- a/frontend/src/lib/providers.ts
+++ b/frontend/src/lib/providers.ts
@@ -2,6 +2,8 @@
 // settings and auth method so the user usually only types an address and signs
 // in or enters a password. custom uses autodiscovery instead of fixed hosts.
 
+import type { TLSMode } from './types'
+
 export type AuthKind = 'oauth' | 'password'
 
 export interface ProviderPreset {
@@ -14,6 +16,11 @@ export interface ProviderPreset {
   imapPort?: number
   smtpHost?: string
   smtpPort?: number
+  // the connection security each leg needs, stated rather than read back out of
+  // the port. outlook and icloud submit over STARTTLS on 587 while the rest use
+  // implicit TLS, and that is a fact about the provider, not about the number.
+  imapTls?: TLSMode
+  smtpTls?: TLSMode
   // note is shown under the form (e.g. app-specific password guidance).
   note?: string
   // appPasswordUrl, when set, replaces the plain note with a warning box that
@@ -41,8 +48,10 @@ export const providerPresets: ProviderPreset[] = [
     oauthProvider: 'google',
     imapHost: 'imap.gmail.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.gmail.com',
     smtpPort: 465,
+    smtpTls: 'ssl',
     appPasswordUrl: 'https://myaccount.google.com/apppasswords',
     oauthOptional: true,
   },
@@ -53,8 +62,10 @@ export const providerPresets: ProviderPreset[] = [
     oauthProvider: 'microsoft',
     imapHost: 'outlook.office365.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.office365.com',
     smtpPort: 587,
+    smtpTls: 'starttls',
     allowClientSecret: true,
   },
   {
@@ -63,8 +74,10 @@ export const providerPresets: ProviderPreset[] = [
     kind: 'password',
     imapHost: 'imap.mail.me.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.mail.me.com',
     smtpPort: 587,
+    smtpTls: 'starttls',
     appPasswordUrl: 'https://appleid.apple.com',
   },
   {
@@ -73,8 +86,10 @@ export const providerPresets: ProviderPreset[] = [
     kind: 'password',
     imapHost: 'imap.mail.yahoo.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.mail.yahoo.com',
     smtpPort: 465,
+    smtpTls: 'ssl',
     note: 'Yahoo requires an app password generated in account security.',
   },
   {
@@ -83,8 +98,10 @@ export const providerPresets: ProviderPreset[] = [
     kind: 'password',
     imapHost: 'imap.fastmail.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.fastmail.com',
     smtpPort: 465,
+    smtpTls: 'ssl',
     note: 'Fastmail requires an app password.',
   },
   {
@@ -93,8 +110,10 @@ export const providerPresets: ProviderPreset[] = [
     kind: 'password',
     imapHost: 'imap.purelymail.com',
     imapPort: 993,
+    imapTls: 'ssl',
     smtpHost: 'smtp.purelymail.com',
     smtpPort: 465,
+    smtpTls: 'ssl',
     note: 'Use your Purelymail password, or an app password if you enabled 2FA.',
   },
   {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -18,6 +18,12 @@ export interface Account {
   // the Local Folders account, which holds imported mail and has no server:
   // it never syncs, and the ui hides the server-side folder actions on it.
   local: boolean
+  // pinned connection security, a TLSMode value: 'ssl', 'starttls', or '' to
+  // derive it from the port, which is what accounts created before it was
+  // storable use. typed as string to match the generated dto, which cannot
+  // carry the union.
+  imapTls: string
+  smtpTls: string
 }
 
 // ThunderbirdAccount is one account read out of a Thunderbird profile. There is
@@ -52,6 +58,9 @@ export interface ThunderbirdProfile {
   accounts: ThunderbirdAccount[]
   localFolders: ThunderbirdFolder[]
 }
+
+// TLSMode is the connection security for one leg of an account.
+export type TLSMode = '' | 'ssl' | 'starttls'
 
 export interface Folder {
   id: number
@@ -662,6 +671,9 @@ export interface Discovered {
   imapPort: number
   smtpHost: string
   smtpPort: number
+  // the security the source stated, empty when it said nothing usable.
+  imapTls: string
+  smtpTls: string
   oauth: boolean
   source: string
 }
@@ -677,6 +689,8 @@ export interface AddAccountRequest {
   imapPort: number
   smtpHost: string
   smtpPort: number
+  imapTls: TLSMode
+  smtpTls: TLSMode
   password: string
   provider: string
   clientId: string
@@ -691,6 +705,8 @@ export interface TestConnectionRequest {
   username: string
   imapHost: string
   imapPort: number
+  // tested with the same security the account will use, not a guess from the port.
+  imapTls: TLSMode
   password: string
 }
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -9,8 +9,11 @@ export namespace desktop {
 	    imapPort: number;
 	    smtpHost: string;
 	    smtpPort: number;
+	    imapTls: string;
+	    smtpTls: string;
 	    local: boolean;
 	
+
 	    static createFrom(source: any = {}) {
 	        return new AccountDTO(source);
 	    }
@@ -25,6 +28,8 @@ export namespace desktop {
 	        this.imapPort = source["imapPort"];
 	        this.smtpHost = source["smtpHost"];
 	        this.smtpPort = source["smtpPort"];
+	        this.imapTls = source["imapTls"];
+	        this.smtpTls = source["smtpTls"];
 	        this.local = source["local"];
 	    }
 	}
@@ -50,6 +55,8 @@ export namespace desktop {
 	    imapPort: number;
 	    smtpHost: string;
 	    smtpPort: number;
+	    imapTls: string;
+	    smtpTls: string;
 	    password: string;
 	    provider: string;
 	    clientId: string;
@@ -68,6 +75,8 @@ export namespace desktop {
 	        this.imapPort = source["imapPort"];
 	        this.smtpHost = source["smtpHost"];
 	        this.smtpPort = source["smtpPort"];
+	        this.imapTls = source["imapTls"];
+	        this.smtpTls = source["smtpTls"];
 	        this.password = source["password"];
 	        this.provider = source["provider"];
 	        this.clientId = source["clientId"];
@@ -355,9 +364,11 @@ export namespace desktop {
 	    imapPort: number;
 	    smtpHost: string;
 	    smtpPort: number;
+	    imapTls: string;
+	    smtpTls: string;
 	    oauth: boolean;
 	    source: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new DiscoveredDTO(source);
 	    }
@@ -368,6 +379,8 @@ export namespace desktop {
 	        this.imapPort = source["imapPort"];
 	        this.smtpHost = source["smtpHost"];
 	        this.smtpPort = source["smtpPort"];
+	        this.imapTls = source["imapTls"];
+	        this.smtpTls = source["smtpTls"];
 	        this.oauth = source["oauth"];
 	        this.source = source["source"];
 	    }
@@ -1113,8 +1126,9 @@ export namespace desktop {
 	    username: string;
 	    imapHost: string;
 	    imapPort: number;
+	    imapTls: string;
 	    password: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new TestConnectionRequest(source);
 	    }
@@ -1125,6 +1139,7 @@ export namespace desktop {
 	        this.username = source["username"];
 	        this.imapHost = source["imapHost"];
 	        this.imapPort = source["imapPort"];
+	        this.imapTls = source["imapTls"];
 	        this.password = source["password"];
 	    }
 	}
@@ -1507,6 +1522,8 @@ export namespace desktop {
 	    smtpHost: string;
 	    smtpPort: number;
 	    password: string;
+	    imapTls: string;
+	    smtpTls: string;
 
 	    static createFrom(source: any = {}) {
 	        return new UpdateAccountRequest(source);
@@ -1522,6 +1539,8 @@ export namespace desktop {
 	        this.smtpHost = source["smtpHost"];
 	        this.smtpPort = source["smtpPort"];
 	        this.password = source["password"];
+	        this.imapTls = source["imapTls"];
+	        this.smtpTls = source["smtpTls"];
 	    }
 	}
 	export class UpdateCheckResult {

--- a/internal/autoconfig/autoconfig.go
+++ b/internal/autoconfig/autoconfig.go
@@ -29,6 +29,11 @@ type Discovered struct {
 	IMAPPort int    `json:"imapPort"`
 	SMTPHost string `json:"smtpHost"`
 	SMTPPort int    `json:"smtpPort"`
+	// IMAPTLS and SMTPTLS are the connection security the source specified:
+	// "ssl" or "starttls". Autoconfig documents state this outright, so it is
+	// carried through rather than guessed back out of the port.
+	IMAPTLS string `json:"imapTls"`
+	SMTPTLS string `json:"smtpTls"`
 	// OAuth is true when the provider's autoconfig says to authenticate with
 	// OAuth2 (gmail, outlook). Otherwise password auth is expected.
 	OAuth bool `json:"oauth"`
@@ -67,6 +72,8 @@ func Discover(ctx context.Context, client *http.Client, email string) (Discovere
 		IMAPPort: 993,
 		SMTPHost: "smtp." + domain,
 		SMTPPort: 465,
+		IMAPTLS:  "ssl",
+		SMTPTLS:  "ssl",
 		Source:   "guess",
 	}, nil
 }
@@ -80,6 +87,10 @@ type mxProvider struct {
 	imapPort int
 	smtpHost string
 	smtpPort int
+	// imapTLS and smtpTLS are stated rather than inferred from the ports, so a
+	// provider on a non-conventional port can be added here correctly.
+	imapTLS string
+	smtpTLS string
 }
 
 // knownMXProviders are mail hosts that serve many custom domains behind a shared
@@ -87,9 +98,9 @@ type mxProvider struct {
 // a reliable signal.
 var knownMXProviders = []mxProvider{
 	// Namecheap Private Email.
-	{suffix: "privateemail.com", imapHost: "mail.privateemail.com", imapPort: 993, smtpHost: "mail.privateemail.com", smtpPort: 465},
+	{suffix: "privateemail.com", imapHost: "mail.privateemail.com", imapPort: 993, smtpHost: "mail.privateemail.com", smtpPort: 465, imapTLS: "ssl", smtpTLS: "ssl"},
 	// Purelymail.
-	{suffix: "purelymail.com", imapHost: "imap.purelymail.com", imapPort: 993, smtpHost: "smtp.purelymail.com", smtpPort: 465},
+	{suffix: "purelymail.com", imapHost: "imap.purelymail.com", imapPort: 993, smtpHost: "smtp.purelymail.com", smtpPort: 465, imapTLS: "ssl", smtpTLS: "ssl"},
 }
 
 // discoverByMX looks up the domain's MX records and, if one matches a known
@@ -112,6 +123,8 @@ func discoverByMX(ctx context.Context, domain string) (Discovered, bool) {
 					IMAPPort: p.imapPort,
 					SMTPHost: p.smtpHost,
 					SMTPPort: p.smtpPort,
+					IMAPTLS:  p.imapTLS,
+					SMTPTLS:  p.smtpTLS,
 					Source:   "mx",
 				}, true
 			}
@@ -186,6 +199,7 @@ func parse(body []byte, src string) (Discovered, error) {
 		if strings.EqualFold(s.Type, "imap") {
 			out.IMAPHost = s.Hostname
 			out.IMAPPort = s.Port
+			out.IMAPTLS = socketTLS(s.SocketType)
 			out.OAuth = strings.EqualFold(s.Authentication, "OAuth2")
 			break
 		}
@@ -194,10 +208,26 @@ func parse(body []byte, src string) (Discovered, error) {
 		if strings.EqualFold(s.Type, "smtp") {
 			out.SMTPHost = s.Hostname
 			out.SMTPPort = s.Port
+			out.SMTPTLS = socketTLS(s.SocketType)
 			break
 		}
 	}
 	return out, nil
+}
+
+// socketTLS maps an autoconfig socketType onto the security values the rest of
+// the app uses. SSL and TLS both mean implicit TLS in these documents. Anything
+// else, including the plain and unencrypted values, returns empty: the caller
+// then leaves the choice alone rather than being told to connect in clear.
+func socketTLS(socketType string) string {
+	switch strings.ToUpper(socketType) {
+	case "SSL", "TLS":
+		return "ssl"
+	case "STARTTLS":
+		return "starttls"
+	default:
+		return ""
+	}
 }
 
 // domainOf returns the part after @ in an email address, lowercased.

--- a/internal/desktop/bind_account_manage.go
+++ b/internal/desktop/bind_account_manage.go
@@ -35,6 +35,10 @@ type UpdateAccountRequest struct {
 	// re-enter it. An account imported from another client has no stored
 	// password at all, and this is how it gets one.
 	Password string `json:"password"`
+	// IMAPTLS and SMTPTLS pin the connection security: "ssl", "starttls", or
+	// empty to derive it from the port.
+	IMAPTLS string `json:"imapTls"`
+	SMTPTLS string `json:"smtpTls"`
 }
 
 // UpdateAccount persists edits to an account's display name and server settings.
@@ -44,6 +48,9 @@ type UpdateAccountRequest struct {
 func (a *App) UpdateAccount(req UpdateAccountRequest) (AccountDTO, error) {
 	if err := a.ready(); err != nil {
 		return AccountDTO{}, err
+	}
+	if !validTLSMode(req.IMAPTLS) || !validTLSMode(req.SMTPTLS) {
+		return AccountDTO{}, errUnknownTLSMode
 	}
 	account, err := a.store.GetAccount(a.ctx, req.ID)
 	if err != nil {
@@ -55,6 +62,8 @@ func (a *App) UpdateAccount(req UpdateAccountRequest) (AccountDTO, error) {
 	account.IMAPPort = req.IMAPPort
 	account.SMTPHost = req.SMTPHost
 	account.SMTPPort = req.SMTPPort
+	account.IMAPTLS = req.IMAPTLS
+	account.SMTPTLS = req.SMTPTLS
 	if err := a.store.UpdateAccount(a.ctx, account); err != nil {
 		return AccountDTO{}, err
 	}

--- a/internal/desktop/bind_account_setup.go
+++ b/internal/desktop/bind_account_setup.go
@@ -25,8 +25,12 @@ type DiscoveredDTO struct {
 	IMAPPort int    `json:"imapPort"`
 	SMTPHost string `json:"smtpHost"`
 	SMTPPort int    `json:"smtpPort"`
-	OAuth    bool   `json:"oauth"`
-	Source   string `json:"source"`
+	// IMAPTLS and SMTPTLS are the security the source stated ("ssl" or
+	// "starttls"), empty when it said nothing usable.
+	IMAPTLS string `json:"imapTls"`
+	SMTPTLS string `json:"smtpTls"`
+	OAuth   bool   `json:"oauth"`
+	Source  string `json:"source"`
 }
 
 // DiscoverConfig resolves likely imap/smtp settings for an email address using
@@ -42,6 +46,8 @@ func (a *App) DiscoverConfig(email string) (DiscoveredDTO, error) {
 		IMAPPort: d.IMAPPort,
 		SMTPHost: d.SMTPHost,
 		SMTPPort: d.SMTPPort,
+		IMAPTLS:  d.IMAPTLS,
+		SMTPTLS:  d.SMTPTLS,
 		OAuth:    d.OAuth,
 		Source:   d.Source,
 	}, nil
@@ -62,6 +68,10 @@ type TestConnectionRequest struct {
 	Username string `json:"username"`
 	IMAPHost string `json:"imapHost"`
 	IMAPPort int    `json:"imapPort"`
+	// IMAPTLS pins the connection security: "ssl", "starttls", or empty to
+	// derive it from the port. Sent so the test uses the same transport the
+	// account will, instead of testing a different one.
+	IMAPTLS  string `json:"imapTls"`
 	Password string `json:"password"`
 }
 
@@ -77,6 +87,7 @@ func (a *App) TestConnection(req TestConnectionRequest) error {
 		Port:     req.IMAPPort,
 		Username: username,
 		Password: req.Password,
+		TLS:      imapTLSMode(req.IMAPTLS),
 		Dial:     a.proxyDial(),
 	})
 	if err != nil {
@@ -97,10 +108,14 @@ type AddAccountRequest struct {
 	// Username is the login name when it differs from the email; empty logs in
 	// with Email.
 	Username    string `json:"username"`
-	IMAPHost    string `json:"imapHost"`
-	IMAPPort    int    `json:"imapPort"`
-	SMTPHost    string `json:"smtpHost"`
-	SMTPPort    int    `json:"smtpPort"`
+	IMAPHost string `json:"imapHost"`
+	IMAPPort int    `json:"imapPort"`
+	SMTPHost string `json:"smtpHost"`
+	SMTPPort int    `json:"smtpPort"`
+	// IMAPTLS and SMTPTLS pin the connection security: "ssl", "starttls", or
+	// empty to derive it from the port.
+	IMAPTLS string `json:"imapTls"`
+	SMTPTLS string `json:"smtpTls"`
 	// auth
 	Password string `json:"password"`
 	Provider string `json:"provider"`
@@ -160,6 +175,9 @@ func (a *App) AddOAuthAccount(req AddAccountRequest) (AccountDTO, error) {
 // the secret, discover folders, sync, and start idling. On any failure after the
 // row is created it rolls the account back so a half-created account is not left.
 func (a *App) createAccount(req AddAccountRequest, secret credentials.Secret) (AccountDTO, error) {
+	if !validTLSMode(req.IMAPTLS) || !validTLSMode(req.SMTPTLS) {
+		return AccountDTO{}, errUnknownTLSMode
+	}
 	account := &storage.Account{
 		Email:       req.Email,
 		DisplayName: req.DisplayName,
@@ -168,6 +186,8 @@ func (a *App) createAccount(req AddAccountRequest, secret credentials.Secret) (A
 		IMAPPort:    req.IMAPPort,
 		SMTPHost:    req.SMTPHost,
 		SMTPPort:    req.SMTPPort,
+		IMAPTLS:     req.IMAPTLS,
+		SMTPTLS:     req.SMTPTLS,
 	}
 	id, err := a.store.CreateAccount(a.ctx, account)
 	if err != nil {

--- a/internal/desktop/bind_credentials.go
+++ b/internal/desktop/bind_credentials.go
@@ -34,6 +34,7 @@ func (a *App) resolveIMAP(account storage.Account) (pimap.Config, error) {
 		Host:     account.IMAPHost,
 		Port:     account.IMAPPort,
 		Username: loginName(account),
+		TLS:      imapTLSMode(account.IMAPTLS),
 		Dial:     a.proxyDial(),
 	}
 
@@ -65,6 +66,7 @@ func (a *App) resolveSMTP(account storage.Account) (psmtp.Config, error) {
 		Host:     account.SMTPHost,
 		Port:     account.SMTPPort,
 		Username: loginName(account),
+		TLS:      smtpTLSMode(account.SMTPTLS),
 		Dial:     a.proxyDial(),
 	}
 

--- a/internal/desktop/dto.go
+++ b/internal/desktop/dto.go
@@ -28,6 +28,10 @@ type AccountDTO struct {
 	// Local marks the Local Folders account, which holds imported mail and has
 	// no server. The ui labels it and hides the server-side actions.
 	Local bool `json:"local"`
+	// IMAPTLS and SMTPTLS are the pinned connection security ("ssl" or
+	// "starttls"), or empty when it is derived from the port.
+	IMAPTLS string `json:"imapTls"`
+	SMTPTLS string `json:"smtpTls"`
 }
 
 // FolderDTO is one mailbox in an account's tree. ParentID is null at the root.
@@ -231,6 +235,8 @@ func toAccountDTO(a storage.Account) AccountDTO {
 		SMTPHost:    a.SMTPHost,
 		SMTPPort:    a.SMTPPort,
 		Local:       a.Local,
+		IMAPTLS:     effectiveIMAPTLS(a),
+		SMTPTLS:     effectiveSMTPTLS(a),
 	}
 }
 

--- a/internal/desktop/tlsmode.go
+++ b/internal/desktop/tlsmode.go
@@ -1,0 +1,81 @@
+package desktop
+
+import (
+	"errors"
+
+	pimap "github.com/TRC-Loop/Pelton/internal/imap"
+	psmtp "github.com/TRC-Loop/Pelton/internal/smtp"
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+// errUnknownTLSMode rejects a security value the frontend should never send.
+var errUnknownTLSMode = errors.New("unknown connection security")
+
+// Connection security as stored on an account and exchanged with the frontend.
+// Empty means derive it from the port, which is how every account created
+// before it was storable behaves.
+const (
+	tlsModeAuto     = ""
+	tlsModeSSL      = "ssl"
+	tlsModeStartTLS = "starttls"
+)
+
+// validTLSMode reports whether a value is one the frontend may send.
+func validTLSMode(mode string) bool {
+	switch mode {
+	case tlsModeAuto, tlsModeSSL, tlsModeStartTLS:
+		return true
+	}
+	return false
+}
+
+// imapTLSMode maps the stored value onto the imap layer's own enum. Anything
+// unrecognised falls back to deriving from the port rather than guessing, so a
+// bad value cannot silently downgrade a connection to cleartext.
+func imapTLSMode(mode string) pimap.TLSMode {
+	switch mode {
+	case tlsModeSSL:
+		return pimap.TLSImplicit
+	case tlsModeStartTLS:
+		return pimap.TLSStartTLS
+	default:
+		return pimap.TLSAuto
+	}
+}
+
+// effectiveIMAPTLS and effectiveSMTPTLS report the security an account actually
+// connects with: the stored value, or what the port resolves to when nothing is
+// pinned. The imap and smtp layers apply exactly this rule when handed TLSAuto,
+// so reporting it here lets the ui show the truth for an account that predates
+// the setting without repeating the rule, and drifting from it later.
+func effectiveIMAPTLS(a storage.Account) string {
+	if a.IMAPTLS != tlsModeAuto {
+		return a.IMAPTLS
+	}
+	if a.IMAPPort == pimap.PortStartTLS {
+		return tlsModeStartTLS
+	}
+	return tlsModeSSL
+}
+
+func effectiveSMTPTLS(a storage.Account) string {
+	if a.SMTPTLS != tlsModeAuto {
+		return a.SMTPTLS
+	}
+	if a.SMTPPort == psmtp.PortStartTLS {
+		return tlsModeStartTLS
+	}
+	return tlsModeSSL
+}
+
+// smtpTLSMode is imapTLSMode for the smtp layer.
+func smtpTLSMode(mode string) psmtp.TLSMode {
+	switch mode {
+	case tlsModeSSL:
+		return psmtp.TLSImplicit
+	case tlsModeStartTLS:
+		return psmtp.TLSStartTLS
+	default:
+		return psmtp.TLSAuto
+	}
+}

--- a/internal/desktop/tlsmode_test.go
+++ b/internal/desktop/tlsmode_test.go
@@ -1,0 +1,54 @@
+package desktop
+
+import (
+	"testing"
+
+	pimap "github.com/TRC-Loop/Pelton/internal/imap"
+	psmtp "github.com/TRC-Loop/Pelton/internal/smtp"
+)
+
+func TestTLSModeMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		wantIMAP pimap.TLSMode
+		wantSMTP psmtp.TLSMode
+		wantOK   bool
+	}{
+		{"empty derives from the port", "", pimap.TLSAuto, psmtp.TLSAuto, true},
+		{"ssl is implicit tls", "ssl", pimap.TLSImplicit, psmtp.TLSImplicit, true},
+		{"starttls upgrades", "starttls", pimap.TLSStartTLS, psmtp.TLSStartTLS, true},
+		// an unrecognised value must not fall through to cleartext; deriving
+		// from the port is the safe reading.
+		{"garbage falls back to auto", "plaintext", pimap.TLSAuto, psmtp.TLSAuto, false},
+		{"case is not normalised", "SSL", pimap.TLSAuto, psmtp.TLSAuto, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imapTLSMode(tt.mode); got != tt.wantIMAP {
+				t.Errorf("imapTLSMode(%q) = %v, want %v", tt.mode, got, tt.wantIMAP)
+			}
+			if got := smtpTLSMode(tt.mode); got != tt.wantSMTP {
+				t.Errorf("smtpTLSMode(%q) = %v, want %v", tt.mode, got, tt.wantSMTP)
+			}
+			if got := validTLSMode(tt.mode); got != tt.wantOK {
+				t.Errorf("validTLSMode(%q) = %v, want %v", tt.mode, got, tt.wantOK)
+			}
+		})
+	}
+}
+
+// A STARTTLS account on a custom port is the case #237 reported: the port says
+// nothing useful, so only the stored mode can get the transport right.
+func TestTLSModeCustomPortStillStartTLS(t *testing.T) {
+	cfg := pimap.Config{Host: "127.0.0.1", Port: 1143, TLS: imapTLSMode(tlsModeStartTLS)}
+	if cfg.TLS != pimap.TLSStartTLS {
+		t.Fatalf("imap TLS = %v, want TLSStartTLS", cfg.TLS)
+	}
+
+	send := psmtp.Config{Host: "127.0.0.1", Port: 1025, TLS: smtpTLSMode(tlsModeStartTLS)}
+	if send.TLS != psmtp.TLSStartTLS {
+		t.Fatalf("smtp TLS = %v, want TLSStartTLS", send.TLS)
+	}
+}

--- a/internal/storage/accounts.go
+++ b/internal/storage/accounts.go
@@ -20,10 +20,15 @@ type Account struct {
 	// Username is the login name when it differs from the email address. Empty
 	// means authenticate with Email.
 	Username  string
-	IMAPHost  string
-	IMAPPort  int
-	SMTPHost  string
-	SMTPPort  int
+	IMAPHost string
+	IMAPPort int
+	SMTPHost string
+	SMTPPort int
+	// IMAPTLS and SMTPTLS pin the connection security: "ssl" for implicit TLS,
+	// "starttls" to upgrade a cleartext connection. Empty derives it from the
+	// port, which is what every account created before this was storable does.
+	IMAPTLS   string
+	SMTPTLS   string
 	CreatedAt time.Time
 	// Position is the account section's rank in the sidebar, or 0 until the user
 	// reorders them. Unpositioned accounts sort after positioned ones by id, so
@@ -47,7 +52,7 @@ const LocalAccountName = "Local Folders"
 // accountColumns is the select list every account query shares, in the order
 // scanAccount reads them.
 const accountColumns = `id, email, display_name, username, imap_host, imap_port,
-       smtp_host, smtp_port, created_at, position, is_local`
+       smtp_host, smtp_port, imap_tls, smtp_tls, created_at, position, is_local`
 
 // CreateAccount inserts an account and returns its new id. CreatedAt is set to
 // now if the caller left it zero.
@@ -58,11 +63,11 @@ func (d *DB) CreateAccount(ctx context.Context, a *Account) (int64, error) {
 	}
 
 	const query = `
-INSERT INTO accounts (email, display_name, username, imap_host, imap_port, smtp_host, smtp_port, created_at, is_local)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+INSERT INTO accounts (email, display_name, username, imap_host, imap_port, smtp_host, smtp_port, imap_tls, smtp_tls, created_at, is_local)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	res, err := d.sql.ExecContext(ctx, query,
 		a.Email, a.DisplayName, a.Username, a.IMAPHost, a.IMAPPort, a.SMTPHost, a.SMTPPort,
-		formatTime(created), boolToInt(a.Local))
+		a.IMAPTLS, a.SMTPTLS, formatTime(created), boolToInt(a.Local))
 	if err != nil {
 		return 0, fmt.Errorf("storage: insert account %q: %w", a.Email, err)
 	}
@@ -120,10 +125,12 @@ FROM accounts ORDER BY position = 0, position, id`
 func (d *DB) UpdateAccount(ctx context.Context, a *Account) error {
 	const query = `
 UPDATE accounts
-SET email = ?, display_name = ?, username = ?, imap_host = ?, imap_port = ?, smtp_host = ?, smtp_port = ?
+SET email = ?, display_name = ?, username = ?, imap_host = ?, imap_port = ?, smtp_host = ?, smtp_port = ?,
+    imap_tls = ?, smtp_tls = ?
 WHERE id = ?`
 	res, err := d.sql.ExecContext(ctx, query,
-		a.Email, a.DisplayName, a.Username, a.IMAPHost, a.IMAPPort, a.SMTPHost, a.SMTPPort, a.ID)
+		a.Email, a.DisplayName, a.Username, a.IMAPHost, a.IMAPPort, a.SMTPHost, a.SMTPPort,
+		a.IMAPTLS, a.SMTPTLS, a.ID)
 	if err != nil {
 		return fmt.Errorf("storage: update account %d: %w", a.ID, err)
 	}
@@ -159,7 +166,7 @@ func scanAccount(row rowScanner) (*Account, error) {
 		local   int
 	)
 	if err := row.Scan(&a.ID, &a.Email, &a.DisplayName, &a.Username, &a.IMAPHost, &a.IMAPPort,
-		&a.SMTPHost, &a.SMTPPort, &created, &a.Position, &local); err != nil {
+		&a.SMTPHost, &a.SMTPPort, &a.IMAPTLS, &a.SMTPTLS, &created, &a.Position, &local); err != nil {
 		return nil, err
 	}
 	t, err := parseTime(created)

--- a/internal/storage/migrations/0020_account_tls_mode.sql
+++ b/internal/storage/migrations/0020_account_tls_mode.sql
@@ -1,0 +1,9 @@
+-- Connection security per account, stored instead of guessed from the port.
+-- Deriving it meant STARTTLS was only reachable on 143 and 587, which locked
+-- out anything on a custom port (Proton Mail Bridge, tunnels, test servers).
+--
+-- '' keeps the old behaviour for every existing account: the imap and smtp
+-- layers read it as their TLSAuto mode and infer from the port, so nothing that
+-- already works changes. 'ssl' and 'starttls' pin the transport explicitly.
+ALTER TABLE accounts ADD COLUMN imap_tls TEXT NOT NULL DEFAULT '';
+ALTER TABLE accounts ADD COLUMN smtp_tls TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
Closes #237.

Connection security was never stored. The wizard derived it from the port (`imapPort === 143 ? 'starttls' : 'ssl'`) and the backend did the same, so STARTTLS only existed on 143 and 587. Picking STARTTLS rewrote the port, typing a custom port flipped the mode back, and Proton Mail Bridge on 1143 and 1025 was unreachable.

The backend already had the enum for this: imap and smtp both have TLSAuto, TLSImplicit and TLSStartTLS, with TLSAuto doing the port inference. Nothing ever set it, so every connection ran on Auto. Now the mode is stored per account and passed through.

**Storage.** Migration 0020 adds `imap_tls` and `smtp_tls`, defaulting to `''`. Empty maps to TLSAuto, so every existing account keeps the exact behaviour it has today and nothing needs re-adding.

**Wizard.** The mode is its own field now. Choosing one still fills in that mode's usual port, but only when the current port is the other mode's default, so it never overwrites a port you typed. Changing the port no longer touches the mode.

**Presets and autodiscovery state the mode instead of it being guessed.** The provider presets carry `imapTls`/`smtpTls` directly, so Outlook and iCloud say STARTTLS because that is a fact about those providers, not because 587 happens to be their port. Autoconfig documents already declare a `socketType` and the parser was reading it and throwing it away; it now flows through `Discovered` to the wizard. When a source says nothing usable, the current choice stands rather than being overwritten.

Nothing derives a mode from a port anywhere in the frontend now.

**Test connection** now sends the mode too, so it tests the transport the account will actually use rather than a different one.

**Editing an existing mailbox** gets the same two controls in Settings, Mailboxes, which is where someone hitting this would go to fix it. An older account stores `''`, and the DTO reports what it actually connects with by asking the same rule the imap and smtp layers apply, using their own port constants. So the control shows the truth without the frontend keeping a second copy of that rule to drift from, and saving pins it.

An unrecognised value maps to Auto rather than cleartext, and both the add and update paths reject anything that isn't `''`, `ssl` or `starttls`, so a bad value can't quietly downgrade a connection.

Verified: go build, go vet, go test ./internal/... , pnpm check 0/0, clean frontend build. New table test covers the mapping, the reject cases and the 1143/1025 case from the report.

Not tested against a real server. Worth checking with Bridge on 1143 and 1025, and that an existing account still connects untouched after the migration.

Unrelated, found while running the suite: `TestEmptyTrashTwiceCountsOnlyWhatItMarked` fails intermittently on a TempDir cleanup, roughly one run in ten. It does the same on unmodified dev, so it is pre-existing and not from this branch, but it will make CI flap.
