### PR TITLE
feat: delete moves mail to the trash

### DIFF
--- a/internal/desktop/bind_backfill.go
+++ b/internal/desktop/bind_backfill.go
@@ -5,7 +5,6 @@ import (
 
 	pimap "github.com/TRC-Loop/Pelton/internal/imap"
 	"github.com/TRC-Loop/Pelton/internal/storage"
-	psync "github.com/TRC-Loop/Pelton/internal/sync"
 )
 
 // Fetching older mail on demand (#175). A first sync only caches a folder's
@@ -119,9 +118,7 @@ func (a *App) backfillAccount(accountID int64, folders []storage.Folder) (int, b
 	}
 	defer client.Logout()
 
-	engine := psync.NewEngine(client, a.store, a.log)
-	engine.ColorSync = a.boolSetting(settingFlagColorSync, false)
-	engine.InitialLimit = a.syncMessageLimit()
+	engine := a.newSyncEngine(client, accountID)
 
 	batch := a.backfillBatch()
 	var (

--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -224,9 +224,7 @@ func (a *App) syncFolders(client *pimap.Client, accountID int64) error {
 			folders = append(folders, f)
 		}
 	}
-	engine := psync.NewEngine(client, a.store, a.log)
-	engine.ColorSync = a.boolSetting(settingFlagColorSync, false)
-	engine.InitialLimit = a.syncMessageLimit()
+	engine := a.newSyncEngine(client, accountID)
 
 	newTotal := 0
 	for i, f := range folders {
@@ -285,9 +283,7 @@ func (a *App) syncOneFolder(client *pimap.Client, folder storage.Folder) error {
 	if folder.SyncExcluded {
 		return nil
 	}
-	engine := psync.NewEngine(client, a.store, a.log)
-	engine.ColorSync = a.boolSetting(settingFlagColorSync, false)
-	engine.InitialLimit = a.syncMessageLimit()
+	engine := a.newSyncEngine(client, folder.AccountID)
 
 	res, err := engine.SyncFolder(a.ctx, folder)
 	if err != nil {
@@ -383,4 +379,35 @@ func (a *App) idleSession(account storage.Account) error {
 		}
 	}
 	return nil
+}
+
+// newSyncEngine builds a sync engine for one account with the settings every
+// caller needs, including where deleted mail goes. Roles are resolved here
+// because the sync package does not know about them.
+func (a *App) newSyncEngine(client *pimap.Client, accountID int64) *psync.Engine {
+	engine := psync.NewEngine(client, a.store, a.log)
+	engine.ColorSync = a.boolSetting(settingFlagColorSync, false)
+	engine.InitialLimit = a.syncMessageLimit()
+	if trash, ok := a.findTrashFolder(accountID); ok {
+		engine.TrashPath = trash.IMAPPath
+		engine.TrashFolderID = trash.ID
+	}
+	return engine
+}
+
+// findTrashFolder returns the account's trash-role folder. Without one, a
+// delete has nowhere to go and falls back to a permanent expunge, so the caller
+// has to know whether there is one.
+func (a *App) findTrashFolder(accountID int64) (storage.Folder, bool) {
+	folders, err := a.store.ListFolders(a.ctx, accountID)
+	if err != nil {
+		a.log.Error("find trash folder", "account", accountID, "err", err)
+		return storage.Folder{}, false
+	}
+	for _, f := range folders {
+		if folderRole(f) == roleTrash {
+			return f, true
+		}
+	}
+	return storage.Folder{}, false
 }

--- a/internal/desktop/bind_trash_test.go
+++ b/internal/desktop/bind_trash_test.go
@@ -1,0 +1,97 @@
+package desktop
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+func trashTestApp(t *testing.T) (*App, *storage.DB, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.RunMigrations(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return &App{ctx: ctx, store: db, log: slog.New(slog.DiscardHandler)}, db, ctx
+}
+
+// TestSyncEngineKnowsWhereTheTrashIs: without this wiring every delete would
+// fall back to a permanent expunge, which is exactly what this change is
+// getting away from.
+func TestSyncEngineKnowsWhereTheTrashIs(t *testing.T) {
+	a, db, ctx := trashTestApp(t)
+	accountID, err := db.CreateAccount(ctx, &storage.Account{Email: "me@example.com"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	inbox := &storage.Folder{AccountID: accountID, Name: "INBOX", IMAPPath: "INBOX"}
+	trash := &storage.Folder{AccountID: accountID, Name: "Trash", IMAPPath: "Trash"}
+	for _, f := range []*storage.Folder{inbox, trash} {
+		if _, err := db.CreateFolder(ctx, f); err != nil {
+			t.Fatalf("create folder: %v", err)
+		}
+	}
+
+	engine := a.newSyncEngine(nil, accountID)
+	if engine.TrashPath != "Trash" {
+		t.Errorf("TrashPath = %q, want %q", engine.TrashPath, "Trash")
+	}
+	if engine.TrashFolderID != trash.ID {
+		t.Errorf("TrashFolderID = %d, want %d", engine.TrashFolderID, trash.ID)
+	}
+}
+
+// TestSyncEngineWithNoTrashFolder: an account whose server has no trash keeps
+// the permanent delete, since there is nowhere to move mail to.
+func TestSyncEngineWithNoTrashFolder(t *testing.T) {
+	a, db, ctx := trashTestApp(t)
+	accountID, err := db.CreateAccount(ctx, &storage.Account{Email: "me@example.com"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	inbox := &storage.Folder{AccountID: accountID, Name: "INBOX", IMAPPath: "INBOX"}
+	if _, err := db.CreateFolder(ctx, inbox); err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+
+	engine := a.newSyncEngine(nil, accountID)
+	if engine.TrashPath != "" {
+		t.Errorf("TrashPath = %q, want it empty", engine.TrashPath)
+	}
+}
+
+// TestFindTrashFolderFollowsARoleOverride: the user can tell Pelton which
+// folder is the trash, and a delete has to respect that rather than the name.
+func TestFindTrashFolderFollowsARoleOverride(t *testing.T) {
+	a, db, ctx := trashTestApp(t)
+	accountID, err := db.CreateAccount(ctx, &storage.Account{Email: "me@example.com"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	inbox := &storage.Folder{AccountID: accountID, Name: "INBOX", IMAPPath: "INBOX"}
+	bin := &storage.Folder{AccountID: accountID, Name: "Papierkorb", IMAPPath: "Papierkorb"}
+	for _, f := range []*storage.Folder{inbox, bin} {
+		if _, err := db.CreateFolder(ctx, f); err != nil {
+			t.Fatalf("create folder: %v", err)
+		}
+	}
+	if err := db.SetFolderRoleOverride(ctx, bin.ID, roleTrash); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+
+	folder, ok := a.findTrashFolder(accountID)
+	if !ok {
+		t.Fatal("findTrashFolder found nothing")
+	}
+	if folder.ID != bin.ID {
+		t.Errorf("trash is folder %d, want %d", folder.ID, bin.ID)
+	}
+}

--- a/internal/sync/delete_test.go
+++ b/internal/sync/delete_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
 )
 
 // TestSyncOnlyDeletesWhatTheUserDeleted is the guard on the whole destructive
@@ -109,5 +111,137 @@ func TestSyncDoesNotPushADeleteTheServerAlreadyApplied(t *testing.T) {
 	}
 	if len(client.deleted) != 0 {
 		t.Errorf("sync deleted %v on the server, want nothing", client.deleted)
+	}
+}
+
+// deleteOne marks the cached message with the given uid for deletion.
+func deleteOne(t *testing.T, db *storage.DB, folderID int64, uid uint32) {
+	t.Helper()
+	states, err := db.ListMessageStates(context.Background(), folderID)
+	if err != nil {
+		t.Fatalf("list states: %v", err)
+	}
+	for _, s := range states {
+		if s.UID == uid {
+			if err := db.MarkDeletePending(context.Background(), s.ID); err != nil {
+				t.Fatalf("mark pending: %v", err)
+			}
+			return
+		}
+	}
+	t.Fatalf("uid %d is not cached", uid)
+}
+
+// TestDeleteMovesToTrash is the behaviour people expect of a delete: the
+// message goes to the trash, where it can still be recovered, rather than being
+// destroyed on the spot.
+func TestDeleteMovesToTrash(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2, 3}}
+	engine := NewEngine(client, db, nil)
+	engine.TrashPath = "Trash"
+	engine.TrashFolderID = folder.ID + 1
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	deleteOne(t, db, folder.ID, 2)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	if !slices.Equal(client.moved, []imap.UID{2}) {
+		t.Errorf("moved %v to the trash, want [2]", client.moved)
+	}
+	if client.movedTo != "Trash" {
+		t.Errorf("moved to %q, want %q", client.movedTo, "Trash")
+	}
+	if len(client.deleted) != 0 {
+		t.Errorf("expunged %v as well, want nothing", client.deleted)
+	}
+}
+
+// TestDeleteFromTrashIsPermanent: the message is already in the trash, so there
+// is nowhere left to move it. This is emptying the trash, and deleting a single
+// message from inside it.
+func TestDeleteFromTrashIsPermanent(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2}}
+	engine := NewEngine(client, db, nil)
+	engine.TrashPath = folder.IMAPPath
+	engine.TrashFolderID = folder.ID
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	deleteOne(t, db, folder.ID, 1)
+	deleteOne(t, db, folder.ID, 2)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	if !slices.Equal(client.deleted, []imap.UID{2, 1}) && !slices.Equal(client.deleted, []imap.UID{1, 2}) {
+		t.Errorf("expunged %v, want both uids", client.deleted)
+	}
+	if len(client.moved) != 0 {
+		t.Errorf("moved %v out of the trash, want nothing", client.moved)
+	}
+}
+
+// TestDeleteWithoutATrashFolderIsPermanent covers an account whose server has
+// no trash: there is nothing to move to, so the delete is the old expunge.
+func TestDeleteWithoutATrashFolderIsPermanent(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2}}
+	engine := NewEngine(client, db, nil)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+	deleteOne(t, db, folder.ID, 1)
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	if !slices.Equal(client.deleted, []imap.UID{1}) {
+		t.Errorf("expunged %v, want [1]", client.deleted)
+	}
+	if len(client.moved) != 0 {
+		t.Errorf("moved %v, want nothing: there is no trash folder", client.moved)
+	}
+}
+
+// TestTrashableGuardsOnPathAndID: a folder that merely shares the trash's path,
+// or its id, is the trash as far as this decision goes. Getting it wrong either
+// way is bad: expunging what should have been moved destroys mail, and moving
+// the trash into itself fails or loops.
+func TestTrashable(t *testing.T) {
+	engine := &Engine{TrashPath: "Trash", TrashFolderID: 7}
+	tests := []struct {
+		name   string
+		folder storage.Folder
+		want   bool
+	}{
+		{"an ordinary folder", storage.Folder{ID: 3, IMAPPath: "INBOX"}, true},
+		{"the trash by id", storage.Folder{ID: 7, IMAPPath: "Trash"}, false},
+		{"the trash by path alone", storage.Folder{ID: 9, IMAPPath: "Trash"}, false},
+		{"the trash by id alone", storage.Folder{ID: 7, IMAPPath: "Bin"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := engine.trashable(tt.folder); got != tt.want {
+				t.Errorf("trashable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+	none := &Engine{}
+	if none.trashable(storage.Folder{ID: 3, IMAPPath: "INBOX"}) {
+		t.Error("trashable() is true with no trash folder configured")
 	}
 }

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -43,16 +43,18 @@ func (e *Engine) clearPending(ctx context.Context, state storage.MessageState, f
 	return nil
 }
 
-// pushDeletes deletes the given messages on the server, then removes them from
-// the cache. the whole batch goes in one DeleteMessages call, so a folder with
-// many local deletions costs a couple of round trips rather than a couple per
-// message, and the imap layer keeps the removal scoped to exactly these uids.
+// pushDeletes applies the user's deletions on the server, then removes them
+// from the cache. the whole batch goes in one call, so a folder with many local
+// deletions costs a couple of round trips rather than a couple per message.
 //
-// decision: delete means \Deleted + EXPUNGE here, not move-to-Trash. it is the
-// standard, provider neutral delete. the known divergence is gmail, where this
-// only removes a label inside an ordinary mailbox, see DeleteMessages in the
-// imap package. moving to the account's Trash folder is the cleaner gmail
-// behaviour and is a candidate for a later version.
+// deleting a message moves it to the account's trash. that is what people mean
+// by delete, it is recoverable, and on gmail it is the only thing that deletes
+// at all: \Deleted plus EXPUNGE inside an ordinary label only removes the
+// label there.
+//
+// the permanent delete is \Deleted plus a scoped expunge, and it happens in
+// exactly two cases: the message is already in the trash (emptying it, or
+// deleting from inside it), or the account has no trash folder to move to.
 func (e *Engine) pushDeletes(ctx context.Context, folder storage.Folder, states []storage.MessageState) error {
 	if len(states) == 0 {
 		return nil
@@ -63,9 +65,14 @@ func (e *Engine) pushDeletes(ctx context.Context, folder storage.Folder, states 
 		uids = append(uids, imap.UID(s.UID))
 	}
 
-	// scoped to exactly these uids by the imap layer, which will not issue an
-	// expunge that could take a message another client merely flagged.
-	if err := e.client.DeleteMessages(uids...); err != nil {
+	// both paths are scoped to exactly these uids by the imap layer, which will
+	// not issue an expunge that could take a message another client merely
+	// flagged.
+	if e.trashable(folder) {
+		if err := e.client.MoveMessages(uids, e.TrashPath); err != nil {
+			return fmt.Errorf("sync: move to trash on server: %w", err)
+		}
+	} else if err := e.client.DeleteMessages(uids...); err != nil {
 		return fmt.Errorf("sync: delete on server: %w", err)
 	}
 
@@ -76,4 +83,14 @@ func (e *Engine) pushDeletes(ctx context.Context, folder storage.Folder, states 
 		}
 	}
 	return nil
+}
+
+// trashable reports whether deletions from this folder should move to the trash
+// rather than be expunged. Comparing the id as well as the path keeps a folder
+// merely named like the trash from being mistaken for it.
+func (e *Engine) trashable(folder storage.Folder) bool {
+	if e.TrashPath == "" {
+		return false
+	}
+	return folder.ID != e.TrashFolderID && folder.IMAPPath != e.TrashPath
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -20,6 +20,7 @@ type mailClient interface {
 	FetchMessage(uid imap.UID) (*pimap.Message, error)
 	AddFlags(uid imap.UID, flags ...imap.Flag) error
 	DeleteMessages(uids ...imap.UID) error
+	MoveMessages(uids []imap.UID, mailbox string) error
 }
 
 // Engine orchestrates one account's imap connection and the local store. It is
@@ -32,6 +33,13 @@ type Engine struct {
 	// ColorSync, when true, adopts server-side flag colors (Thunderbird $LabelN
 	// keywords) into the local cache during each folder sync.
 	ColorSync bool
+	// TrashPath and TrashFolderID identify the account's trash folder, which is
+	// where a deleted message goes. Deleting from the trash itself, or from an
+	// account with no trash folder (TrashPath empty), is the permanent delete
+	// instead. The caller sets these because folder roles are resolved above
+	// this layer.
+	TrashPath     string
+	TrashFolderID int64
 	// InitialLimit caps how many of a folder's newest messages the first sync
 	// fetches; the rest wait behind the folder's sync floor until a backfill asks
 	// for them (see window.go). 0 means no cap, the pre-#175 behavior. It only

--- a/internal/sync/window_test.go
+++ b/internal/sync/window_test.go
@@ -207,8 +207,11 @@ type fakeClient struct {
 	// mailbox reset.
 	uidValidity uint32
 	// deleted records every uid handed to DeleteMessages, so a test can assert
-	// that a sync only ever asks to delete what the user deleted.
+	// that a sync only ever asks to delete what the user deleted. moved and
+	// movedTo do the same for the move-to-trash path.
 	deleted []imap.UID
+	moved   []imap.UID
+	movedTo string
 }
 
 func (c *fakeClient) Select(string) (*pimap.Mailbox, error) {
@@ -235,6 +238,12 @@ func (c *fakeClient) FetchMessage(uid imap.UID) (*pimap.Message, error) {
 func (c *fakeClient) AddFlags(imap.UID, ...imap.Flag) error { return nil }
 func (c *fakeClient) DeleteMessages(uids ...imap.UID) error {
 	c.deleted = append(c.deleted, uids...)
+	return nil
+}
+
+func (c *fakeClient) MoveMessages(uids []imap.UID, mailbox string) error {
+	c.moved = append(c.moved, uids...)
+	c.movedTo = mailbox
 	return nil
 }
 


### PR DESCRIPTION
Closes #280. Recreated against dev: #281 was auto-closed when its base branch
was deleted on merge of #279.

Deleting a message did \Deleted plus EXPUNGE, which destroys it on any server
that is not Gmail. Now it moves to the account's Trash, and the permanent
delete is what happens when the message is already there: emptying the trash,
or deleting from inside it. An account whose server has no trash folder keeps
the old permanent delete, since there is nowhere to move to.

On Gmail this also fixes a real bug rather than only softening one: \Deleted
plus EXPUNGE inside an ordinary label only removed the label, so a delete never
deleted.

Nothing changes about how a delete feels. It is still the same pending-delete
row, so it still works offline, the row still leaves the list at once, and undo
still works until the next sync pushes it.

The sync engine takes the trash folder from the caller (TrashPath and
TrashFolderID) because folder roles are resolved in the desktop layer, and a
role override the user set is respected. Tests cover the move, the two
permanent cases, the trashable guard on both id and path, and the wiring
including the override.