### PR TITLE
fix: open encrypted mail with a locked key

### DIFF
--- a/internal/crypto/open.go
+++ b/internal/crypto/open.go
@@ -194,16 +194,20 @@ func (p *PGP) decrypt(ciphertext, passphrase []byte) (*Opened, error) {
 		return nil, ErrMalformedArmor
 	}
 
-	// prompt is called once per candidate key. Returning an error rather than
-	// nil on the second call stops go-crypto retrying the same wrong passphrase
-	// against every key in the ring.
-	var asked bool
+	// the keys are unlocked here rather than through go-crypto's prompt
+	// callback. That callback is invoked once per candidate key, and the primary
+	// key is tried before the encryption subkey the message actually names, so a
+	// passphrase handed to the first call never reached the key that needed it
+	// and a locked key could not open anything even with the right passphrase.
+	if err := unlockRing(private, passphrase); err != nil {
+		return nil, err
+	}
+
+	// nothing is left to ask for: any key that could be unlocked has been. A
+	// prompt at this point would be go-crypto looping over keys the passphrase
+	// does not fit.
 	prompt := func(keys []openpgp.Key, symmetric bool) ([]byte, error) {
-		if asked || len(passphrase) == 0 {
-			return nil, ErrPassphraseRequired
-		}
-		asked = true
-		return passphrase, nil
+		return nil, ErrPassphraseRequired
 	}
 
 	md, err := openpgp.ReadMessage(block.Body, keyring, prompt, cryptoConfig())
@@ -316,4 +320,38 @@ func decryptError(err error) error {
 		return ErrNoDecryptionKey
 	}
 	return fmt.Errorf("crypto: decrypt: %w", err)
+}
+
+// unlockRing decrypts every locked private key the passphrase fits, in memory
+// only: the store reloads from disk on the next call, so nothing stays unlocked
+// beyond this operation.
+//
+// It reports a problem only when no usable key is left. A ring holding one
+// unlocked key and one belonging to another passphrase is fine, since the
+// message names the key it wants and go-crypto will find it.
+func unlockRing(private openpgp.EntityList, passphrase []byte) error {
+	var usable, locked int
+	for _, ent := range private {
+		if !entityLocked(ent) {
+			usable++
+			continue
+		}
+		locked++
+		if len(passphrase) == 0 {
+			continue
+		}
+		if err := ent.DecryptPrivateKeys(passphrase); err == nil {
+			usable++
+		}
+	}
+	switch {
+	case usable > 0:
+		return nil
+	case locked > 0 && len(passphrase) == 0:
+		return ErrPassphraseRequired
+	case locked > 0:
+		return ErrWrongPassphrase
+	default:
+		return ErrNoDecryptionKey
+	}
 }

--- a/internal/crypto/open_locked_test.go
+++ b/internal/crypto/open_locked_test.go
@@ -1,0 +1,122 @@
+package crypto
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+// TestOpenLockedKeyWithTheRightPassphrase is the other half of
+// TestOpenLockedKeyAsksForPassphrase, which only ever checked that the wrong
+// passphrase fails. Reading a message with a locked key is the ordinary case
+// for anyone who imported a key from gpg.
+func TestOpenLockedKeyWithTheRightPassphrase(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{alice})
+	part, err := p.Wrap([]byte(sampleEntity), ModeEncrypt, Options{
+		SenderEmail: "alice@example.test",
+		Recipients:  []string{"alice@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	raw := message("alice@example.test", part)
+
+	locked := newTestEntity(t, "alice@example.test")
+	*locked = *alice
+	passphrase := []byte("correct horse")
+	lockEntity(t, locked, passphrase)
+	reader := newOpenTestPGP(t, []*openpgp.Entity{alice}, []*openpgp.Entity{locked})
+
+	opened, err := reader.Open(raw, passphrase)
+	if err != nil {
+		t.Fatalf("Open() with the right passphrase: %v", err)
+	}
+	if !opened.Encrypted {
+		t.Error("the message is not reported as encrypted")
+	}
+	if !bytes.Contains(opened.Body, []byte("the eagle lands at dawn")) {
+		t.Errorf("decrypted body = %q", opened.Body)
+	}
+}
+
+// TestOpenLockedKeyAmongUnlockedOnes: a ring can hold several keys, and one
+// belonging to a passphrase the user did not type must not stop a message
+// addressed to an unlocked one from opening.
+func TestOpenLockedKeyAmongUnlockedOnes(t *testing.T) {
+	alice := newTestEntity(t, "alice@example.test")
+	bob := newTestEntity(t, "bob@example.test")
+	p := newOpenTestPGP(t, []*openpgp.Entity{alice, bob}, []*openpgp.Entity{alice, bob})
+	part, err := p.Wrap([]byte(sampleEntity), ModeEncrypt, Options{
+		SenderEmail: "alice@example.test",
+		Recipients:  []string{"alice@example.test"},
+	})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	raw := message("alice@example.test", part)
+
+	lockedBob := newTestEntity(t, "bob@example.test")
+	*lockedBob = *bob
+	lockEntity(t, lockedBob, []byte("bob's passphrase"))
+	reader := newOpenTestPGP(t, []*openpgp.Entity{alice, bob}, []*openpgp.Entity{alice, lockedBob})
+
+	if _, err := reader.Open(raw, nil); err != nil {
+		t.Fatalf("Open() with an unlocked key present: %v", err)
+	}
+}
+
+func TestUnlockRing(t *testing.T) {
+	passphrase := []byte("correct horse")
+	locked := func(t *testing.T) *openpgp.Entity {
+		ent := newTestEntity(t, "alice@example.test")
+		lockEntity(t, ent, passphrase)
+		return ent
+	}
+
+	tests := []struct {
+		name       string
+		ring       func(t *testing.T) openpgp.EntityList
+		passphrase []byte
+		wantErr    error
+	}{
+		{
+			name:    "no keys at all",
+			ring:    func(*testing.T) openpgp.EntityList { return nil },
+			wantErr: ErrNoDecryptionKey,
+		},
+		{
+			name: "an unlocked key needs nothing",
+			ring: func(t *testing.T) openpgp.EntityList {
+				return openpgp.EntityList{newTestEntity(t, "alice@example.test")}
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "locked with no passphrase asks for one",
+			ring:    func(t *testing.T) openpgp.EntityList { return openpgp.EntityList{locked(t)} },
+			wantErr: ErrPassphraseRequired,
+		},
+		{
+			name:       "locked with the wrong passphrase says so",
+			ring:       func(t *testing.T) openpgp.EntityList { return openpgp.EntityList{locked(t)} },
+			passphrase: []byte("nope"),
+			wantErr:    ErrWrongPassphrase,
+		},
+		{
+			name:       "locked with the right passphrase opens",
+			ring:       func(t *testing.T) openpgp.EntityList { return openpgp.EntityList{locked(t)} },
+			passphrase: passphrase,
+			wantErr:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := unlockRing(tt.ring(t), tt.passphrase); !errors.Is(err, tt.wantErr) {
+				t.Errorf("unlockRing() = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #291.

Decrypting with a passphrase-protected key failed whatever passphrase was
given, which is the ordinary state of a key imported from gpg. For those users
the decrypt half of #227 never worked.

go-crypto's prompt callback is called once per candidate key, and it tries the
primary key before the encryption subkey the message names. The callback handed
the passphrase to that first call and refused every call after, so the key that
needed it never got one.

The keys are now unlocked up front instead, in memory only: the store reloads
from disk on the next call, so nothing stays unlocked past the operation. A ring
holding one usable key and one belonging to a different passphrase still works,
since the message names the key it wants.

The old test only checked that no passphrase and a wrong passphrase fail, which
is why this went unnoticed. Added the missing half, a mixed ring, and a table
over unlockRing covering no keys, unlocked, locked with nothing, locked with the
wrong passphrase and locked with the right one.

Found while working on #194.