### PR TITLE
fix: never expunge mail another client marked deleted

### DIFF
--- a/internal/imap/expunge.go
+++ b/internal/imap/expunge.go
@@ -1,45 +1,142 @@
 package imap
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/emersion/go-imap/v2"
 )
 
-// MarkDeleted sets the \Deleted flag on the given uids in a single STORE.
-// nothing is actually removed until Expunge runs.
-func (c *Client) MarkDeleted(uids ...imap.UID) error {
+// DeleteMessages permanently removes the given uids from the selected mailbox,
+// and only those. It marks them \Deleted and expunges.
+//
+// The care is in the expunge. UID EXPUNGE (RFC 4315) removes exactly the uids
+// asked for, but it needs UIDPLUS, and a plain EXPUNGE removes every message in
+// the mailbox that carries \Deleted, including ones another client marked and
+// has not expunged yet. Deleting one message in Pelton must never take a mail
+// somebody's other client had merely flagged.
+//
+// So without UIDPLUS the foreign \Deleted marks are lifted for the length of
+// the expunge and put back afterwards. It is the only way to scope a plain
+// EXPUNGE, and the failure mode is a flag another client has to set again,
+// rather than mail nobody can get back. When the mailbox holds no foreign marks
+// at all, which is the ordinary case, a plain EXPUNGE is already exact and
+// nothing is touched.
+//
+// gmail diverges from all of this: \Deleted plus EXPUNGE inside an ordinary
+// label only removes that label, real deletion happens in [Gmail]/Trash or All
+// Mail. See the note in push.go.
+func (c *Client) DeleteMessages(uids ...imap.UID) error {
 	if len(uids) == 0 {
 		return nil
 	}
-	storeFlags := &imap.StoreFlags{
-		Op:     imap.StoreFlagsAdd,
-		Flags:  []imap.Flag{imap.FlagDeleted},
-		Silent: true,
-	}
-	if err := c.raw.Store(imap.UIDSetNum(uids...), storeFlags, nil).Close(); err != nil {
-		return fmt.Errorf("imap: mark deleted: %w", err)
-	}
-	return nil
-}
-
-// Expunge permanently removes \Deleted messages. when the server advertises
-// UIDPLUS and uids are given it issues UID EXPUNGE, removing only those uids so
-// a \Deleted message another client left behind is untouched. otherwise a plain
-// EXPUNGE removes every \Deleted message in the mailbox.
-//
-// gmail diverges: \Deleted plus EXPUNGE inside an ordinary label only removes
-// that label, real deletion happens in [Gmail]/Trash or All Mail. a later
-// version may move to Trash on gmail instead, see push.go.
-func (c *Client) Expunge(uids ...imap.UID) error {
-	if len(uids) > 0 && c.raw.Caps().Has(imap.CapUIDPlus) {
+	if c.raw.Caps().Has(imap.CapUIDPlus) {
+		if err := c.markDeleted(uids); err != nil {
+			return err
+		}
 		if _, err := c.raw.UIDExpunge(imap.UIDSetNum(uids...)).Collect(); err != nil {
 			return fmt.Errorf("imap: uid expunge: %w", err)
 		}
 		return nil
 	}
+
+	// the search has to run before our own marks go on, or ours would come back
+	// as foreign. a failure here is not a reason to expunge blindly: without
+	// knowing what else is flagged there is no safe unscoped EXPUNGE.
+	existing, err := c.searchDeleted()
+	if err != nil {
+		return fmt.Errorf("imap: refusing to expunge without UIDPLUS, cannot tell what else is marked deleted: %w", err)
+	}
+	foreign := foreignDeleted(existing, uids)
+
+	if len(foreign) == 0 {
+		if err := c.markDeleted(uids); err != nil {
+			return err
+		}
+		return c.expungeAll()
+	}
+
+	if err := c.storeMany(foreign, imap.StoreFlagsDel, imap.FlagDeleted); err != nil {
+		return fmt.Errorf("imap: cannot protect another client's deletions, not expunging: %w", err)
+	}
+
+	markErr := c.markDeleted(uids)
+	var expungeErr error
+	if markErr == nil {
+		expungeErr = c.expungeAll()
+	}
+
+	// the marks go back on whatever happened above, and a failure to restore
+	// them is reported rather than swallowed: the other client's pending
+	// deletions are gone from its point of view until it marks them again.
+	var restoreErr error
+	if err := c.storeMany(foreign, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		restoreErr = fmt.Errorf("imap: could not restore %d \\Deleted mark(s) set by another client: %w", len(foreign), err)
+	}
+	return errors.Join(markErr, expungeErr, restoreErr)
+}
+
+// markDeleted sets \Deleted on the given uids in a single STORE. Nothing is
+// removed until an expunge runs.
+func (c *Client) markDeleted(uids []imap.UID) error {
+	if err := c.storeMany(uids, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		return fmt.Errorf("imap: mark deleted: %w", err)
+	}
+	return nil
+}
+
+// expungeAll issues a plain EXPUNGE, which removes every \Deleted message in
+// the mailbox. Only call it once the mailbox is known to hold no \Deleted
+// message other than the ones being deleted.
+func (c *Client) expungeAll() error {
 	if _, err := c.raw.Expunge().Collect(); err != nil {
 		return fmt.Errorf("imap: expunge: %w", err)
 	}
 	return nil
+}
+
+// searchDeleted returns the uids currently carrying \Deleted in the selected
+// mailbox.
+func (c *Client) searchDeleted() ([]imap.UID, error) {
+	if c.raw.Mailbox() == nil {
+		return nil, fmt.Errorf("imap: no mailbox selected")
+	}
+	criteria := &imap.SearchCriteria{Flag: []imap.Flag{imap.FlagDeleted}}
+	data, err := c.raw.UIDSearch(criteria, nil).Wait()
+	if err != nil {
+		return nil, fmt.Errorf("imap: search deleted: %w", err)
+	}
+	return data.AllUIDs(), nil
+}
+
+// storeMany issues one UID STORE for a set of uids. An empty set is a no-op
+// rather than a STORE with no target.
+func (c *Client) storeMany(uids []imap.UID, op imap.StoreFlagsOp, flags ...imap.Flag) error {
+	if len(uids) == 0 {
+		return nil
+	}
+	storeFlags := &imap.StoreFlags{Op: op, Flags: flags, Silent: true}
+	if err := c.raw.Store(imap.UIDSetNum(uids...), storeFlags, nil).Close(); err != nil {
+		return fmt.Errorf("imap: store flags on %d uid(s): %w", len(uids), err)
+	}
+	return nil
+}
+
+// foreignDeleted returns the uids that are flagged \Deleted but are not ours to
+// delete: the messages a plain EXPUNGE would take with it.
+func foreignDeleted(existing, ours []imap.UID) []imap.UID {
+	if len(existing) == 0 {
+		return nil
+	}
+	mine := make(map[imap.UID]struct{}, len(ours))
+	for _, uid := range ours {
+		mine[uid] = struct{}{}
+	}
+	var foreign []imap.UID
+	for _, uid := range existing {
+		if _, ok := mine[uid]; !ok {
+			foreign = append(foreign, uid)
+		}
+	}
+	return foreign
 }

--- a/internal/imap/expunge_test.go
+++ b/internal/imap/expunge_test.go
@@ -1,9 +1,12 @@
 package imap
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -20,14 +23,28 @@ const testMessage = "From: someone@example.com\r\n" +
 	"\r\n" +
 	"body\r\n"
 
-// newTestServer starts an in-memory imap server on localhost with the given
-// capabilities and returns a logged-in client with INBOX selected, holding one
-// message per subject.
+// testOptions configures the in-memory server a test runs against.
+type testOptions struct {
+	// caps is what the server advertises. nil is IMAP4rev1 only, which is a
+	// server without UIDPLUS: the dangerous case.
+	caps imap.CapSet
+	// failSearch makes SEARCH fail, so the client cannot learn what else is
+	// marked \Deleted.
+	failSearch bool
+	// failStoreAfter makes the nth STORE fail (1 = the first). 0 never fails.
+	// It is how the restore step is broken on purpose.
+	failStoreAfter int
+	// subjects seeds one message per subject.
+	subjects []string
+}
+
+// newTestServer starts an in-memory imap server on localhost and returns a
+// logged-in client with INBOX selected, plus the raw protocol stream both ways.
 //
 // Nothing here is a mock: it is the real go-imap server, so a plain EXPUNGE
 // behaves exactly as it does against a real one, which is the entire point of
 // these tests.
-func newTestServer(t *testing.T, caps imap.CapSet, subjects ...string) *Client {
+func newTestServer(t *testing.T, opts testOptions) (*Client, *wireLog) {
 	t.Helper()
 
 	mem := imapmemserver.New()
@@ -37,13 +54,19 @@ func newTestServer(t *testing.T, caps imap.CapSet, subjects ...string) *Client {
 	}
 	mem.AddUser(user)
 
+	wire := &wireLog{}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return mem.NewSession(), nil, nil
+			session := mem.NewSession()
+			if opts.failSearch || opts.failStoreAfter > 0 {
+				session = &brokenSession{Session: session, opts: opts}
+			}
+			return session, nil, nil
 		},
-		Caps:         caps,
+		Caps:         opts.caps,
 		InsecureAuth: true,
 		Logger:       discardLogger{},
+		DebugWriter:  wire,
 	})
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -62,7 +85,7 @@ func newTestServer(t *testing.T, caps imap.CapSet, subjects ...string) *Client {
 		t.Fatalf("login: %v", err)
 	}
 
-	for _, subject := range subjects {
+	for _, subject := range opts.subjects {
 		body := strings.Replace(testMessage, "%s", subject, 1)
 		cmd := raw.Append("INBOX", int64(len(body)), nil)
 		if _, err := cmd.Write([]byte(body)); err != nil {
@@ -80,13 +103,100 @@ func newTestServer(t *testing.T, caps imap.CapSet, subjects ...string) *Client {
 	if _, err := c.Select("INBOX"); err != nil {
 		t.Fatalf("select: %v", err)
 	}
-	return c
+	// the seeding above is not part of what a test asserts on.
+	wire.reset()
+	return c, wire
 }
 
 // discardLogger keeps the server's connection logging out of the test output.
 type discardLogger struct{}
 
 func (discardLogger) Printf(string, ...any) {}
+
+// plainServer is the common case these tests care about: no UIDPLUS.
+func plainServer(t *testing.T, subjects ...string) (*Client, *wireLog) {
+	t.Helper()
+	return newTestServer(t, testOptions{subjects: subjects})
+}
+
+// wireLog records the protocol stream so a test can assert on the commands
+// actually sent, not just on the mailbox that came out the other end.
+type wireLog struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (w *wireLog) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Write(p)
+	return len(p), nil
+}
+
+func (w *wireLog) reset() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Reset()
+}
+
+func (w *wireLog) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// commands returns the client commands seen, uppercased and without their tags,
+// in order.
+func (w *wireLog) commands() []string {
+	var out []string
+	for _, line := range strings.Split(w.String(), "\n") {
+		line = strings.TrimSpace(line)
+		// client lines are "<tag> COMMAND ..."; server lines start with * or +.
+		if line == "" || strings.HasPrefix(line, "*") || strings.HasPrefix(line, "+") {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		out = append(out, strings.ToUpper(parts[1]))
+	}
+	return out
+}
+
+// hasBareExpunge reports whether an unscoped EXPUNGE was sent, which is the
+// command that takes another client's marked mail with it.
+func (w *wireLog) hasBareExpunge() bool {
+	for _, cmd := range w.commands() {
+		if cmd == "EXPUNGE" {
+			return true
+		}
+	}
+	return false
+}
+
+// brokenSession makes a chosen command fail, to exercise the paths where the
+// server stops cooperating half way through a delete.
+type brokenSession struct {
+	imapserver.Session
+	opts   testOptions
+	stores int
+}
+
+func (s *brokenSession) Search(kind imapserver.NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error) {
+	if s.opts.failSearch {
+		return nil, errors.New("search is broken")
+	}
+	return s.Session.Search(kind, criteria, options)
+}
+
+func (s *brokenSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error {
+	s.stores++
+	if s.opts.failStoreAfter > 0 && s.stores == s.opts.failStoreAfter {
+		return errors.New("store is broken")
+	}
+	return s.Session.Store(w, numSet, flags, options)
+}
 
 // remainingSubjects returns the subjects still in the mailbox, in uid order.
 func remainingSubjects(t *testing.T, c *Client) []string {
@@ -125,7 +235,7 @@ func uidOf(t *testing.T, c *Client, subject string) imap.UID {
 // UIDPLUS. A plain EXPUNGE here takes both. Only the one Pelton was told to
 // delete may go.
 func TestDeleteMessagesLeavesAnotherClientsDeletedMail(t *testing.T) {
-	c := newTestServer(t, nil, "theirs", "ours", "untouched")
+	c, wire := plainServer(t, "theirs", "ours", "untouched")
 
 	theirs := uidOf(t, c, "theirs")
 	ours := uidOf(t, c, "ours")
@@ -134,6 +244,7 @@ func TestDeleteMessagesLeavesAnotherClientsDeletedMail(t *testing.T) {
 	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
 		t.Fatalf("mark theirs: %v", err)
 	}
+	wire.reset()
 
 	if err := c.DeleteMessages(ours); err != nil {
 		t.Fatalf("DeleteMessages: %v", err)
@@ -154,13 +265,29 @@ func TestDeleteMessagesLeavesAnotherClientsDeletedMail(t *testing.T) {
 	if !slices.Equal(deleted, []imap.UID{theirs}) {
 		t.Errorf("\\Deleted uids = %v, want just %v", deleted, theirs)
 	}
+
+	// and the shape of it on the wire: their mark comes off, ours goes on, the
+	// expunge runs, their mark goes back on.
+	wantCmds := []string{"UID STORE", "UID STORE", "EXPUNGE", "UID STORE"}
+	var gotCmds []string
+	for _, cmd := range wire.commands() {
+		for _, prefix := range wantCmds {
+			if strings.HasPrefix(cmd, prefix) {
+				gotCmds = append(gotCmds, prefix)
+				break
+			}
+		}
+	}
+	if !slices.Equal(gotCmds, wantCmds) {
+		t.Errorf("commands were %v, want %v\n%s", gotCmds, wantCmds, wire.String())
+	}
 }
 
 // TestDeleteMessagesWithUIDPlus covers the same scenario on a server that does
 // advertise UIDPLUS, where UID EXPUNGE does the scoping for us.
 func TestDeleteMessagesWithUIDPlus(t *testing.T) {
 	caps := imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapUIDPlus: {}}
-	c := newTestServer(t, caps, "theirs", "ours", "untouched")
+	c, wire := newTestServer(t, testOptions{caps: caps, subjects: []string{"theirs", "ours", "untouched"}})
 
 	theirs := uidOf(t, c, "theirs")
 	ours := uidOf(t, c, "ours")
@@ -177,12 +304,15 @@ func TestDeleteMessagesWithUIDPlus(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("mailbox holds %v, want %v", got, want)
 	}
+	if wire.hasBareExpunge() {
+		t.Errorf("an unscoped EXPUNGE was sent even though the server has UIDPLUS\n%s", wire.String())
+	}
 }
 
 // TestDeleteMessagesBatch deletes several at once, which is what a folder full
 // of pending deletes or an emptied trash does.
 func TestDeleteMessagesBatch(t *testing.T) {
-	c := newTestServer(t, nil, "one", "two", "three", "keep")
+	c, _ := plainServer(t, "one", "two", "three", "keep")
 
 	uids := []imap.UID{uidOf(t, c, "one"), uidOf(t, c, "two"), uidOf(t, c, "three")}
 	if err := c.DeleteMessages(uids...); err != nil {
@@ -199,7 +329,7 @@ func TestDeleteMessagesBatch(t *testing.T) {
 // an empty batch reaching a plain EXPUNGE and clearing whatever the mailbox
 // happened to have marked.
 func TestDeleteMessagesNoUIDsIsANoOp(t *testing.T) {
-	c := newTestServer(t, nil, "theirs", "keep")
+	c, wire := plainServer(t, "theirs", "keep")
 
 	theirs := uidOf(t, c, "theirs")
 	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
@@ -214,13 +344,16 @@ func TestDeleteMessagesNoUIDsIsANoOp(t *testing.T) {
 	if !slices.Equal(got, []string{"theirs", "keep"}) {
 		t.Fatalf("mailbox holds %v, want both messages", got)
 	}
+	if wire.hasBareExpunge() {
+		t.Errorf("an empty batch still reached EXPUNGE\n%s", wire.String())
+	}
 }
 
 // TestDeleteMessagesKeepsOurOwnEarlierMark covers a retry: a previous attempt
 // already flagged our message, so it comes back from the search. It is ours, so
 // it must not be treated as foreign and protected from its own deletion.
 func TestDeleteMessagesKeepsOurOwnEarlierMark(t *testing.T) {
-	c := newTestServer(t, nil, "ours", "keep")
+	c, _ := plainServer(t, "ours", "keep")
 
 	ours := uidOf(t, c, "ours")
 	if err := c.storeMany([]imap.UID{ours}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
@@ -254,5 +387,198 @@ func TestForeignDeleted(t *testing.T) {
 				t.Errorf("foreignDeleted() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDeleteMessagesLargeMixedBatch is the shape a real mailbox has: many
+// messages, another client's marks scattered through them, and a big batch of
+// our own deletions. Every one of ours must go and every one of theirs must
+// stay, with its mark.
+func TestDeleteMessagesLargeMixedBatch(t *testing.T) {
+	const total = 60
+	subjects := make([]string, 0, total)
+	for i := range total {
+		subjects = append(subjects, fmt.Sprintf("msg-%02d", i))
+	}
+	c, wire := plainServer(t, subjects...)
+
+	// every third message is one another client marked, every other one is ours
+	// to delete, and the rest are bystanders.
+	var theirs, ours []imap.UID
+	var wantLeft []string
+	for i, subject := range subjects {
+		uid := uidOf(t, c, subject)
+		switch {
+		case i%3 == 0:
+			theirs = append(theirs, uid)
+			wantLeft = append(wantLeft, subject)
+		case i%2 == 1:
+			ours = append(ours, uid)
+		default:
+			wantLeft = append(wantLeft, subject)
+		}
+	}
+	if len(theirs) == 0 || len(ours) == 0 {
+		t.Fatalf("bad fixture: %d theirs, %d ours", len(theirs), len(ours))
+	}
+	if err := c.storeMany(theirs, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	if err := c.DeleteMessages(ours...); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+
+	if got := remainingSubjects(t, c); !slices.Equal(got, wantLeft) {
+		t.Errorf("mailbox holds %v,\nwant %v", got, wantLeft)
+	}
+	deleted, err := c.searchDeleted()
+	if err != nil {
+		t.Fatalf("search deleted: %v", err)
+	}
+	if !slices.Equal(deleted, theirs) {
+		t.Errorf("\\Deleted uids = %v, want %v", deleted, theirs)
+	}
+}
+
+// TestDeleteEveryMessageWithAForeignMark is the emptied trash: the batch is the
+// whole folder except what another client marked, which still has to survive.
+func TestDeleteEveryMessageWithAForeignMark(t *testing.T) {
+	c, _ := plainServer(t, "theirs", "a", "b", "c")
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	ours := []imap.UID{uidOf(t, c, "a"), uidOf(t, c, "b"), uidOf(t, c, "c")}
+
+	if err := c.DeleteMessages(ours...); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs"}) {
+		t.Fatalf("mailbox holds %v, want just [theirs]", got)
+	}
+}
+
+// TestDeleteMessagesRefusesWhenItCannotSeeWhatIsMarked: with no UIDPLUS and no
+// working SEARCH there is no way to know what a plain EXPUNGE would take, so
+// nothing is expunged at all. Failing a delete is recoverable; guessing is not.
+func TestDeleteMessagesRefusesWhenItCannotSeeWhatIsMarked(t *testing.T) {
+	c, wire := newTestServer(t, testOptions{
+		failSearch: true,
+		subjects:   []string{"theirs", "ours", "keep"},
+	})
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	err := c.DeleteMessages(uidOf(t, c, "ours"))
+	if err == nil {
+		t.Fatal("DeleteMessages returned no error when it could not search")
+	}
+	if wire.hasBareExpunge() {
+		t.Errorf("expunged anyway after the search failed\n%s", wire.String())
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
+		t.Errorf("mailbox holds %v, want all three still there", got)
+	}
+}
+
+// TestDeleteMessagesReportsAFailedRestore: the expunge went through but the
+// other client's marks could not be put back. The caller has to hear about it,
+// because from that client's side its pending deletions have been undone.
+func TestDeleteMessagesReportsAFailedRestore(t *testing.T) {
+	// stores in order: the test's own mark (1), lift the foreign mark (2), mark
+	// ours (3), restore the foreign mark (4).
+	c, _ := newTestServer(t, testOptions{
+		failStoreAfter: 4,
+		subjects:       []string{"theirs", "ours", "keep"},
+	})
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+
+	err := c.DeleteMessages(uidOf(t, c, "ours"))
+	if err == nil {
+		t.Fatal("DeleteMessages hid a failed restore")
+	}
+	if !strings.Contains(err.Error(), "restore") {
+		t.Errorf("error = %v, want it to say the marks could not be restored", err)
+	}
+	// the delete itself still happened, and nothing of theirs was lost with it.
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Errorf("mailbox holds %v, want [theirs keep]", got)
+	}
+}
+
+// TestDeleteMessagesStopsWhenItCannotLiftForeignMarks: if the marks cannot be
+// taken off, expunging would destroy that mail, so the delete does not happen.
+func TestDeleteMessagesStopsWhenItCannotLiftForeignMarks(t *testing.T) {
+	// stores in order: the test's own mark (1), lift the foreign mark (2).
+	c, wire := newTestServer(t, testOptions{
+		failStoreAfter: 2,
+		subjects:       []string{"theirs", "ours", "keep"},
+	})
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	if err := c.DeleteMessages(uidOf(t, c, "ours")); err == nil {
+		t.Fatal("DeleteMessages carried on after it could not lift the foreign marks")
+	}
+	if wire.hasBareExpunge() {
+		t.Errorf("expunged with the foreign marks still on\n%s", wire.String())
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
+		t.Errorf("mailbox holds %v, want all three still there", got)
+	}
+}
+
+// TestDeleteMessagesTwiceIsHarmless covers the retry a failed push does on the
+// next sync, once the message is already gone.
+func TestDeleteMessagesTwiceIsHarmless(t *testing.T) {
+	c, _ := plainServer(t, "theirs", "ours", "keep")
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	ours := uidOf(t, c, "ours")
+
+	if err := c.DeleteMessages(ours); err != nil {
+		t.Fatalf("first DeleteMessages: %v", err)
+	}
+	if err := c.DeleteMessages(ours); err != nil {
+		t.Fatalf("second DeleteMessages on a gone uid: %v", err)
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Errorf("mailbox holds %v, want [theirs keep]", got)
+	}
+}
+
+// TestDeleteMessagesUnknownUID: a uid that was never in the mailbox must not
+// turn into a mailbox-wide expunge.
+func TestDeleteMessagesUnknownUID(t *testing.T) {
+	c, _ := plainServer(t, "theirs", "keep")
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+
+	if err := c.DeleteMessages(imap.UID(9999)); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Errorf("mailbox holds %v, want both messages", got)
 	}
 }

--- a/internal/imap/expunge_test.go
+++ b/internal/imap/expunge_test.go
@@ -1,0 +1,258 @@
+package imap
+
+import (
+	"net"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// the messages the tests put in the mailbox. Content does not matter, only that
+// each is a distinct message with its own uid.
+const testMessage = "From: someone@example.com\r\n" +
+	"To: me@example.com\r\n" +
+	"Subject: %s\r\n" +
+	"\r\n" +
+	"body\r\n"
+
+// newTestServer starts an in-memory imap server on localhost with the given
+// capabilities and returns a logged-in client with INBOX selected, holding one
+// message per subject.
+//
+// Nothing here is a mock: it is the real go-imap server, so a plain EXPUNGE
+// behaves exactly as it does against a real one, which is the entire point of
+// these tests.
+func newTestServer(t *testing.T, caps imap.CapSet, subjects ...string) *Client {
+	t.Helper()
+
+	mem := imapmemserver.New()
+	user := imapmemserver.NewUser("user", "pass")
+	if err := user.Create("INBOX", nil); err != nil {
+		t.Fatalf("create INBOX: %v", err)
+	}
+	mem.AddUser(user)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		Caps:         caps,
+		InsecureAuth: true,
+		Logger:       discardLogger{},
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	raw := imapclient.New(conn, nil)
+	t.Cleanup(func() { _ = raw.Close() })
+	if err := raw.Login("user", "pass").Wait(); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	for _, subject := range subjects {
+		body := strings.Replace(testMessage, "%s", subject, 1)
+		cmd := raw.Append("INBOX", int64(len(body)), nil)
+		if _, err := cmd.Write([]byte(body)); err != nil {
+			t.Fatalf("append %q: %v", subject, err)
+		}
+		if err := cmd.Close(); err != nil {
+			t.Fatalf("close append %q: %v", subject, err)
+		}
+		if _, err := cmd.Wait(); err != nil {
+			t.Fatalf("append %q: %v", subject, err)
+		}
+	}
+
+	c := &Client{raw: raw}
+	if _, err := c.Select("INBOX"); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	return c
+}
+
+// discardLogger keeps the server's connection logging out of the test output.
+type discardLogger struct{}
+
+func (discardLogger) Printf(string, ...any) {}
+
+// remainingSubjects returns the subjects still in the mailbox, in uid order.
+func remainingSubjects(t *testing.T, c *Client) []string {
+	t.Helper()
+	headers, err := c.FetchRecentHeaders(100)
+	if err != nil {
+		t.Fatalf("fetch headers: %v", err)
+	}
+	slices.SortFunc(headers, func(a, b MessageHeader) int { return int(a.UID) - int(b.UID) })
+	out := make([]string, 0, len(headers))
+	for _, h := range headers {
+		out = append(out, h.Subject)
+	}
+	return out
+}
+
+// uidOf returns the uid of the message with the given subject.
+func uidOf(t *testing.T, c *Client, subject string) imap.UID {
+	t.Helper()
+	headers, err := c.FetchRecentHeaders(100)
+	if err != nil {
+		t.Fatalf("fetch headers: %v", err)
+	}
+	for _, h := range headers {
+		if h.Subject == subject {
+			return h.UID
+		}
+	}
+	t.Fatalf("no message with subject %q", subject)
+	return 0
+}
+
+// TestDeleteMessagesLeavesAnotherClientsDeletedMail is the regression test for
+// the destructive case: Thunderbird marked a message \Deleted and has not
+// expunged it, Pelton is asked to delete a different one, and the server has no
+// UIDPLUS. A plain EXPUNGE here takes both. Only the one Pelton was told to
+// delete may go.
+func TestDeleteMessagesLeavesAnotherClientsDeletedMail(t *testing.T) {
+	c := newTestServer(t, nil, "theirs", "ours", "untouched")
+
+	theirs := uidOf(t, c, "theirs")
+	ours := uidOf(t, c, "ours")
+
+	// another client marks its message and leaves it sitting there.
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+
+	if err := c.DeleteMessages(ours); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+
+	got := remainingSubjects(t, c)
+	want := []string{"theirs", "untouched"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("mailbox holds %v, want %v", got, want)
+	}
+
+	// and their mark has to survive too, or their pending deletion is silently
+	// undone.
+	deleted, err := c.searchDeleted()
+	if err != nil {
+		t.Fatalf("search deleted: %v", err)
+	}
+	if !slices.Equal(deleted, []imap.UID{theirs}) {
+		t.Errorf("\\Deleted uids = %v, want just %v", deleted, theirs)
+	}
+}
+
+// TestDeleteMessagesWithUIDPlus covers the same scenario on a server that does
+// advertise UIDPLUS, where UID EXPUNGE does the scoping for us.
+func TestDeleteMessagesWithUIDPlus(t *testing.T) {
+	caps := imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapUIDPlus: {}}
+	c := newTestServer(t, caps, "theirs", "ours", "untouched")
+
+	theirs := uidOf(t, c, "theirs")
+	ours := uidOf(t, c, "ours")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+
+	if err := c.DeleteMessages(ours); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+
+	got := remainingSubjects(t, c)
+	want := []string{"theirs", "untouched"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("mailbox holds %v, want %v", got, want)
+	}
+}
+
+// TestDeleteMessagesBatch deletes several at once, which is what a folder full
+// of pending deletes or an emptied trash does.
+func TestDeleteMessagesBatch(t *testing.T) {
+	c := newTestServer(t, nil, "one", "two", "three", "keep")
+
+	uids := []imap.UID{uidOf(t, c, "one"), uidOf(t, c, "two"), uidOf(t, c, "three")}
+	if err := c.DeleteMessages(uids...); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+
+	got := remainingSubjects(t, c)
+	if !slices.Equal(got, []string{"keep"}) {
+		t.Fatalf("mailbox holds %v, want just [keep]", got)
+	}
+}
+
+// TestDeleteMessagesNoUIDsIsANoOp guards the case that would be worst of all:
+// an empty batch reaching a plain EXPUNGE and clearing whatever the mailbox
+// happened to have marked.
+func TestDeleteMessagesNoUIDsIsANoOp(t *testing.T) {
+	c := newTestServer(t, nil, "theirs", "keep")
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+
+	if err := c.DeleteMessages(); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+
+	got := remainingSubjects(t, c)
+	if !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Fatalf("mailbox holds %v, want both messages", got)
+	}
+}
+
+// TestDeleteMessagesKeepsOurOwnEarlierMark covers a retry: a previous attempt
+// already flagged our message, so it comes back from the search. It is ours, so
+// it must not be treated as foreign and protected from its own deletion.
+func TestDeleteMessagesKeepsOurOwnEarlierMark(t *testing.T) {
+	c := newTestServer(t, nil, "ours", "keep")
+
+	ours := uidOf(t, c, "ours")
+	if err := c.storeMany([]imap.UID{ours}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("pre-mark ours: %v", err)
+	}
+
+	if err := c.DeleteMessages(ours); err != nil {
+		t.Fatalf("DeleteMessages: %v", err)
+	}
+	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"keep"}) {
+		t.Fatalf("mailbox holds %v, want just [keep]", got)
+	}
+}
+
+func TestForeignDeleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []imap.UID
+		ours     []imap.UID
+		want     []imap.UID
+	}{
+		{"nothing marked", nil, []imap.UID{1}, nil},
+		{"only ours marked", []imap.UID{1, 2}, []imap.UID{1, 2}, nil},
+		{"one foreign", []imap.UID{1, 2, 3}, []imap.UID{2}, []imap.UID{1, 3}},
+		{"all foreign", []imap.UID{7, 8}, []imap.UID{1}, []imap.UID{7, 8}},
+		{"deleting nothing makes everything foreign", []imap.UID{7}, nil, []imap.UID{7}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := foreignDeleted(tt.existing, tt.ours); !slices.Equal(got, tt.want) {
+				t.Errorf("foreignDeleted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sync/delete_test.go
+++ b/internal/sync/delete_test.go
@@ -1,0 +1,113 @@
+package sync
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestSyncOnlyDeletesWhatTheUserDeleted is the guard on the whole destructive
+// path: a folder sync must hand the imap layer exactly the uids the user marked
+// for deletion, and never widen that set because the cache and the server
+// disagree about anything else.
+func TestSyncOnlyDeletesWhatTheUserDeleted(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2, 3, 4, 5}}
+	engine := NewEngine(client, db, nil)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	states, err := db.ListMessageStates(ctx, folder.ID)
+	if err != nil {
+		t.Fatalf("list states: %v", err)
+	}
+	if len(states) != 5 {
+		t.Fatalf("cached %d messages, want 5", len(states))
+	}
+	// the user deletes exactly one of them.
+	var target uint32
+	for _, s := range states {
+		if s.UID == 3 {
+			target = s.UID
+			if err := db.MarkDeletePending(ctx, s.ID); err != nil {
+				t.Fatalf("mark pending: %v", err)
+			}
+		}
+	}
+	if target == 0 {
+		t.Fatal("uid 3 was not cached")
+	}
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	if !slices.Equal(client.deleted, []imap.UID{3}) {
+		t.Errorf("sync asked the server to delete %v, want just [3]", client.deleted)
+	}
+}
+
+// TestSyncDeletesNothingOnTheServerWhenTheCacheIsStale covers the case that
+// would be worst: the server dropped messages the cache still has. That is a
+// local cleanup, and it must never turn into a server-side delete.
+func TestSyncDeletesNothingOnTheServerWhenTheCacheIsStale(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2, 3, 4, 5}}
+	engine := NewEngine(client, db, nil)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	// the server now reports an empty mailbox, the shape a bad SELECT or another
+	// client emptying the folder would produce.
+	client.uids = nil
+	res, err := engine.SyncFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if res.Deleted != 5 {
+		t.Errorf("dropped %d cached messages, want 5", res.Deleted)
+	}
+	if len(client.deleted) != 0 {
+		t.Errorf("sync deleted %v on the server, want nothing", client.deleted)
+	}
+}
+
+// TestSyncDoesNotPushADeleteTheServerAlreadyApplied: the message is gone
+// upstream, so there is nothing to expunge and the local row just goes.
+func TestSyncDoesNotPushADeleteTheServerAlreadyApplied(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2}}
+	engine := NewEngine(client, db, nil)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	states, err := db.ListMessageStates(ctx, folder.ID)
+	if err != nil {
+		t.Fatalf("list states: %v", err)
+	}
+	for _, s := range states {
+		if s.UID == 2 {
+			if err := db.MarkDeletePending(ctx, s.ID); err != nil {
+				t.Fatalf("mark pending: %v", err)
+			}
+		}
+	}
+
+	client.uids = []uint32{1}
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if len(client.deleted) != 0 {
+		t.Errorf("sync deleted %v on the server, want nothing", client.deleted)
+	}
+}

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -44,15 +44,15 @@ func (e *Engine) clearPending(ctx context.Context, state storage.MessageState, f
 }
 
 // pushDeletes deletes the given messages on the server, then removes them from
-// the cache. it marks all uids \Deleted in one STORE and expunges them in one
-// call, so a folder with many local deletions costs two round trips, not two
-// per message.
+// the cache. the whole batch goes in one DeleteMessages call, so a folder with
+// many local deletions costs a couple of round trips rather than a couple per
+// message, and the imap layer keeps the removal scoped to exactly these uids.
 //
 // decision: delete means \Deleted + EXPUNGE here, not move-to-Trash. it is the
 // standard, provider neutral delete. the known divergence is gmail, where this
-// only removes a label inside an ordinary mailbox, see Expunge in the imap
-// package. moving to the account's Trash folder is the cleaner gmail behaviour
-// and is a candidate for a later version.
+// only removes a label inside an ordinary mailbox, see DeleteMessages in the
+// imap package. moving to the account's Trash folder is the cleaner gmail
+// behaviour and is a candidate for a later version.
 func (e *Engine) pushDeletes(ctx context.Context, folder storage.Folder, states []storage.MessageState) error {
 	if len(states) == 0 {
 		return nil
@@ -63,11 +63,10 @@ func (e *Engine) pushDeletes(ctx context.Context, folder storage.Folder, states 
 		uids = append(uids, imap.UID(s.UID))
 	}
 
-	if err := e.client.MarkDeleted(uids...); err != nil {
-		return fmt.Errorf("sync: mark deleted on server: %w", err)
-	}
-	if err := e.client.Expunge(uids...); err != nil {
-		return fmt.Errorf("sync: expunge on server: %w", err)
+	// scoped to exactly these uids by the imap layer, which will not issue an
+	// expunge that could take a message another client merely flagged.
+	if err := e.client.DeleteMessages(uids...); err != nil {
+		return fmt.Errorf("sync: delete on server: %w", err)
 	}
 
 	// server delete succeeded, now drop the local rows and their files.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -19,8 +19,7 @@ type mailClient interface {
 	FetchAllFlags() ([]pimap.MessageHeader, error)
 	FetchMessage(uid imap.UID) (*pimap.Message, error)
 	AddFlags(uid imap.UID, flags ...imap.Flag) error
-	MarkDeleted(uids ...imap.UID) error
-	Expunge(uids ...imap.UID) error
+	DeleteMessages(uids ...imap.UID) error
 }
 
 // Engine orchestrates one account's imap connection and the local store. It is

--- a/internal/sync/window_test.go
+++ b/internal/sync/window_test.go
@@ -206,6 +206,9 @@ type fakeClient struct {
 	// uidValidity defaults to 1; a test changes it to simulate a server-side
 	// mailbox reset.
 	uidValidity uint32
+	// deleted records every uid handed to DeleteMessages, so a test can assert
+	// that a sync only ever asks to delete what the user deleted.
+	deleted []imap.UID
 }
 
 func (c *fakeClient) Select(string) (*pimap.Mailbox, error) {
@@ -230,8 +233,10 @@ func (c *fakeClient) FetchMessage(uid imap.UID) (*pimap.Message, error) {
 }
 
 func (c *fakeClient) AddFlags(imap.UID, ...imap.Flag) error { return nil }
-func (c *fakeClient) MarkDeleted(...imap.UID) error         { return nil }
-func (c *fakeClient) Expunge(...imap.UID) error             { return nil }
+func (c *fakeClient) DeleteMessages(uids ...imap.UID) error {
+	c.deleted = append(c.deleted, uids...)
+	return nil
+}
 
 func newSyncTestFolder(t *testing.T) (*storage.DB, storage.Folder) {
 	t.Helper()


### PR DESCRIPTION
Closes #276.

Without UIDPLUS, pushDeletes fell back to a plain EXPUNGE, which removes every
\Deleted message in the mailbox and not only the ones Pelton marked. Another
client that marks without expunging, which is ordinary Thunderbird behaviour,
could lose mail because I deleted something unrelated in Pelton.

DeleteMessages now owns the whole sequence and never issues an unscoped
expunge:

- UIDPLUS present: UID EXPUNGE, scoped by the server.
- No UIDPLUS: search for what is already marked, and if nothing foreign is
  there a plain EXPUNGE is already exact.
- No UIDPLUS with foreign marks: lift those marks, expunge, put them back. The
  worst case becomes a flag another client has to set again rather than mail
  nobody can get back, and a failed restore is reported instead of swallowed.
- Search fails: refuse to expunge at all rather than guess.

The unsafe primitive is gone from the package surface, so sync cannot reach it.

Tests run against a real in-process go-imap server, not a mock, so a plain
EXPUNGE behaves as it does against a real one. The main one puts a message
marked by "another client" next to the one being deleted on a server with no
UIDPLUS and asserts both that the other message survives and that its mark
survives. I checked it fails on the old code. Also covered: the UIDPLUS path,
batches, an empty batch reaching EXPUNGE, and a retry where our own earlier
mark comes back from the search.

On the sync side, three tests assert the engine only ever asks to delete the
uids the user marked: not when the server view is empty and the cache is stale,
and not when the server already applied the delete.