### PR TITLE
chore: point dependabot at dev from the branch it reads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    # dev is the integration branch; nothing lands on main directly, dependency
+    # updates included. Without this dependabot opens against the default
+    # branch. It has to be set on main specifically: dependabot only ever reads
+    # this file from the default branch, so a copy on dev has no effect.
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     groups:
@@ -12,6 +17,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Dependabot keeps opening against main. #235 and #236 both did, and dep updates go to dev in this repo.

`target-branch: "dev"` is already set, but only in dev's copy of this file, and dependabot only ever reads its config from the default branch. So the setting has been there and has never had any effect.

Adding it here, where it actually gets read. Same two lines dev already has.

This is the reason those two PRs could not just be merged: their branches were cut from main, and main and dev have diverged both ways, so retargeting would have pulled unrelated main commits into dev. Their bumps went in as #258 instead.

Config only, nothing shipped changes. YAML parses and both ecosystems now resolve to dev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `.github/dependabot.yml` so both Go modules and npm updates target `dev`.
- Added documentation for the Go branch behavior.
- Configuration-only change. No shipped code changes.

## AI usage

AI use is **Not Likely** based on the available repository and commit metadata. No clear AI indicators were found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->