### PR TITLE
Quote html-only mail when replying

### DIFF
--- a/frontend/src/lib/demo.ts
+++ b/frontend/src/lib/demo.ts
@@ -185,6 +185,7 @@ export function demoMessage(id: number): MessageDetail {
     toAddresses: 'spud@pelton.email',
     ccAddresses: '',
     bodyPlain: 'Hey, quick one about the potato shipment...',
+    bodyQuote: 'Hey, quick one about the potato shipment...',
     bodyHtmlSafe: sharedBodyHtml,
     unsubscribe: null,
     // the demo mail is not protected, so there is nothing to decrypt.

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -93,6 +93,11 @@ export interface MessageDetail extends MessageSummary {
   toAddresses: string
   ccAddresses: string
   bodyPlain: string
+  // bodyQuote is the message as plain text for a reply or forward to quote:
+  // bodyPlain when the message has a text part, and the html rendered down to
+  // text when it does not. Replies to html-only mail quoted nothing before
+  // this existed (#239).
+  bodyQuote: string
   bodyHtmlSafe: string
   isHtml: boolean
   hasRemoteContent: boolean

--- a/frontend/src/stores/compose.ts
+++ b/frontend/src/stores/compose.ts
@@ -198,9 +198,14 @@ function withPrefix(subject: string, prefix: string): string {
 
 // quoteBody builds a quoted reply body. plaintext and markdown both quote with
 // "> "; html mode is the stubbed editor so it also gets the plain quote.
+//
+// bodyQuote, not bodyPlain: an html-only message has no text part, so quoting
+// bodyPlain produced an empty reply (#239). The backend renders the html down
+// to text for this field, and falls back to it only when there is no text part
+// to prefer.
 function quoteBody(detail: MessageDetail, _mode: EditorMode): string {
   const attribution = `On ${detail.date}, ${detail.fromName || detail.fromAddress} wrote:`
-  const quoted = detail.bodyPlain
+  const quoted = detail.bodyQuote
     .split('\n')
     .map((line) => `> ${line}`)
     .join('\n')
@@ -216,7 +221,7 @@ function forwardBody(detail: MessageDetail, _mode: EditorMode): string {
     `Subject: ${detail.subject}`,
     `To: ${detail.toAddresses}`,
   ].join('\n')
-  return `\n\n${header}\n\n${detail.bodyPlain}\n`
+  return `\n\n${header}\n\n${detail.bodyQuote}\n`
 }
 
 // messageIdRef would be the original Message-ID for threading. the detail dto

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -643,6 +643,7 @@ export namespace desktop {
 	    ccAddresses: string;
 	    bodyPlain: string;
 	    bodyHtmlSafe: string;
+	    bodyQuote: string;
 	    isHtml: boolean;
 	    hasRemoteContent: boolean;
 	    remoteAllowed: boolean;
@@ -682,6 +683,7 @@ export namespace desktop {
 	        this.ccAddresses = source["ccAddresses"];
 	        this.bodyPlain = source["bodyPlain"];
 	        this.bodyHtmlSafe = source["bodyHtmlSafe"];
+	        this.bodyQuote = source["bodyQuote"];
 	        this.isHtml = source["isHtml"];
 	        this.hasRemoteContent = source["hasRemoteContent"];
 	        this.remoteAllowed = source["remoteAllowed"];

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/smallstep/pkcs7 v0.2.3
-	github.com/wailsapp/wails/v2 v2.14.0
+	github.com/wailsapp/wails/v2 v2.13.0
 	github.com/yuin/goldmark v1.8.5
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6N
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.14.0 h1:+GlF6BM8Mg7Saa1lxUAzfZ6jsEMg2zQhQvUHtqB7xpc=
-github.com/wailsapp/wails/v2 v2.14.0/go.mod h1:scxrgwfsv6yR6fE6cCF+Flfl+JeU+SR87T9x4kILJ6M=
+github.com/wailsapp/wails/v2 v2.13.0 h1:S7OgXWpj72V91unF8iDWJKbcS9ZpwCT3R0QVru4v2Mg=
+github.com/wailsapp/wails/v2 v2.13.0/go.mod h1:nVr/wSIEZ7xxKPkzK65mjpKpaOPQI2k4pvLwGR/i4kc=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/desktop/bind_messages.go
+++ b/internal/desktop/bind_messages.go
@@ -105,6 +105,7 @@ func (a *App) GetMessage(id int64) (MessageDetailDTO, error) {
 		ToAddresses:       m.ToAddresses,
 		CcAddresses:       m.CcAddresses,
 		BodyPlain:         m.BodyPlain,
+		BodyQuote:         quoteText(m.BodyPlain, m.BodyHTML),
 		IsHTML:            m.BodyHTML != "",
 		HasRemoteContent:  mailview.HasRemoteContent(m.BodyHTML),
 		RemoteAllowed:     autoAllow,
@@ -125,6 +126,7 @@ func (a *App) GetMessage(id int64) (MessageDetailDTO, error) {
 			if isHTML {
 				detail.IsHTML = true
 				detail.BodyPlain = ""
+				detail.BodyQuote = quoteText("", body)
 				detail.BodyHTMLSafe = a.renderHTML(body, atts, autoAllow)
 				detail.HasRemoteContent = mailview.HasRemoteContent(body)
 				detail.RemoteHosts = mailview.RemoteHosts(body)
@@ -132,6 +134,7 @@ func (a *App) GetMessage(id int64) (MessageDetailDTO, error) {
 			} else {
 				detail.IsHTML = false
 				detail.BodyPlain = body
+				detail.BodyQuote = body
 				detail.BodyHTMLSafe = ""
 			}
 		}
@@ -447,4 +450,15 @@ func trimSuffixByte(s string, b byte) string {
 		return s[:len(s)-1]
 	}
 	return s
+}
+
+// quoteText is the message as text for a reply or forward to quote: the text
+// part when there is one, and otherwise the html rendered down to text. An
+// html-only message has no text part at all, which is why replying to one used
+// to quote nothing (#239).
+func quoteText(plain, html string) string {
+	if strings.TrimSpace(plain) != "" {
+		return plain
+	}
+	return mailview.TextForQuote(html)
 }

--- a/internal/desktop/dto.go
+++ b/internal/desktop/dto.go
@@ -142,10 +142,15 @@ type AttachmentDTO struct {
 // offer "load remote images".
 type MessageDetailDTO struct {
 	MessageSummaryDTO
-	ToAddresses      string `json:"toAddresses"`
-	CcAddresses      string `json:"ccAddresses"`
-	BodyPlain        string `json:"bodyPlain"`
-	BodyHTMLSafe     string `json:"bodyHtmlSafe"`
+	ToAddresses  string `json:"toAddresses"`
+	CcAddresses  string `json:"ccAddresses"`
+	BodyPlain    string `json:"bodyPlain"`
+	BodyHTMLSafe string `json:"bodyHtmlSafe"`
+	// BodyQuote is the message as plain text for a reply or forward to quote.
+	// It is BodyPlain when the message has a text part, and the html rendered
+	// down to text when it does not, which is the case BodyPlain is empty for
+	// and replies to html-only mail used to come out blank (#239).
+	BodyQuote        string `json:"bodyQuote"`
 	IsHTML           bool   `json:"isHtml"`
 	HasRemoteContent bool   `json:"hasRemoteContent"`
 	// RemoteAllowed is true when this message's remote content was rendered

--- a/internal/desktop/quotetext_test.go
+++ b/internal/desktop/quotetext_test.go
@@ -1,0 +1,42 @@
+package desktop
+
+import "testing"
+
+func TestQuoteTextPrefersTheTextPart(t *testing.T) {
+	tests := []struct {
+		name  string
+		plain string
+		html  string
+		want  string
+	}{
+		{
+			name:  "text part wins when present",
+			plain: "the plain part",
+			html:  "<p>the html part</p>",
+			want:  "the plain part",
+		},
+		{
+			name: "html only falls back to rendered text",
+			html: "<p>Hi Arne,</p><p>Here is the thing.</p>",
+			want: "Hi Arne,\nHere is the thing.",
+		},
+		{
+			name:  "a whitespace-only text part is not a text part",
+			plain: "\n  \n",
+			html:  "<p>real content</p>",
+			want:  "real content",
+		},
+		{
+			name: "nothing at all",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quoteText(tt.plain, tt.html); got != tt.want {
+				t.Errorf("quoteText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/mailview/quote.go
+++ b/internal/mailview/quote.go
@@ -1,0 +1,110 @@
+package mailview
+
+import (
+	"strings"
+
+	htmltok "golang.org/x/net/html"
+)
+
+// blockElements are the elements that end a line of prose. A quote built from
+// html has to keep the sender's line structure: collapsing a message to one
+// paragraph, the way PlainText does for snippets and the search index, makes an
+// unreadable reply.
+var blockElements = map[string]bool{
+	"address": true, "article": true, "aside": true, "blockquote": true,
+	"div": true, "dd": true, "dl": true, "dt": true, "fieldset": true,
+	"figcaption": true, "figure": true, "footer": true, "form": true,
+	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+	"header": true, "hr": true, "li": true, "main": true, "nav": true,
+	"ol": true, "p": true, "pre": true, "section": true, "table": true,
+	"tbody": true, "td": true, "tfoot": true, "th": true, "thead": true,
+	"tr": true, "ul": true,
+}
+
+// TextForQuote renders html as the plain text a reply or forward quotes. Block
+// elements and <br> become line breaks, entities are decoded, and script/style
+// content is dropped.
+//
+// It is separate from PlainText, which flattens everything to a single line
+// because a snippet and a search document have no use for line structure. A
+// quote does: it is the sender's message, and the reader is about to write
+// between its lines.
+func TextForQuote(markup string) string {
+	if markup == "" {
+		return ""
+	}
+	z := htmltok.NewTokenizer(strings.NewReader(markup))
+	var lines []string
+	var line strings.Builder
+	// depth of nested elements whose text is being discarded.
+	skip := 0
+
+	endLine := func() {
+		lines = append(lines, strings.TrimRight(line.String(), " "))
+		line.Reset()
+	}
+
+	for {
+		switch z.Next() {
+		case htmltok.ErrorToken:
+			// io.EOF or malformed markup: keep whatever was recovered.
+			endLine()
+			return joinQuoteLines(lines)
+		case htmltok.TextToken:
+			if skip > 0 {
+				continue
+			}
+			// runs of whitespace inside a line collapse, since html treats a
+			// newline in the source as a space. The line breaks come from the
+			// tags, not from how the sender's html happens to be wrapped.
+			text := strings.Join(strings.Fields(string(z.Text())), " ")
+			if text == "" {
+				continue
+			}
+			if line.Len() > 0 && !strings.HasSuffix(line.String(), " ") {
+				line.WriteByte(' ')
+			}
+			line.WriteString(text)
+		case htmltok.StartTagToken, htmltok.SelfClosingTagToken:
+			name, _ := z.TagName()
+			tag := string(name)
+			if skipTextIn[tag] {
+				skip++
+				continue
+			}
+			if tag == "br" || blockElements[tag] {
+				endLine()
+			}
+		case htmltok.EndTagToken:
+			name, _ := z.TagName()
+			tag := string(name)
+			if skipTextIn[tag] {
+				if skip > 0 {
+					skip--
+				}
+				continue
+			}
+			if blockElements[tag] {
+				endLine()
+			}
+		}
+	}
+}
+
+// joinQuoteLines drops the blank lines the walk produces. Adjacent blocks each
+// end a line, so </p><p> yields an empty one between them, and mail wrapped in
+// nested layout tables yields many.
+//
+// Every blank line goes, not just the runs: a quote is prefixed with "> " on
+// each line, which separates paragraphs well enough on its own, and keeping
+// them would mean deciding which of a layout table's empty rows the sender
+// meant. The cost is that a deliberate blank line in the original is lost.
+func joinQuoteLines(lines []string) string {
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/mailview/quote_test.go
+++ b/internal/mailview/quote_test.go
@@ -1,0 +1,108 @@
+package mailview
+
+import "testing"
+
+func TestTextForQuoteKeepsLineStructure(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "paragraphs become separate lines",
+			html: "<p>First line.</p><p>Second line.</p>",
+			want: "First line.\nSecond line.",
+		},
+		{
+			name: "br breaks a line",
+			html: "<p>One<br>Two</p>",
+			want: "One\nTwo",
+		},
+		{
+			name: "source wrapping is not a line break",
+			html: "<p>a sentence that the sender's\n   html happened to wrap</p>",
+			want: "a sentence that the sender's html happened to wrap",
+		},
+		{
+			name: "inline markup stays on its line",
+			html: "<p>hello <b>bold</b> and <i>italic</i> world</p>",
+			want: "hello bold and italic world",
+		},
+		{
+			name: "entities are decoded",
+			html: "<p>Tom &amp; Jerry &lt;3</p>",
+			want: "Tom & Jerry <3",
+		},
+		{
+			name: "list items get their own lines",
+			html: "<ul><li>one</li><li>two</li></ul>",
+			want: "one\ntwo",
+		},
+		{
+			name: "table cells get their own lines",
+			html: "<table><tr><td>left</td><td>right</td></tr></table>",
+			want: "left\nright",
+		},
+		{
+			name: "script and style content is dropped",
+			html: "<p>visible</p><script>var x = 1</script><style>p{color:red}</style>",
+			want: "visible",
+		},
+		{
+			name: "nested layout tables do not produce blank screenfuls",
+			html: "<table><tr><td><table><tr><td><div><p>hi</p></div></td></tr></table></td></tr></table>",
+			want: "hi",
+		},
+		{
+			name: "empty input",
+			html: "",
+			want: "",
+		},
+		{
+			name: "markup with no text",
+			html: "<div></div><p></p>",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TextForQuote(tt.html); got != tt.want {
+				t.Errorf("TextForQuote() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTextForQuoteOnARealisticNewsletter is the shape of the message from the
+// report: html only, wrapped in layout tables, which used to quote as nothing
+// at all.
+func TestTextForQuoteOnARealisticNewsletter(t *testing.T) {
+	const html = `<html><body style="margin:0">
+<table width="100%"><tr><td align="center">
+  <table width="600"><tr><td>
+    <h1>Weekly update</h1>
+    <p>Hi Arne,</p>
+    <p>Here is what happened this week. Nothing much,
+       but we wrote it down anyway.</p>
+    <ul><li>One thing</li><li>Another thing</li></ul>
+    <p>Cheers,<br>The team</p>
+  </td></tr></table>
+</td></tr></table>
+</body></html>`
+
+	want := "Weekly update\nHi Arne,\nHere is what happened this week. Nothing much, but we wrote it down anyway.\nOne thing\nAnother thing\nCheers,\nThe team"
+	if got := TextForQuote(html); got != want {
+		t.Errorf("TextForQuote() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestPlainTextStillFlattens guards the split: the snippet and search path
+// deliberately collapses to one line, and must not pick up line breaks from
+// this change.
+func TestPlainTextStillFlattens(t *testing.T) {
+	const html = "<p>First line.</p><p>Second line.</p>"
+	if got := PlainText(html); got != "First line. Second line." {
+		t.Errorf("PlainText() = %q, want it still flattened to one line", got)
+	}
+}


### PR DESCRIPTION
Closes #239.

Replying to an html-formatted mail gave you the attribution line and nothing under it.

`quoteBody` quoted `bodyPlain`, and an html-only message has no text part, so that field is empty. `forwardBody` did the same thing.

There is now a `bodyQuote` on the message detail: the text part when the message has one, and the html rendered down to text when it does not. Reply and forward quote that.

I did not reuse `mailview.PlainText` for the rendering. That one flattens everything to a single line on purpose, because a snippet and a search document have no use for line structure, and a quote does: it is the sender's message and I am about to write between its lines. So `TextForQuote` is its own function, breaking lines at block elements and `<br>`, decoding entities, dropping script and style.

One call worth arguing with: it drops every blank line rather than collapsing runs of them. Mail wrapped in nested layout tables otherwise quotes as screenfuls of "> ", and there is no way to tell which of a layout table's empty rows the sender meant. The "> " prefix separates paragraphs well enough on its own. The cost is that a deliberate blank line in the original is lost, and I am fine with that trade but happy to flip it.

The pgp path is handled too. It replaces the body after the dto is built, so without that it would have carried a stale quote.

Verified: go build, go vet, go test ./internal/... , builds for windows and linux, pnpm check 0/0, clean frontend build. Tests cover line structure, entities, lists, tables, script and style, nested layout tables, a realistic newsletter, that PlainText still flattens, and that a whitespace-only text part does not beat real html content.
