### PR TITLE
feat: mark folders that are not syncing

### DIFF
--- a/frontend/src/components/settings/SettingsPanel.svelte
+++ b/frontend/src/components/settings/SettingsPanel.svelte
@@ -61,6 +61,7 @@
     setMultiSelectEnabled,
     setShowSelectedCount,
     setSidebarIndentGuides,
+    setShowUnsyncedFolder,
     setStartupSelection,
     setShowFlaggedCount,
     setViewsPlacement,
@@ -1004,6 +1005,14 @@
               checked={$prefs.sidebarIndentGuides}
               label={$t('settingsPanel.toggle.indentGuides')}
               on:change={(e) => setSidebarIndentGuides(e.detail)}
+            />
+          </div>
+          <div class="toggle" title={$t('settingsPanel.hint.unsyncedFolder')}>
+            <span class="row-label">{$t('settingsPanel.toggle.unsyncedFolder')}</span>
+            <ToggleSwitch
+              checked={$prefs.showUnsyncedFolder}
+              label={$t('settingsPanel.toggle.unsyncedFolder')}
+              on:change={(e) => setShowUnsyncedFolder(e.detail)}
             />
           </div>
           <div class="toggle" title={$t('settingsPanel.hint.flaggedCount')}>

--- a/frontend/src/components/sidebar/FolderNode.svelte
+++ b/frontend/src/components/sidebar/FolderNode.svelte
@@ -37,6 +37,7 @@
   } from '../../stores/folderdialog'
   import { startFolderDrag, endFolderDrag } from '../../stores/sidebardrag'
   import { refreshSidebar } from '../../stores/accounts'
+  import { prefs } from '../../stores/prefs'
   import { reorderFolders, setFolderPinned, setFolderSyncExcluded } from '../../lib/api'
   import { toastError, errorMessage } from '../../stores/toast'
   import { t } from '../../lib/i18n'
@@ -155,11 +156,18 @@
     normal: IconFolder,
   }
   $: Icon = roleIcons[folder.role] ?? IconFolder
+
+  // a folder the user took out of sync looks identical to one that simply has
+  // no new mail, which is how somebody forgets they excluded it. The marker is
+  // a setting because a mailbox with many excluded folders does not need a row
+  // of icons repeating what its owner already knows.
+  $: unsynced = folder.syncExcluded && $prefs.showUnsyncedFolder
 </script>
 
 <div class="node" data-reorder-id={folder.id}>
   <SidebarRow
     label={folder.name}
+    title={unsynced ? $t('folders.notSyncing') : ''}
     count={folder.unreadCount}
     active={isActive}
     {depth}
@@ -171,6 +179,11 @@
     on:contextmenu={(e) => onContext(e.detail)}
   >
     <svelte:component this={Icon} size={15} stroke={1.6} />
+    <span slot="badge" class="unsynced" aria-hidden="true">
+      {#if unsynced}
+        <IconRefreshOff size={13} stroke={1.6} />
+      {/if}
+    </span>
   </SidebarRow>
 
   {#if expanded && children.length > 0}
@@ -186,3 +199,14 @@
     </div>
   {/if}
 </div>
+
+<style>
+  /* sits between the folder name and its unread count, in the muted tone the
+     other secondary marks use. */
+  .unsynced {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-tertiary);
+    flex-shrink: 0;
+  }
+</style>

--- a/frontend/src/components/sidebar/SidebarRow.svelte
+++ b/frontend/src/components/sidebar/SidebarRow.svelte
@@ -73,6 +73,7 @@
   >
     <span class="icon" aria-hidden="true"><slot /></span>
     <span class="label">{label}</span>
+    <slot name="badge" />
     {#if count > 0}
       <span class="count" aria-label={`${count} ${$t('sidebar.unreadSuffix')}`}>{count}</span>
     {/if}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -925,6 +925,7 @@ export const SettingKeys = {
   viewsPlacement: 'views_placement',
   flagColorSync: 'flag_color_sync',
   showOfflineIndicator: 'show_offline_indicator',
+  showUnsyncedFolder: 'show_unsynced_folder',
   swipeEnabled: 'swipe_enabled',
   swipeLeftAction: 'swipe_left_action',
   swipeRightAction: 'swipe_right_action',

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -629,6 +629,7 @@ const de: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Alle löschen',
   'folders.roleAction': 'Verwenden als…',
   'folders.stopSync': 'Diesen Ordner nicht mehr synchronisieren',
+  'folders.notSyncing': 'Wird nicht synchronisiert. Neue Mails in diesem Ordner werden erst wieder abgerufen, wenn du die Synchronisierung einschaltest.',
   'folders.resumeSync': 'Diesen Ordner wieder synchronisieren',
   'folders.roleTitle': '{name} verwenden als',
   'folders.roleHint':
@@ -1074,7 +1075,9 @@ const de: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Anzahl „N ausgewählt" anzeigen',
   'settingsPanel.toggle.showSelectedCountAria': 'Anzahl der Auswahl anzeigen',
   'settingsPanel.hint.indentGuides': 'Zeichnet vertikale Hilfslinien, die verschachtelte Ordner verbinden.',
+  'settingsPanel.hint.unsyncedFolder': 'Zeigt ein kleines Symbol bei jedem Ordner, den du von der Synchronisierung ausgenommen hast, damit klar ist, warum dort nichts Neues ankommt.',
   'settingsPanel.toggle.indentGuides': 'Einrückungslinien für Ordner anzeigen',
+  'settingsPanel.toggle.unsyncedFolder': 'Nicht synchronisierte Ordner markieren',
   'settingsPanel.hint.flaggedCount': 'Blendet die Anzahl und die Fettschrift in der Ansicht „Markiert" aus (der Eintrag bleibt bestehen).',
   'settingsPanel.toggle.flaggedCount': 'Anzahl markierter Nachrichten anzeigen',
   'settingsPanel.label.startupSelection': 'Beim Start öffnen',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -629,6 +629,7 @@ const en: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Delete them all',
   'folders.roleAction': 'Use as…',
   'folders.stopSync': 'Stop syncing this folder',
+  'folders.notSyncing': 'Not syncing. New mail in this folder is not fetched until you turn sync back on.',
   'folders.resumeSync': 'Sync this folder again',
   'folders.roleTitle': 'Use {name} as',
   'folders.roleHint':
@@ -1074,7 +1075,9 @@ const en: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Show "N selected" count',
   'settingsPanel.toggle.showSelectedCountAria': 'Show selected count',
   'settingsPanel.hint.indentGuides': 'Draw vertical guide lines connecting nested folders.',
+  'settingsPanel.hint.unsyncedFolder': 'Shows a small icon on any folder you took out of sync, so it is clear why no new mail arrives there.',
   'settingsPanel.toggle.indentGuides': 'Show folder indent guides',
+  'settingsPanel.toggle.unsyncedFolder': 'Mark folders that are not syncing',
   'settingsPanel.hint.flaggedCount': 'Hide the count and bold styling on the Flagged view (the entry stays).',
   'settingsPanel.toggle.flaggedCount': 'Show flagged count',
   'settingsPanel.label.startupSelection': 'Open on launch',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -629,6 +629,7 @@ const es: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Eliminarlos todos',
   'folders.roleAction': 'Usar como…',
   'folders.stopSync': 'Dejar de sincronizar esta carpeta',
+  'folders.notSyncing': 'No se sincroniza. El correo nuevo de esta carpeta no se descarga hasta que vuelvas a activar la sincronización.',
   'folders.resumeSync': 'Volver a sincronizar esta carpeta',
   'folders.roleTitle': 'Usar {name} como',
   'folders.roleHint':
@@ -1074,7 +1075,9 @@ const es: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Mostrar el recuento "N seleccionados"',
   'settingsPanel.toggle.showSelectedCountAria': 'Mostrar recuento de seleccionados',
   'settingsPanel.hint.indentGuides': 'Dibuja líneas guía verticales que conectan las carpetas anidadas.',
+  'settingsPanel.hint.unsyncedFolder': 'Muestra un icono pequeño en cada carpeta que hayas excluido de la sincronización, para que quede claro por qué no llega nada nuevo.',
   'settingsPanel.toggle.indentGuides': 'Mostrar guías de sangría de carpetas',
+  'settingsPanel.toggle.unsyncedFolder': 'Marcar las carpetas que no se sincronizan',
   'settingsPanel.hint.flaggedCount': 'Oculta el recuento y el estilo en negrita en la vista Marcados (la entrada permanece).',
   'settingsPanel.toggle.flaggedCount': 'Mostrar recuento de marcados',
   'settingsPanel.label.startupSelection': 'Abrir al iniciar',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -629,6 +629,7 @@ const fr: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Tout supprimer',
   'folders.roleAction': 'Utiliser comme…',
   'folders.stopSync': 'Ne plus synchroniser ce dossier',
+  'folders.notSyncing': 'Pas de synchronisation. Les nouveaux messages de ce dossier ne sont pas récupérés tant que vous ne la réactivez pas.',
   'folders.resumeSync': 'Synchroniser à nouveau ce dossier',
   'folders.roleTitle': 'Utiliser {name} comme',
   'folders.roleHint':
@@ -1074,7 +1075,9 @@ const fr: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Afficher le compteur « N sélectionnés »',
   'settingsPanel.toggle.showSelectedCountAria': 'Afficher le nombre sélectionné',
   'settingsPanel.hint.indentGuides': 'Trace des lignes de guidage verticales reliant les dossiers imbriqués.',
+  'settingsPanel.hint.unsyncedFolder': 'Affiche une petite icône sur chaque dossier exclu de la synchronisation, pour comprendre pourquoi rien de nouveau n’y arrive.',
   'settingsPanel.toggle.indentGuides': 'Afficher les guides d\'indentation des dossiers',
+  'settingsPanel.toggle.unsyncedFolder': 'Marquer les dossiers non synchronisés',
   'settingsPanel.hint.flaggedCount': 'Masque le compteur et le style gras sur la vue Marqués (l\'entrée reste).',
   'settingsPanel.toggle.flaggedCount': 'Afficher le nombre de messages marqués',
   'settingsPanel.label.startupSelection': 'Ouvrir au démarrage',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -629,6 +629,7 @@ const nl: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Alles verwijderen',
   'folders.roleAction': 'Gebruiken als…',
   'folders.stopSync': 'Deze map niet meer synchroniseren',
+  'folders.notSyncing': 'Synchroniseert niet. Nieuwe berichten in deze map worden pas opgehaald als je synchronisatie weer aanzet.',
   'folders.resumeSync': 'Deze map weer synchroniseren',
   'folders.roleTitle': '{name} gebruiken als',
   'folders.roleHint':
@@ -1074,7 +1075,9 @@ const nl: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Aantal "N geselecteerd" tonen',
   'settingsPanel.toggle.showSelectedCountAria': 'Aantal geselecteerde items tonen',
   'settingsPanel.hint.indentGuides': 'Teken verticale hulplijnen die geneste mappen verbinden.',
+  'settingsPanel.hint.unsyncedFolder': 'Toont een klein pictogram bij elke map die je van synchronisatie hebt uitgesloten, zodat duidelijk is waarom daar niets nieuws binnenkomt.',
   'settingsPanel.toggle.indentGuides': 'Inspringhulplijnen voor mappen tonen',
+  'settingsPanel.toggle.unsyncedFolder': 'Niet-synchroniserende mappen markeren',
   'settingsPanel.hint.flaggedCount': 'Verberg het aantal en de vetgedrukte opmaak bij de weergave Gemarkeerd (de vermelding blijft staan).',
   'settingsPanel.toggle.flaggedCount': 'Aantal gemarkeerd tonen',
   'settingsPanel.label.startupSelection': 'Openen bij starten',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -627,6 +627,7 @@ const pl: Record<string, string> = {
   'folders.emptyTrashConfirm': 'Usuń wszystkie',
   'folders.roleAction': 'Używaj jako…',
   'folders.stopSync': 'Przestań synchronizować ten folder',
+  'folders.notSyncing': 'Bez synchronizacji. Nowe wiadomości w tym folderze nie będą pobierane, dopóki nie włączysz jej z powrotem.',
   'folders.resumeSync': 'Znów synchronizuj ten folder',
   'folders.roleTitle': 'Używaj {name} jako',
   'folders.roleHint':
@@ -1027,7 +1028,9 @@ const pl: Record<string, string> = {
   'settingsPanel.toggle.showSelectedCount': 'Pokazuj licznik „N zaznaczono”',
   'settingsPanel.toggle.showSelectedCountAria': 'Pokazuj licznik zaznaczonych',
   'settingsPanel.hint.indentGuides': 'Rysuj pionowe linie prowadzące łączące zagnieżdżone foldery.',
+  'settingsPanel.hint.unsyncedFolder': 'Pokazuje małą ikonę przy każdym folderze wyłączonym z synchronizacji, żeby było jasne, dlaczego nic w nim nie przybywa.',
   'settingsPanel.toggle.indentGuides': 'Pokazuj prowadnice wcięć folderów',
+  'settingsPanel.toggle.unsyncedFolder': 'Oznaczaj foldery bez synchronizacji',
   'settingsPanel.hint.flaggedCount': 'Ukryj licznik i pogrubienie w widoku Oznaczone (pozycja pozostaje).',
   'settingsPanel.toggle.flaggedCount': 'Pokazuj licznik oznaczonych',
   'settingsPanel.label.startupSelection': 'Otwórz przy starcie',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -325,6 +325,9 @@ export interface UIPrefs {
   flagColorSync: boolean
   // showOfflineIndicator shows the little downloaded badge on pinned messages.
   showOfflineIndicator: boolean
+  // showUnsyncedFolder marks folders excluded from sync in the sidebar, so a
+  // folder that stopped receiving new mail says why.
+  showUnsyncedFolder: boolean
   // swipe gestures on message rows (trackpad only).
   swipeEnabled: boolean
   swipeLeftAction: string

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -47,6 +47,7 @@ const defaults: UIPrefs = {
   viewsPlacement: 'hidden',
   flagColorSync: false,
   showOfflineIndicator: true,
+  showUnsyncedFolder: true,
   swipeEnabled: true,
   swipeLeftAction: 'delete',
   swipeRightAction: 'unread',
@@ -259,6 +260,12 @@ export function setNotifyNewMail(value: boolean): void {
 export function setShowOfflineIndicator(value: boolean): void {
   prefs.update((p) => ({ ...p, showOfflineIndicator: value }))
   void setSetting(SettingKeys.showOfflineIndicator, String(value))
+}
+
+// setShowUnsyncedFolder toggles the marker on folders excluded from sync.
+export function setShowUnsyncedFolder(value: boolean): void {
+  prefs.update((p) => ({ ...p, showUnsyncedFolder: value }))
+  void setSetting(SettingKeys.showUnsyncedFolder, String(value))
 }
 
 // setSwipeEnabled toggles trackpad swipe gestures on message rows.

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1389,6 +1389,7 @@ export namespace desktop {
 	    showFlaggedCount: boolean;
 	    flagColorSync: boolean;
 	    showOfflineIndicator: boolean;
+	    showUnsyncedFolder: boolean;
 	    swipeEnabled: boolean;
 	    swipeLeftAction: string;
 	    swipeRightAction: string;
@@ -1467,6 +1468,7 @@ export namespace desktop {
 	        this.showFlaggedCount = source["showFlaggedCount"];
 	        this.flagColorSync = source["flagColorSync"];
 	        this.showOfflineIndicator = source["showOfflineIndicator"];
+	        this.showUnsyncedFolder = source["showUnsyncedFolder"];
 	        this.swipeEnabled = source["swipeEnabled"];
 	        this.swipeLeftAction = source["swipeLeftAction"];
 	        this.swipeRightAction = source["swipeRightAction"];

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -55,6 +55,7 @@ const (
 	// newer feature settings.
 	settingFlagColorSync       = "flag_color_sync"
 	settingShowOffline         = "show_offline_indicator"
+	settingShowUnsyncedFolder  = "show_unsynced_folder"
 	settingSwipeEnabled        = "swipe_enabled"
 	settingSwipeLeft           = "swipe_left_action"
 	settingSwipeRight          = "swipe_right_action"
@@ -236,6 +237,9 @@ type UIPrefsDTO struct {
 	// ShowOfflineIndicator shows the little downloaded/offline badge on pinned
 	// messages. On by default; can be hidden.
 	ShowOfflineIndicator bool `json:"showOfflineIndicator"`
+	// ShowUnsyncedFolder marks folders the user excluded from sync in the
+	// sidebar, so a folder that stopped receiving new mail says why.
+	ShowUnsyncedFolder bool `json:"showUnsyncedFolder"`
 	// Swipe gestures on message rows (trackpad only). SwipeEnabled turns them on;
 	// SwipeLeftAction/SwipeRightAction pick what each direction does
 	// (delete, unread, read, flag, archive, snooze, none).
@@ -379,6 +383,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 
 		FlagColorSync:              a.boolSetting(settingFlagColorSync, false),
 		ShowOfflineIndicator:       a.boolSetting(settingShowOffline, true),
+		ShowUnsyncedFolder:         a.boolSetting(settingShowUnsyncedFolder, true),
 		SwipeEnabled:               a.boolSetting(settingSwipeEnabled, true),
 		SwipeLeftAction:            a.stringSetting(settingSwipeLeft, "delete"),
 		SwipeRightAction:           a.stringSetting(settingSwipeRight, "unread"),


### PR DESCRIPTION
Follow-up to #173. A folder taken out of sync looked exactly like one with no
new mail, which is how you forget you excluded it and then wonder why nothing
arrives there.

Excluded folders now carry a small crossed-out sync icon in the sidebar,
between the name and the unread count, and hovering the row says what it means.
The setting is under Settings, Sidebar and is on by default. It is a setting
because somebody who excluded a dozen folders on purpose does not need a column
of icons telling them so.