### PR TITLE
fix: keep moves from expunging other mail

### DIFF
--- a/internal/imap/expunge_test.go
+++ b/internal/imap/expunge_test.go
@@ -108,6 +108,11 @@ func newTestServer(t *testing.T, opts testOptions) (*Client, *wireLog) {
 	return c, wire
 }
 
+// createMailbox adds a mailbox to the running test server, for the move tests.
+func createMailbox(c *Client, name string) error {
+	return c.raw.Create(name, nil).Wait()
+}
+
 // discardLogger keeps the server's connection logging out of the test output.
 type discardLogger struct{}
 
@@ -198,10 +203,15 @@ func (s *brokenSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, fla
 	return s.Session.Store(w, numSet, flags, options)
 }
 
-// remainingSubjects returns the subjects still in the mailbox, in uid order.
-func remainingSubjects(t *testing.T, c *Client) []string {
+// mailboxSubjects returns the subjects a mailbox holds, in uid order. It
+// re-selects first: the client's cached message count follows the untagged
+// EXPUNGE responses, and those are not something a test should assert through.
+func mailboxSubjects(t *testing.T, c *Client, mailbox string) []string {
 	t.Helper()
-	headers, err := c.FetchRecentHeaders(100)
+	if _, err := c.Select(mailbox); err != nil {
+		t.Fatalf("select %q: %v", mailbox, err)
+	}
+	headers, err := c.FetchRecentHeaders(1000)
 	if err != nil {
 		t.Fatalf("fetch headers: %v", err)
 	}
@@ -213,10 +223,13 @@ func remainingSubjects(t *testing.T, c *Client) []string {
 	return out
 }
 
-// uidOf returns the uid of the message with the given subject.
+// uidOf returns the uid of the message with the given subject in INBOX.
 func uidOf(t *testing.T, c *Client, subject string) imap.UID {
 	t.Helper()
-	headers, err := c.FetchRecentHeaders(100)
+	if _, err := c.Select("INBOX"); err != nil {
+		t.Fatalf("select INBOX: %v", err)
+	}
+	headers, err := c.FetchRecentHeaders(1000)
 	if err != nil {
 		t.Fatalf("fetch headers: %v", err)
 	}
@@ -250,7 +263,7 @@ func TestDeleteMessagesLeavesAnotherClientsDeletedMail(t *testing.T) {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
 
-	got := remainingSubjects(t, c)
+	got := mailboxSubjects(t, c, "INBOX")
 	want := []string{"theirs", "untouched"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("mailbox holds %v, want %v", got, want)
@@ -299,7 +312,7 @@ func TestDeleteMessagesWithUIDPlus(t *testing.T) {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
 
-	got := remainingSubjects(t, c)
+	got := mailboxSubjects(t, c, "INBOX")
 	want := []string{"theirs", "untouched"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("mailbox holds %v, want %v", got, want)
@@ -319,7 +332,7 @@ func TestDeleteMessagesBatch(t *testing.T) {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
 
-	got := remainingSubjects(t, c)
+	got := mailboxSubjects(t, c, "INBOX")
 	if !slices.Equal(got, []string{"keep"}) {
 		t.Fatalf("mailbox holds %v, want just [keep]", got)
 	}
@@ -340,7 +353,7 @@ func TestDeleteMessagesNoUIDsIsANoOp(t *testing.T) {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
 
-	got := remainingSubjects(t, c)
+	got := mailboxSubjects(t, c, "INBOX")
 	if !slices.Equal(got, []string{"theirs", "keep"}) {
 		t.Fatalf("mailbox holds %v, want both messages", got)
 	}
@@ -363,7 +376,7 @@ func TestDeleteMessagesKeepsOurOwnEarlierMark(t *testing.T) {
 	if err := c.DeleteMessages(ours); err != nil {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"keep"}) {
 		t.Fatalf("mailbox holds %v, want just [keep]", got)
 	}
 }
@@ -430,7 +443,7 @@ func TestDeleteMessagesLargeMixedBatch(t *testing.T) {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
 
-	if got := remainingSubjects(t, c); !slices.Equal(got, wantLeft) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, wantLeft) {
 		t.Errorf("mailbox holds %v,\nwant %v", got, wantLeft)
 	}
 	deleted, err := c.searchDeleted()
@@ -456,7 +469,7 @@ func TestDeleteEveryMessageWithAForeignMark(t *testing.T) {
 	if err := c.DeleteMessages(ours...); err != nil {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs"}) {
 		t.Fatalf("mailbox holds %v, want just [theirs]", got)
 	}
 }
@@ -483,7 +496,7 @@ func TestDeleteMessagesRefusesWhenItCannotSeeWhatIsMarked(t *testing.T) {
 	if wire.hasBareExpunge() {
 		t.Errorf("expunged anyway after the search failed\n%s", wire.String())
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
 		t.Errorf("mailbox holds %v, want all three still there", got)
 	}
 }
@@ -512,7 +525,7 @@ func TestDeleteMessagesReportsAFailedRestore(t *testing.T) {
 		t.Errorf("error = %v, want it to say the marks could not be restored", err)
 	}
 	// the delete itself still happened, and nothing of theirs was lost with it.
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
 		t.Errorf("mailbox holds %v, want [theirs keep]", got)
 	}
 }
@@ -538,7 +551,7 @@ func TestDeleteMessagesStopsWhenItCannotLiftForeignMarks(t *testing.T) {
 	if wire.hasBareExpunge() {
 		t.Errorf("expunged with the foreign marks still on\n%s", wire.String())
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "ours", "keep"}) {
 		t.Errorf("mailbox holds %v, want all three still there", got)
 	}
 }
@@ -560,7 +573,7 @@ func TestDeleteMessagesTwiceIsHarmless(t *testing.T) {
 	if err := c.DeleteMessages(ours); err != nil {
 		t.Fatalf("second DeleteMessages on a gone uid: %v", err)
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
 		t.Errorf("mailbox holds %v, want [theirs keep]", got)
 	}
 }
@@ -578,7 +591,7 @@ func TestDeleteMessagesUnknownUID(t *testing.T) {
 	if err := c.DeleteMessages(imap.UID(9999)); err != nil {
 		t.Fatalf("DeleteMessages: %v", err)
 	}
-	if got := remainingSubjects(t, c); !slices.Equal(got, []string{"theirs", "keep"}) {
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
 		t.Errorf("mailbox holds %v, want both messages", got)
 	}
 }

--- a/internal/imap/move.go
+++ b/internal/imap/move.go
@@ -6,15 +6,42 @@ import (
 	"github.com/emersion/go-imap/v2"
 )
 
-// Move moves the message with the given UID to another mailbox. go-imap falls
-// back to COPY + STORE \Deleted + EXPUNGE when the server lacks the MOVE
-// extension, so this works on older servers too. A mailbox must be selected.
+// Move moves the message with the given UID to another mailbox. A mailbox must
+// be selected.
 func (c *Client) Move(uid imap.UID, mailbox string) error {
+	return c.MoveMessages([]imap.UID{uid}, mailbox)
+}
+
+// MoveMessages moves the given UIDs to another mailbox in one operation. A
+// mailbox must be selected.
+//
+// When the server has the MOVE extension this is a single atomic command. When
+// it does not, the move is a copy followed by a delete, and that delete goes
+// through DeleteMessages so it stays scoped to these uids. go-imap has its own
+// fallback for the same case, but it finishes with a plain EXPUNGE, which would
+// take any message another client had merely flagged \Deleted (#276). So the
+// fallback is done here instead.
+func (c *Client) MoveMessages(uids []imap.UID, mailbox string) error {
+	if len(uids) == 0 {
+		return nil
+	}
 	if c.raw.Mailbox() == nil {
 		return fmt.Errorf("imap: no mailbox selected for move")
 	}
-	if _, err := c.raw.Move(imap.UIDSetNum(uid), mailbox).Wait(); err != nil {
-		return fmt.Errorf("imap: move uid %d to %q: %w", uid, mailbox, err)
+	if c.raw.Caps().Has(imap.CapMove) {
+		if _, err := c.raw.Move(imap.UIDSetNum(uids...), mailbox).Wait(); err != nil {
+			return fmt.Errorf("imap: move %d uid(s) to %q: %w", len(uids), mailbox, err)
+		}
+		return nil
+	}
+
+	// copy first: if this fails nothing has been removed, and the mail is still
+	// where it was.
+	if _, err := c.raw.Copy(imap.UIDSetNum(uids...), mailbox).Wait(); err != nil {
+		return fmt.Errorf("imap: copy %d uid(s) to %q: %w", len(uids), mailbox, err)
+	}
+	if err := c.DeleteMessages(uids...); err != nil {
+		return fmt.Errorf("imap: move %d uid(s) to %q, copied but not removed from the source: %w", len(uids), mailbox, err)
 	}
 	return nil
 }

--- a/internal/imap/move_test.go
+++ b/internal/imap/move_test.go
@@ -1,0 +1,128 @@
+package imap
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestMoveWithoutMoveExtensionLeavesForeignDeletedMail is the move-path twin of
+// TestDeleteMessagesLeavesAnotherClientsDeletedMail. Without the MOVE
+// extension a move is a copy plus a delete, and go-imap's own fallback ends in
+// a plain EXPUNGE, which would take a message another client had only flagged.
+func TestMoveWithoutMoveExtensionLeavesForeignDeletedMail(t *testing.T) {
+	c, wire := newTestServer(t, testOptions{subjects: []string{"theirs", "ours", "keep"}})
+	if err := createMailbox(c, "Archive"); err != nil {
+		t.Fatalf("create Archive: %v", err)
+	}
+
+	theirs := uidOf(t, c, "theirs")
+	ours := uidOf(t, c, "ours")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	if err := c.MoveMessages([]imap.UID{ours}, "Archive"); err != nil {
+		t.Fatalf("MoveMessages: %v", err)
+	}
+
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Fatalf("source holds %v, want [theirs keep]", got)
+	}
+	deleted, err := c.searchDeleted()
+	if err != nil {
+		t.Fatalf("search deleted: %v", err)
+	}
+	if !slices.Equal(deleted, []imap.UID{theirs}) {
+		t.Errorf("\\Deleted uids = %v, want just %v", deleted, theirs)
+	}
+
+	// and the message really did arrive at the destination.
+	if got := mailboxSubjects(t, c, "Archive"); !slices.Equal(got, []string{"ours"}) {
+		t.Errorf("destination holds %v, want [ours]", got)
+	}
+}
+
+// TestMoveWithMoveExtension covers the ordinary path, where the server does it
+// all in one command.
+func TestMoveWithMoveExtension(t *testing.T) {
+	caps := imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapMove: {}}
+	c, wire := newTestServer(t, testOptions{caps: caps, subjects: []string{"theirs", "ours", "keep"}})
+	if err := createMailbox(c, "Archive"); err != nil {
+		t.Fatalf("create Archive: %v", err)
+	}
+
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	if err := c.MoveMessages([]imap.UID{uidOf(t, c, "ours")}, "Archive"); err != nil {
+		t.Fatalf("MoveMessages: %v", err)
+	}
+	if wire.hasBareExpunge() {
+		t.Errorf("a move on a MOVE-capable server sent an EXPUNGE\n%s", wire.String())
+	}
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Errorf("source holds %v, want [theirs keep]", got)
+	}
+}
+
+// TestMoveBatchWithoutMoveExtension moves several at once, which is what a
+// delete of a multi-selection turns into.
+func TestMoveBatchWithoutMoveExtension(t *testing.T) {
+	c, _ := newTestServer(t, testOptions{subjects: []string{"a", "b", "c", "keep"}})
+	if err := createMailbox(c, "Trash"); err != nil {
+		t.Fatalf("create Trash: %v", err)
+	}
+
+	uids := []imap.UID{uidOf(t, c, "a"), uidOf(t, c, "b"), uidOf(t, c, "c")}
+	if err := c.MoveMessages(uids, "Trash"); err != nil {
+		t.Fatalf("MoveMessages: %v", err)
+	}
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"keep"}) {
+		t.Fatalf("source holds %v, want just [keep]", got)
+	}
+	if got := mailboxSubjects(t, c, "Trash"); !slices.Equal(got, []string{"a", "b", "c"}) {
+		t.Errorf("destination holds %v, want [a b c]", got)
+	}
+}
+
+// TestMoveNothingIsANoOp: an empty set must not reach the copy or the delete.
+func TestMoveNothingIsANoOp(t *testing.T) {
+	c, wire := newTestServer(t, testOptions{subjects: []string{"theirs", "keep"}})
+	if err := createMailbox(c, "Trash"); err != nil {
+		t.Fatalf("create Trash: %v", err)
+	}
+	theirs := uidOf(t, c, "theirs")
+	if err := c.storeMany([]imap.UID{theirs}, imap.StoreFlagsAdd, imap.FlagDeleted); err != nil {
+		t.Fatalf("mark theirs: %v", err)
+	}
+	wire.reset()
+
+	if err := c.MoveMessages(nil, "Trash"); err != nil {
+		t.Fatalf("MoveMessages: %v", err)
+	}
+	if wire.hasBareExpunge() {
+		t.Errorf("an empty move reached EXPUNGE\n%s", wire.String())
+	}
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"theirs", "keep"}) {
+		t.Errorf("source holds %v, want both messages", got)
+	}
+}
+
+// TestMoveToAMissingMailboxKeepsTheSource: the copy fails, so nothing may be
+// removed from where it is.
+func TestMoveToAMissingMailboxKeepsTheSource(t *testing.T) {
+	c, _ := newTestServer(t, testOptions{subjects: []string{"ours", "keep"}})
+
+	if err := c.MoveMessages([]imap.UID{uidOf(t, c, "ours")}, "NoSuchMailbox"); err == nil {
+		t.Fatal("MoveMessages to a missing mailbox returned no error")
+	}
+	if got := mailboxSubjects(t, c, "INBOX"); !slices.Equal(got, []string{"ours", "keep"}) {
+		t.Errorf("source holds %v, want both messages", got)
+	}
+}


### PR DESCRIPTION
Closes #278.

Same root cause as #276, found while testing it. go-imap's own MOVE fallback is
COPY, then STORE +FLAGS \Deleted, then EXPUNGE, and that EXPUNGE is unscoped
without UIDPLUS. So archive, move to folder and undo-archive could all take a
message another client had only flagged.

It is also unconditional: the STORE and the EXPUNGE run even when the COPY
failed. Moving to a mailbox that does not exist removed the message from where
it was and put it nowhere. There is a test for that.

MoveMessages now does the fallback itself: MOVE when the server has it,
otherwise COPY and then the scoped DeleteMessages from #277, and only if the
copy actually succeeded. Move is a single-uid wrapper over it, so archive keeps
working as it did.

Tests are against the real in-process go-imap server again. I checked the two
important ones fail on the old path: the foreign \Deleted message is destroyed,
and the failed move loses the source.