### PR TITLE
Post macOS notifications from the app bundle

### DIFF
--- a/internal/desktop/notify.go
+++ b/internal/desktop/notify.go
@@ -4,15 +4,15 @@ import (
 	"strings"
 
 	"github.com/TRC-Loop/Pelton/internal/storage"
-	"github.com/gen2brain/beeep"
 )
 
-// Native OS notifications for new mail (#126). beeep raises a real notification
-// on macOS (Notification Center), Windows (toast) and Linux (dbus). It has no
-// per-notification click callback, so a click does not open a specific message;
-// exact click-to-open would need platform-specific code and is tracked
-// separately. Notifications only fire for INBOX so sent/archived mail moved by
-// a sync never notifies.
+// Native OS notifications for new mail (#126). Delivery is per platform:
+// UserNotifications on macOS so the alert carries the app's own icon (#143),
+// and beeep elsewhere for a Windows toast or a Linux dbus notification. Neither
+// has a per-notification click callback, so a click does not open a specific
+// message; exact click-to-open would need more platform-specific code and is
+// tracked separately. Notifications only fire for INBOX so sent/archived mail
+// moved by a sync never notifies.
 
 // notifyStrings holds the localizable text of a new-mail notification. Like the
 // native menu (see menu_i18n.go), notifications are built in the Go process, so
@@ -104,8 +104,9 @@ func notifyBody(m *storage.Message, s notifyStrings) string {
 
 // sendNotification raises one native OS notification, logging (not failing) on
 // error so a notification backend that is missing or busy never disrupts sync.
+// The delivery itself is per platform: see notify_darwin.go and notify_other.go.
 func (a *App) sendNotification(title, body string) {
-	if err := beeep.Notify(title, body, ""); err != nil {
+	if err := deliverNotification(title, body); err != nil {
 		a.log.Warn("notify", "err", err)
 	}
 }

--- a/internal/desktop/notify_darwin.go
+++ b/internal/desktop/notify_darwin.go
@@ -1,0 +1,94 @@
+package desktop
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation -framework UserNotifications
+#include <stdbool.h>
+#include <stdlib.h>
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+// peltonCanNotify reports whether this process is running from an app bundle.
+// UNUserNotificationCenter requires one: currentNotificationCenter raises an
+// exception in a process with no bundle identifier, which would take the app
+// down rather than fail to notify. A `go run` or an unbundled dev build has
+// none, so the caller falls back to beeep there.
+static bool peltonCanNotify(void) {
+	return [[NSBundle mainBundle] bundleIdentifier] != nil;
+}
+
+// peltonNotify posts one notification through UserNotifications.
+//
+// The point of using this over an osascript "display notification" is the
+// icon: macOS shows the icon of whichever process posted, so going through
+// osascript brands every new-mail alert as Script Editor. Posting from inside
+// the bundle makes macOS use the bundle's own icon, with no asset to ship.
+//
+// Authorization is requested on every call. After the first time it resolves
+// from the stored answer without prompting again, so this costs nothing and
+// means the prompt appears the first time a notification would actually be
+// shown rather than at launch.
+static void peltonNotify(const char *title, const char *body) {
+	NSString *t = [NSString stringWithUTF8String:title];
+	NSString *b = [NSString stringWithUTF8String:body];
+	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+
+	[center requestAuthorizationWithOptions:UNAuthorizationOptionAlert
+	                      completionHandler:^(BOOL granted, NSError *error) {
+		if (!granted) {
+			// the only signal there is: delivery is asynchronous and the Go
+			// caller has already returned. Without this a user whose
+			// notifications never arrive has nothing at all to look at.
+			NSLog(@"pelton: notification authorization denied: %@", error);
+			return;
+		}
+		UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+		content.title = t;
+		content.body = b;
+		// no sound: this change is about the icon, and what Pelton should make
+		// a noise about is its own question (#240).
+		UNNotificationRequest *request =
+		    [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+		                                         content:content
+		                                         trigger:nil];
+		[center addNotificationRequest:request
+		         withCompletionHandler:^(NSError *addError) {
+			if (addError != nil) {
+				NSLog(@"pelton: notification not posted: %@", addError);
+			}
+		}];
+		[content release];
+	}];
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/gen2brain/beeep"
+)
+
+// deliverNotification raises one notification. On macOS this goes through
+// UserNotifications rather than beeep, which falls back to osascript when
+// terminal-notifier is absent and so shows the Script Editor automation icon
+// instead of the Pelton logo (#143). Posting from the app bundle makes macOS
+// use the bundle icon on its own.
+//
+// A process with no bundle (a dev run, a cli tool) cannot use the framework at
+// all, so it keeps the old path. Delivery is asynchronous once handed over, so
+// a rejected authorization or a failed post is not reported back here; a
+// notification is not worth failing a sync over.
+func deliverNotification(title, body string) error {
+	if !bool(C.peltonCanNotify()) {
+		return beeep.Notify(title, body, "")
+	}
+
+	cTitle := C.CString(title)
+	defer C.free(unsafe.Pointer(cTitle))
+	cBody := C.CString(body)
+	defer C.free(unsafe.Pointer(cBody))
+
+	C.peltonNotify(cTitle, cBody)
+	return nil
+}

--- a/internal/desktop/notify_darwin.go
+++ b/internal/desktop/notify_darwin.go
@@ -14,7 +14,13 @@ package desktop
 // down rather than fail to notify. A `go run` or an unbundled dev build has
 // none, so the caller falls back to beeep there.
 static bool peltonCanNotify(void) {
-	return [[NSBundle mainBundle] bundleIdentifier] != nil;
+	// UserNotifications arrived in 10.14 and the deployment target is older, so
+	// every use of it is inside an @available guard. On anything older the
+	// framework is simply absent and the caller keeps the old path.
+	if (@available(macOS 10.14, *)) {
+		return [[NSBundle mainBundle] bundleIdentifier] != nil;
+	}
+	return false;
 }
 
 // peltonNotify posts one notification through UserNotifications.
@@ -29,36 +35,38 @@ static bool peltonCanNotify(void) {
 // means the prompt appears the first time a notification would actually be
 // shown rather than at launch.
 static void peltonNotify(const char *title, const char *body) {
-	NSString *t = [NSString stringWithUTF8String:title];
-	NSString *b = [NSString stringWithUTF8String:body];
-	UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+	if (@available(macOS 10.14, *)) {
+		NSString *t = [NSString stringWithUTF8String:title];
+		NSString *b = [NSString stringWithUTF8String:body];
+		UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
-	[center requestAuthorizationWithOptions:UNAuthorizationOptionAlert
-	                      completionHandler:^(BOOL granted, NSError *error) {
-		if (!granted) {
-			// the only signal there is: delivery is asynchronous and the Go
-			// caller has already returned. Without this a user whose
-			// notifications never arrive has nothing at all to look at.
-			NSLog(@"pelton: notification authorization denied: %@", error);
-			return;
-		}
-		UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-		content.title = t;
-		content.body = b;
-		// no sound: this change is about the icon, and what Pelton should make
-		// a noise about is its own question (#240).
-		UNNotificationRequest *request =
-		    [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
-		                                         content:content
-		                                         trigger:nil];
-		[center addNotificationRequest:request
-		         withCompletionHandler:^(NSError *addError) {
-			if (addError != nil) {
-				NSLog(@"pelton: notification not posted: %@", addError);
+		[center requestAuthorizationWithOptions:UNAuthorizationOptionAlert
+		                      completionHandler:^(BOOL granted, NSError *error) {
+			if (!granted) {
+				// the only signal there is: delivery is asynchronous and the Go
+				// caller has already returned. Without this a user whose
+				// notifications never arrive has nothing at all to look at.
+				NSLog(@"pelton: notification authorization denied: %@", error);
+				return;
 			}
+			UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+			content.title = t;
+			content.body = b;
+			// no sound: this change is about the icon, and what Pelton should make
+			// a noise about is its own question (#240).
+			UNNotificationRequest *request =
+			    [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+			                                         content:content
+			                                         trigger:nil];
+			[center addNotificationRequest:request
+			         withCompletionHandler:^(NSError *addError) {
+				if (addError != nil) {
+					NSLog(@"pelton: notification not posted: %@", addError);
+				}
+			}];
+			[content release];
 		}];
-		[content release];
-	}];
+	}
 }
 */
 import "C"
@@ -76,7 +84,8 @@ import (
 // use the bundle icon on its own.
 //
 // A process with no bundle (a dev run, a cli tool) cannot use the framework at
-// all, so it keeps the old path. Delivery is asynchronous once handed over, so
+// all, and neither can macOS before 10.14, where it does not exist. Both keep
+// the old path and so keep the wrong icon. Delivery is asynchronous once handed over, so
 // a rejected authorization or a failed post is not reported back here; a
 // notification is not worth failing a sync over.
 func deliverNotification(title, body string) error {

--- a/internal/desktop/notify_other.go
+++ b/internal/desktop/notify_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package desktop
+
+import "github.com/gen2brain/beeep"
+
+// deliverNotification raises one OS notification through beeep: a toast on
+// Windows, dbus on Linux. Both take the icon from the running executable, so
+// neither needs the platform-specific handling macOS does (see
+// notify_darwin.go).
+func deliverNotification(title, body string) error {
+	return beeep.Notify(title, body, "")
+}


### PR DESCRIPTION
Closes #143.

New-mail notifications on macOS showed the Script Editor automation icon instead of the Pelton logo. beeep falls back to `osascript` when terminal-notifier is not installed, and macOS shows the icon of whatever process posted the notification, which for osascript is Script Editor. There is no flag to override it.

Option 2 from the issue: post through UserNotifications from inside the app bundle. macOS then uses the bundle's own icon, so there is nothing extra to ship and the notification is branded as Pelton rather than as a helper binary. Windows and Linux keep beeep, split out into notify_other.go.

Two guards, both of which matter:

A process with no bundle identifier cannot use the framework at all. `currentNotificationCenter` raises an exception there rather than failing, which would take the app down instead of just not notifying, so that case falls back to beeep. Both plists set an identifier, so a dev run through `make run` gets the native path too, which is how I tested it.

The deployment target is 10.13 and UserNotifications arrived in 10.14, so every use sits inside an `@available` check and anything older keeps the old path. Without that it was a missing symbol at runtime on an old Mac, not just a compiler warning.

Authorization is requested on the first notification rather than at launch, so the system prompt appears at the moment a notification would actually be shown. Delivery is asynchronous once handed over, so a denied authorization or a failed post cannot be reported back to the caller. Both write an NSLog line instead, since otherwise someone whose notifications never arrive has nothing at all to look at.

No sound. This change is about the icon; what Pelton should make a noise about is #240.

Tested by hand on macOS: the permission prompt appeared on the first notification, and after allowing it the alert carries the Pelton logo. Verified: go build, go vet, go test ./internal/... , builds for windows and linux, and a clean rebuild from an empty build cache with no compiler warnings.

Not tested: macOS 10.13, and whether an unsigned release build is allowed to register for notifications at all. A dev build works, and if a release build turns out not to, the NSLog lines are where it will show up.
