### PR TITLE
Show the address in the password prompt

### DIFF
--- a/frontend/src/components/settings/AccountPasswordDialog.svelte
+++ b/frontend/src/components/settings/AccountPasswordDialog.svelte
@@ -24,6 +24,16 @@
   let busy = false
   let seededFor: unknown = null
 
+  // the address, not the display name. Several mailboxes named "Work" and
+  // "Private" all look the same in this prompt, and the address is the part
+  // that says which login is being asked for, so it is the part that must
+  // never be the one dropped. The name comes along when there is one and it
+  // adds something.
+  $: who =
+    account && account.displayName && account.displayName !== account.email
+      ? `${account.displayName} (${account.email})`
+      : (account?.email ?? '')
+
   $: if (account !== seededFor) {
     seededFor = account
     password = ''
@@ -81,7 +91,7 @@
     </header>
 
     <p class="lead">
-      {$t('mailboxes.passwordPrompt.body').replace('{email}', account.displayName || account.email)}
+      {$t('mailboxes.passwordPrompt.body').replace('{email}', who)}
     </p>
 
     <form on:submit|preventDefault={submit}>


### PR DESCRIPTION
Closes #266.

The prompt read `account.displayName || account.email`, so the address only ever showed when a mailbox had no display name. With several accounts named "Work" and "Private" there was no way to tell which login it was asking about. The placeholder in the string is called `{email}`, so showing the address was clearly the intent.

Now it shows the address, and the display name too when there is one that adds something: `Work (me@example.com)`. A mailbox whose display name is just its address does not get it twice.

This targets main rather than dev, because the file only exists on main and nothing here comes from dev, so it does not touch the release gate. It reaches dev the next time main is merged into dev.

Verified: pnpm check 0/0 and a clean frontend build. Not tested by running, since triggering it needs a mailbox whose stored password has gone stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `AccountPasswordDialog.svelte` to show the account email in the password prompt.
- Shows `Display Name (email)` when the display name differs from the email.
- Shows only the email when both values match.
- Verification completed with `pnpm check` and a clean frontend build.

## AI usage

AI use is **Probably**. The change summary is AI-generated, but no direct repository evidence confirms agentic or partial AI involvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->