### PR TITLE
feat: developer overlays for activity, process and frame timing

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -31,6 +31,22 @@ macOS has no such convention and does not use them.
 
 Reply, reply all, forward, mark read or unread, flag, snooze, archive, delete and download-for-offline ship unbound so they cannot collide with anything. Bind them to whatever you like under **Settings, Shortcuts**; each one acts on the currently open message.
 
+## Developer overlays
+
+Only in a development run, started with `PELTON_DEV` (what `make run` sets) or `PELTON_DEVTOOLS=1`. A normal build does not bind these keys at all.
+
+| Shortcut | Action |
+| -------- | ------ |
+| ++f6++ | Activity log: what the backend is doing, live |
+| ++f7++ | Process: goroutines, heap, database and cache sizes |
+| ++f8++ | Frames: frame timing for the ui |
+
+The overlays are draggable and several can be open at once. They always start closed.
+
+The activity log shows the same lines Pelton writes to its log, so it follows the log level. Set `PELTON_DEBUG=1` for the full sync detail.
+
+The webview inspector is the browser's own, not Pelton's: ++f12++ on Windows, ++cmd+alt+i++ on macOS, right-click and Inspect on Linux. It only exists in a development build.
+
 ## Rebinding
 
 **Settings, Shortcuts** lists every action with its current combo. Click one and press the new combination to rebind it, including the defaults above. If a combo is already taken, Pelton tells you what it is bound to.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -118,6 +118,7 @@
     paletteQuery,
   } from './stores/palette'
   import AccountPasswordDialog from './components/settings/AccountPasswordDialog.svelte'
+  import DevOverlays from './components/dev/DevOverlays.svelte'
   import {
     passwordPrompt,
     answerPasswordPrompt,
@@ -1206,6 +1207,8 @@
 <CommandPalette commands={paletteCommands} mail={paletteMailCommands} />
 
 <AccountPasswordDialog account={$passwordPrompt} onDone={answerPasswordPrompt} />
+
+<DevOverlays />
 
 <style>
   .shell {

--- a/frontend/src/components/dev/ActivityOverlay.svelte
+++ b/frontend/src/components/dev/ActivityOverlay.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  // a live view of the app's log: sync passes, imap and smtp errors, outbox
+  // activity, everything the backend already writes. It reads the same redacted
+  // lines that reach stderr and the log file, so a stored password cannot show
+  // up here either.
+  //
+  // What it can show is limited to what is logged at the current level. Below
+  // debug most of the sync path says nothing, so the level is on screen and
+  // PELTON_DEBUG is how you get more.
+  import { onDestroy, onMount, tick } from 'svelte'
+  import DevPanel from './DevPanel.svelte'
+  import { closeOverlay } from '../../stores/devoverlays'
+  import { devActivity, clearDevActivity } from '../../lib/api'
+  import type { DevLogLine } from '../../lib/types'
+
+  // how often new lines are pulled. Fast enough to feel live, slow enough that
+  // the poll itself is not what the overlay is showing you.
+  const pollMs = 700
+  // how many lines stay on screen. The backend buffer is the real limit; this
+  // keeps the dom from growing past it.
+  const maxLines = 500
+
+  let lines: DevLogLine[] = []
+  let level = ''
+  let error = ''
+  let next = 0
+  let follow = true
+  let body: HTMLElement | null = null
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  onMount(() => {
+    void poll()
+    timer = setInterval(() => void poll(), pollMs)
+  })
+
+  onDestroy(() => {
+    if (timer) {
+      clearInterval(timer)
+    }
+  })
+
+  async function poll(): Promise<void> {
+    try {
+      const page = await devActivity(next)
+      error = ''
+      level = page.level
+      next = page.next
+      if (page.lines.length > 0) {
+        lines = [...lines, ...page.lines].slice(-maxLines)
+        if (follow) {
+          await tick()
+          body?.scrollTo({ top: body.scrollHeight })
+        }
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  async function clear(): Promise<void> {
+    try {
+      await clearDevActivity()
+      lines = []
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  // the seq numbers tell whether the buffer dropped lines while the overlay was
+  // closed or busy, which matters when reading back what happened.
+  $: dropped = lines.length > 0 && lines[0].seq > 0 && lines.length < lines[lines.length - 1].seq + 1
+</script>
+
+<DevPanel title="Activity" shortcut="F6" top="var(--space-5)" left="var(--space-5)" width="520px" onClose={() => closeOverlay('activity')}>
+  <div class="controls">
+    <span class="level">level {level || '?'}</span>
+    <label class="follow">
+      <input type="checkbox" bind:checked={follow} />
+      follow
+    </label>
+    <button type="button" on:click={clear}>clear</button>
+  </div>
+
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+
+  <div class="log" bind:this={body}>
+    {#if lines.length === 0}
+      <p class="empty">Nothing logged yet. Set PELTON_DEBUG=1 for the full sync detail.</p>
+    {:else}
+      {#if dropped}
+        <p class="empty">Older lines were dropped from the buffer.</p>
+      {/if}
+      {#each lines as line (line.seq)}
+        <div class="line">{line.text}</div>
+      {/each}
+    {/if}
+  </div>
+</DevPanel>
+
+<style>
+  .controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+  }
+
+  .level {
+    color: var(--text-tertiary);
+  }
+
+  .follow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    cursor: var(--cursor-action);
+  }
+
+  button {
+    padding: 0 var(--space-2);
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-control);
+    background: transparent;
+    font-family: var(--font-mono);
+    font-size: var(--fz-meta);
+    color: var(--text-secondary);
+    cursor: var(--cursor-action);
+  }
+  button:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .log {
+    max-height: 40vh;
+    overflow: auto;
+  }
+
+  .line {
+    padding: 1px 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.45;
+    border-bottom: var(--hairline) solid var(--border-subtle);
+    color: var(--text-secondary);
+  }
+
+  .empty,
+  .error {
+    margin: 0 0 var(--space-2);
+    color: var(--text-tertiary);
+  }
+
+  .error {
+    color: var(--danger);
+  }
+</style>

--- a/frontend/src/components/dev/DevOverlays.svelte
+++ b/frontend/src/components/dev/DevOverlays.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  // the developer overlays (#188), and the F-keys that toggle them.
+  //
+  // The whole thing renders nothing unless the backend says the overlays are
+  // available, which it only does for a run started with PELTON_DEV or
+  // PELTON_DEVTOOLS. A release build never binds the keys.
+  //
+  // The panels are code-split: a normal build downloads none of this.
+  import { onMount } from 'svelte'
+  import {
+    devToolsAvailable,
+    openOverlays,
+    initDevTools,
+    handleOverlayKey,
+  } from '../../stores/devoverlays'
+
+  onMount(initDevTools)
+
+  function onKeydown(event: KeyboardEvent): void {
+    if (handleOverlayKey(event)) {
+      event.preventDefault()
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+{#if $devToolsAvailable}
+  {#if $openOverlays.has('activity')}
+    {#await import('./ActivityOverlay.svelte') then m}
+      <svelte:component this={m.default} />
+    {/await}
+  {/if}
+  {#if $openOverlays.has('process')}
+    {#await import('./ProcessOverlay.svelte') then m}
+      <svelte:component this={m.default} />
+    {/await}
+  {/if}
+  {#if $openOverlays.has('performance')}
+    {#await import('./PerformanceOverlay.svelte') then m}
+      <svelte:component this={m.default} />
+    {/await}
+  {/if}
+{/if}

--- a/frontend/src/components/dev/DevPanel.svelte
+++ b/frontend/src/components/dev/DevPanel.svelte
@@ -28,6 +28,11 @@
   $: placement = position ?? { top, left }
 
   function startDrag(event: PointerEvent): void {
+    // the close button lives in the drag strip. Capturing the pointer for a
+    // drag would swallow its click, so a press on a control is not a drag.
+    if (event.target instanceof Element && event.target.closest('button')) {
+      return
+    }
     const panel = (event.currentTarget as HTMLElement).parentElement
     if (!panel) {
       return
@@ -50,6 +55,9 @@
   }
 
   function endDrag(event: PointerEvent): void {
+    if (!dragging) {
+      return
+    }
     dragging = false
     ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
   }

--- a/frontend/src/components/dev/DevPanel.svelte
+++ b/frontend/src/components/dev/DevPanel.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  // the shared chrome for a developer overlay: a title strip with the key that
+  // opened it, a close button, and a body that scrolls.
+  //
+  // Panels are draggable by their title strip so two of them can be arranged
+  // side by side. Nothing about the position is stored; the overlays are
+  // scratch tools and every launch starts them closed at their default corner.
+  import { IconX } from '@tabler/icons-svelte'
+
+  /** Panel heading. */
+  export let title: string
+  /** The F-key that toggles this panel, shown next to the title. */
+  export let shortcut: string
+  /** Distance from the top of the window, as a css length. */
+  export let top = 'var(--space-5)'
+  /** Distance from the left of the window, as a css length. */
+  export let left = 'var(--space-5)'
+  /** Panel width, as a css length. */
+  export let width = '360px'
+  /** Called when the close button is pressed. */
+  export let onClose: () => void = () => {}
+
+  let dragging = false
+  let offsetX = 0
+  let offsetY = 0
+  let position: { top: string; left: string } | null = null
+
+  $: placement = position ?? { top, left }
+
+  function startDrag(event: PointerEvent): void {
+    const panel = (event.currentTarget as HTMLElement).parentElement
+    if (!panel) {
+      return
+    }
+    const box = panel.getBoundingClientRect()
+    offsetX = event.clientX - box.left
+    offsetY = event.clientY - box.top
+    dragging = true
+    ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+  }
+
+  function drag(event: PointerEvent): void {
+    if (!dragging) {
+      return
+    }
+    position = {
+      left: `${Math.max(0, event.clientX - offsetX)}px`,
+      top: `${Math.max(0, event.clientY - offsetY)}px`,
+    }
+  }
+
+  function endDrag(event: PointerEvent): void {
+    dragging = false
+    ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+  }
+</script>
+
+<section class="panel" style="top: {placement.top}; left: {placement.left}; width: {width};">
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <header
+    class="bar"
+    class:dragging
+    on:pointerdown={startDrag}
+    on:pointermove={drag}
+    on:pointerup={endDrag}
+    on:pointercancel={endDrag}
+  >
+    <span class="title">{title}</span>
+    <span class="key">{shortcut}</span>
+    <button type="button" class="close" aria-label="Close {title}" on:click={onClose}>
+      <IconX size={13} stroke={2} />
+    </button>
+  </header>
+  <div class="body">
+    <slot />
+  </div>
+</section>
+
+<style>
+  .panel {
+    position: fixed;
+    z-index: 400;
+    display: flex;
+    flex-direction: column;
+    max-height: 60vh;
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-card);
+    background: var(--surface-overlay);
+    box-shadow: var(--shadow-overlay);
+    overflow: hidden;
+    resize: both;
+  }
+
+  .bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+    border-bottom: var(--hairline) solid var(--border-subtle);
+    background: var(--surface-sunken);
+    cursor: grab;
+    user-select: none;
+  }
+  .bar.dragging {
+    cursor: grabbing;
+  }
+
+  .title {
+    flex: 1;
+    min-width: 0;
+    font-size: var(--fz-label);
+    font-weight: var(--fw-semibold);
+    color: var(--text-primary);
+  }
+
+  .key {
+    padding: 0 var(--space-1);
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-control);
+    font-family: var(--font-mono);
+    font-size: var(--fz-meta);
+    color: var(--text-tertiary);
+  }
+
+  .close {
+    display: inline-flex;
+    padding: var(--space-1);
+    border: none;
+    background: transparent;
+    color: var(--text-tertiary);
+    border-radius: var(--radius-control);
+    cursor: var(--cursor-action);
+  }
+  .close:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .body {
+    overflow: auto;
+    padding: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--fz-meta);
+    color: var(--text-secondary);
+  }
+</style>

--- a/frontend/src/components/dev/PerformanceOverlay.svelte
+++ b/frontend/src/components/dev/PerformanceOverlay.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  // frame timing for the ui.
+  //
+  // A plain fps readout in a webview is close to useless: at rest it sits at
+  // whatever the display refreshes at and says the same thing on a fast machine
+  // and a slow one. What is worth watching is the opposite, the frames that
+  // took too long, so this reports the worst frame in the last second and
+  // counts every frame that missed its slot. Those numbers move when a list
+  // scroll janks, which is the thing you would open this to see.
+  import { onDestroy, onMount } from 'svelte'
+  import DevPanel from './DevPanel.svelte'
+  import { closeOverlay } from '../../stores/devoverlays'
+
+  // how many recent frame times the strip shows.
+  const sampleCount = 60
+
+  let frames: number[] = []
+  let fps = 0
+  let worst = 0
+  let longFrames = 0
+  let raf = 0
+  let last = 0
+  // the display's own frame budget, learned from the fastest frame seen rather
+  // than assumed to be 60Hz, so a 120Hz screen is not judged against 16.7ms.
+  let budget = 16.7
+
+  onMount(() => {
+    last = performance.now()
+    raf = requestAnimationFrame(tick)
+  })
+
+  onDestroy(() => cancelAnimationFrame(raf))
+
+  function tick(now: number): void {
+    const delta = now - last
+    last = now
+    raf = requestAnimationFrame(tick)
+
+    // the first frame after the overlay opens carries the mount cost and says
+    // nothing about the ui.
+    if (delta <= 0 || delta > 2000) {
+      return
+    }
+    if (delta < budget) {
+      budget = Math.max(delta, 6)
+    }
+    frames = [...frames, delta].slice(-sampleCount)
+
+    const total = frames.reduce((sum, f) => sum + f, 0)
+    fps = Math.round(1000 / (total / frames.length))
+    worst = Math.max(...frames)
+    if (delta > budget * 1.8) {
+      longFrames++
+    }
+  }
+
+  function reset(): void {
+    frames = []
+    longFrames = 0
+    worst = 0
+  }
+
+  // the strip is scaled against twice the budget, so a frame that missed its
+  // slot fills more than half the bar and stands out without a legend.
+  $: scale = budget * 2
+</script>
+
+<DevPanel title="Frames" shortcut="F8" top="calc(var(--space-5) + 300px)" left="calc(100vw - 300px)" width="260px" onClose={() => closeOverlay('performance')}>
+  <dl>
+    <dt>fps</dt>
+    <dd>{fps}</dd>
+    <dt>budget</dt>
+    <dd>{budget.toFixed(1)} ms</dd>
+    <dt>worst frame</dt>
+    <dd>{worst.toFixed(1)} ms</dd>
+    <dt>missed</dt>
+    <dd>{longFrames}</dd>
+  </dl>
+
+  <div class="strip" aria-hidden="true">
+    {#each frames as frame, i (i)}
+      <span class="bar" class:over={frame > budget * 1.8} style="height: {Math.min(100, (frame / scale) * 100)}%"></span>
+    {/each}
+  </div>
+
+  <button type="button" on:click={reset}>reset</button>
+  <p class="muted">Idle sits at the refresh rate. Scroll a message list to see it work.</p>
+</DevPanel>
+
+<style>
+  dl {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-1) var(--space-3);
+    margin: 0 0 var(--space-3);
+  }
+
+  dt {
+    color: var(--text-tertiary);
+  }
+
+  dd {
+    margin: 0;
+    text-align: right;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .strip {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 40px;
+    padding: var(--space-1);
+    border: var(--hairline) solid var(--border-subtle);
+    border-radius: var(--radius-control);
+    background: var(--surface-sunken);
+  }
+
+  .bar {
+    flex: 1;
+    min-height: 1px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+
+  .bar.over {
+    background: var(--warning);
+  }
+
+  button {
+    margin-top: var(--space-2);
+    padding: 0 var(--space-2);
+    border: var(--hairline) solid var(--border-default);
+    border-radius: var(--radius-control);
+    background: transparent;
+    font-family: var(--font-mono);
+    font-size: var(--fz-meta);
+    color: var(--text-secondary);
+    cursor: var(--cursor-action);
+  }
+  button:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .muted {
+    margin: var(--space-2) 0 0;
+    color: var(--text-tertiary);
+  }
+</style>

--- a/frontend/src/components/dev/ProcessOverlay.svelte
+++ b/frontend/src/components/dev/ProcessOverlay.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // the Go side of the app, sampled: goroutines, heap, gc runs, and what the
+  // app has put on disk. Useful for the two things that are otherwise invisible
+  // from the ui, a goroutine that never exits and a cache that keeps growing.
+  import { onDestroy, onMount } from 'svelte'
+  import DevPanel from './DevPanel.svelte'
+  import { closeOverlay } from '../../stores/devoverlays'
+  import { devProcessStats } from '../../lib/api'
+  import type { DevProcessStats } from '../../lib/types'
+
+  const pollMs = 2000
+
+  let stats: DevProcessStats | null = null
+  let error = ''
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  onMount(() => {
+    void poll()
+    timer = setInterval(() => void poll(), pollMs)
+  })
+
+  onDestroy(() => {
+    if (timer) {
+      clearInterval(timer)
+    }
+  })
+
+  async function poll(): Promise<void> {
+    try {
+      stats = await devProcessStats()
+      error = ''
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  // bytes at three digits of precision, which is all any of these numbers
+  // deserve while they are moving.
+  function bytes(n: number): string {
+    const units = ['B', 'KB', 'MB', 'GB']
+    let value = n
+    let unit = 0
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024
+      unit++
+    }
+    return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`
+  }
+
+  function duration(seconds: number): string {
+    const h = Math.floor(seconds / 3600)
+    const m = Math.floor((seconds % 3600) / 60)
+    const s = seconds % 60
+    return h > 0 ? `${h}h ${m}m` : m > 0 ? `${m}m ${s}s` : `${s}s`
+  }
+</script>
+
+<DevPanel title="Process" shortcut="F7" top="var(--space-5)" left="calc(100vw - 300px)" width="260px" onClose={() => closeOverlay('process')}>
+  {#if error}
+    <p class="error">{error}</p>
+  {:else if !stats}
+    <p class="muted">Sampling…</p>
+  {:else}
+    <dl>
+      <dt>goroutines</dt>
+      <dd>{stats.goroutines}</dd>
+      <dt>heap live</dt>
+      <dd>{bytes(stats.heapBytes)}</dd>
+      <dt>heap from os</dt>
+      <dd>{bytes(stats.heapSysBytes)}</dd>
+      <dt>gc runs</dt>
+      <dd>{stats.gcRuns}</dd>
+      <dt>database</dt>
+      <dd>{bytes(stats.databaseBytes)}</dd>
+      <dt>attachments</dt>
+      <dd>{bytes(stats.attachmentsBytes)}</dd>
+      <dt>data dir</dt>
+      <dd>{bytes(stats.dataDirBytes)}</dd>
+      <dt>uptime</dt>
+      <dd>{duration(stats.uptimeSeconds)}</dd>
+    </dl>
+    <p class="muted">Directory sizes are measured every 10s.</p>
+  {/if}
+</DevPanel>
+
+<style>
+  dl {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-1) var(--space-3);
+    margin: 0;
+  }
+
+  dt {
+    color: var(--text-tertiary);
+  }
+
+  dd {
+    margin: 0;
+    text-align: right;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .muted {
+    margin: var(--space-3) 0 0;
+    color: var(--text-tertiary);
+  }
+
+  .error {
+    margin: 0;
+    color: var(--danger);
+  }
+</style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,8 @@ import type {
   PGPKey,
   LogStatus,
   ThunderbirdProfile,
+  DevActivity,
+  DevProcessStats,
 } from './types'
 
 // isDemoMode reports whether the app launched in the cosmetic --potatoes-are-nice
@@ -1281,4 +1283,34 @@ export function dismissCrashReport(): Promise<void> {
 // copies to the clipboard. It never contains mail or addresses.
 export function getDiagnostics(): Promise<string> {
   return App.GetDiagnostics()
+}
+
+// devToolsEnabled reports whether the developer overlays are available (#188).
+// They are, only when the app was started with PELTON_DEV or PELTON_DEVTOOLS;
+// no setting can turn them on.
+export function devToolsEnabled(): Promise<boolean> {
+  if (isDemoActive()) {
+    return Promise.resolve(false)
+  }
+  return App.DevToolsEnabled()
+}
+
+// devActivity returns the buffered log lines newer than seq, along with the
+// sequence to ask for next. Pass 0 for everything still buffered.
+export function devActivity(after: number): Promise<DevActivity> {
+  return App.DevActivity(after).then((page) => ({
+    lines: page.lines ?? [],
+    next: page.next,
+    level: page.level,
+  }))
+}
+
+// clearDevActivity empties the activity buffer.
+export function clearDevActivity(): Promise<void> {
+  return App.ClearDevActivity()
+}
+
+// devProcessStats samples the Go runtime and the app's on-disk footprint.
+export function devProcessStats(): Promise<DevProcessStats> {
+  return App.DevProcessStats()
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -838,3 +838,31 @@ export interface View {
 // 'sidebar' shows it as a group in the mailbox sidebar, 'tab' shows it in a
 // separate Views tab/rail.
 export type ViewsPlacement = 'hidden' | 'sidebar' | 'tab'
+
+// DevLogLine is one line in the developer activity overlay. seq counts every
+// line the session produced, so a gap in it means lines were dropped.
+export interface DevLogLine {
+  seq: number
+  text: string
+}
+
+// DevActivity is a page of the activity overlay: the lines newer than what was
+// asked for, the sequence to ask for next, and the current log threshold.
+export interface DevActivity {
+  lines: DevLogLine[]
+  next: number
+  level: string
+}
+
+// DevProcessStats is what the process overlay shows: the Go runtime's own
+// numbers and the app's footprint on disk, all in bytes.
+export interface DevProcessStats {
+  goroutines: number
+  heapBytes: number
+  heapSysBytes: number
+  gcRuns: number
+  databaseBytes: number
+  attachmentsBytes: number
+  dataDirBytes: number
+  uptimeSeconds: number
+}

--- a/frontend/src/stores/devoverlays.ts
+++ b/frontend/src/stores/devoverlays.ts
@@ -1,0 +1,78 @@
+// devoverlays.ts owns which developer overlays are open (#188).
+//
+// The overlays only exist when the app was started for development, which the
+// backend decides from PELTON_DEV or PELTON_DEVTOOLS. Nothing here is persisted:
+// every launch starts with all of them closed, so an overlay left open cannot
+// confuse the next session.
+
+import { writable, get } from 'svelte/store'
+import { devToolsEnabled } from '../lib/api'
+
+/** The overlays, in the order their keys run. */
+export type DevOverlay = 'activity' | 'process' | 'performance'
+
+/** Which F-key opens which overlay. */
+export const overlayKeys: Record<string, DevOverlay> = {
+  F6: 'activity',
+  F7: 'process',
+  F8: 'performance',
+}
+
+/** Whether the developer overlays are available at all. */
+export const devToolsAvailable = writable(false)
+
+/** The overlays currently on screen. Several can be open at once. */
+export const openOverlays = writable<Set<DevOverlay>>(new Set())
+
+/**
+ * Asks the backend whether the overlays are available. Called once at startup;
+ * the keys do nothing until it resolves true.
+ */
+export async function initDevTools(): Promise<void> {
+  try {
+    devToolsAvailable.set(await devToolsEnabled())
+  } catch {
+    devToolsAvailable.set(false)
+  }
+}
+
+/** Opens the overlay if it is closed, closes it if it is open. */
+export function toggleOverlay(name: DevOverlay): void {
+  openOverlays.update((open) => {
+    const next = new Set(open)
+    if (!next.delete(name)) {
+      next.add(name)
+    }
+    return next
+  })
+}
+
+/** Closes one overlay. */
+export function closeOverlay(name: DevOverlay): void {
+  openOverlays.update((open) => {
+    const next = new Set(open)
+    next.delete(name)
+    return next
+  })
+}
+
+/**
+ * Handles a keydown for the overlay keys and reports whether it was one. Does
+ * nothing when the overlays are unavailable, so a release build never swallows
+ * F6 to F8.
+ */
+export function handleOverlayKey(event: KeyboardEvent): boolean {
+  if (!get(devToolsAvailable)) {
+    return false
+  }
+  // a modifier means the user meant something else with the key.
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+    return false
+  }
+  const overlay = overlayKeys[event.key]
+  if (!overlay) {
+    return false
+  }
+  toggleOverlay(overlay)
+  return true
+}

--- a/frontend/wailsjs/go/desktop/App.d.ts
+++ b/frontend/wailsjs/go/desktop/App.d.ts
@@ -30,6 +30,8 @@ export function ChooseMailFiles():Promise<Array<string>>;
 
 export function ChooseThunderbirdProfile():Promise<Array<desktop.ThunderbirdProfileDTO>>;
 
+export function ClearDevActivity():Promise<void>;
+
 export function ClearSentOutbox():Promise<void>;
 
 export function CloseWindow():Promise<void>;
@@ -63,6 +65,12 @@ export function DeleteSignature(arg1:number):Promise<void>;
 export function DeleteTheme(arg1:string):Promise<void>;
 
 export function DeleteView(arg1:number):Promise<void>;
+
+export function DevActivity(arg1:number):Promise<desktop.DevActivityDTO>;
+
+export function DevProcessStats():Promise<desktop.DevProcessDTO>;
+
+export function DevToolsEnabled():Promise<boolean>;
 
 export function DiscardFailedSend(arg1:number):Promise<boolean>;
 

--- a/frontend/wailsjs/go/desktop/App.js
+++ b/frontend/wailsjs/go/desktop/App.js
@@ -58,6 +58,10 @@ export function ChooseThunderbirdProfile() {
   return window['go']['desktop']['App']['ChooseThunderbirdProfile']();
 }
 
+export function ClearDevActivity() {
+  return window['go']['desktop']['App']['ClearDevActivity']();
+}
+
 export function ClearSentOutbox() {
   return window['go']['desktop']['App']['ClearSentOutbox']();
 }
@@ -124,6 +128,18 @@ export function DeleteTheme(arg1) {
 
 export function DeleteView(arg1) {
   return window['go']['desktop']['App']['DeleteView'](arg1);
+}
+
+export function DevActivity(arg1) {
+  return window['go']['desktop']['App']['DevActivity'](arg1);
+}
+
+export function DevProcessStats() {
+  return window['go']['desktop']['App']['DevProcessStats']();
+}
+
+export function DevToolsEnabled() {
+  return window['go']['desktop']['App']['DevToolsEnabled']();
 }
 
 export function DiscardFailedSend(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -376,6 +376,80 @@ export namespace desktop {
 	        this.isDefault = source["isDefault"];
 	    }
 	}
+	export class DevLogLineDTO {
+	    seq: number;
+	    text: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new DevLogLineDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.seq = source["seq"];
+	        this.text = source["text"];
+	    }
+	}
+	export class DevActivityDTO {
+	    lines: DevLogLineDTO[];
+	    next: number;
+	    level: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new DevActivityDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.lines = this.convertValues(source["lines"], DevLogLineDTO);
+	        this.next = source["next"];
+	        this.level = source["level"];
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class DevProcessDTO {
+	    goroutines: number;
+	    heapBytes: number;
+	    heapSysBytes: number;
+	    gcRuns: number;
+	    databaseBytes: number;
+	    attachmentsBytes: number;
+	    dataDirBytes: number;
+	    uptimeSeconds: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new DevProcessDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.goroutines = source["goroutines"];
+	        this.heapBytes = source["heapBytes"];
+	        this.heapSysBytes = source["heapSysBytes"];
+	        this.gcRuns = source["gcRuns"];
+	        this.databaseBytes = source["databaseBytes"];
+	        this.attachmentsBytes = source["attachmentsBytes"];
+	        this.dataDirBytes = source["dataDirBytes"];
+	        this.uptimeSeconds = source["uptimeSeconds"];
+	    }
+	}
 	export class DiscoveredDTO {
 	    imapHost: string;
 	    imapPort: number;

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/TRC-Loop/Pelton/internal/configsync"
 	"github.com/TRC-Loop/Pelton/internal/logging"
@@ -58,6 +59,13 @@ type App struct {
 	// learn it is to try, and a restart tries again. See bind_account_manage.go.
 	rejectedLogins   map[int64]struct{}
 	rejectedLoginsMu sync.Mutex
+	// startedAt is when the process came up, for the process overlay's uptime.
+	startedAt time.Time
+	// dirSizes caches measured directory sizes for the process overlay, which
+	// polls while it is open and must not walk the attachment tree every tick.
+	// See bind_devtools.go.
+	dirSizes   map[string]measuredDir
+	dirSizesMu sync.Mutex
 	// contacts caches the address book the phishing checks compare senders
 	// against, so reading down a folder does not requery it per message.
 	contacts correspondentCache
@@ -146,6 +154,7 @@ func newApp(version, channel string) *App {
 		log:        w.Logger(),
 		version:    version,
 		channel:    channel,
+		startedAt:  time.Now(),
 		storeReady: make(chan struct{}),
 	}
 }

--- a/internal/desktop/bind_devtools.go
+++ b/internal/desktop/bind_devtools.go
@@ -1,0 +1,205 @@
+// bind_devtools.go backs the developer overlays (#188): a live view of what the
+// app is doing, without adding log lines and rebuilding.
+//
+// Everything here stays on the machine. There is no reporter and no endpoint;
+// the overlays read what the process already knows about itself. The activity
+// overlay shows log lines, which carry mailbox names and addresses, so the
+// whole surface is off unless the app was deliberately started for development:
+// PELTON_DEV (what `make run` sets) or PELTON_DEVTOOLS. No setting can turn it
+// on, so it cannot be reached by a stray click or by anything remote.
+package desktop
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// devToolsEnvVar turns the overlays on for a build that is not running under
+// PELTON_DEV, which is the only way to get them in a packaged binary.
+const devToolsEnvVar = "PELTON_DEVTOOLS"
+
+// devLogBufferLines is how many recent log lines the activity overlay keeps.
+// Enough to cover a sync pass and the mistake before it, small enough that a
+// session left running overnight costs nothing.
+const devLogBufferLines = 500
+
+// devDirSizeTTL is how long a measured directory size is reused. Walking the
+// attachment tree is the one expensive thing on this screen and its size does
+// not move between two ticks of a 2 second poll.
+const devDirSizeTTL = 10 * time.Second
+
+// errDevToolsDisabled is returned by every binding here when the app was not
+// started for development. It is an error rather than empty data so a caller
+// cannot mistake "off" for "nothing is happening".
+var errDevToolsDisabled = errors.New("developer tools are not enabled")
+
+// DevToolsEnabled reports whether the developer overlays are available. The
+// frontend asks once at startup and does not bind the keys otherwise.
+func (a *App) DevToolsEnabled() bool {
+	return a.IsDevMode() || os.Getenv(devToolsEnvVar) != ""
+}
+
+// DevLogLineDTO is one buffered log line. Seq is the line's position in the
+// whole session, so a reader can both ask for what is new and see that lines
+// were dropped.
+type DevLogLineDTO struct {
+	Seq  uint64 `json:"seq"`
+	Text string `json:"text"`
+}
+
+// DevActivityDTO is a page of the activity log. Next is the sequence to ask for
+// on the following call.
+type DevActivityDTO struct {
+	Lines []DevLogLineDTO `json:"lines"`
+	Next  uint64          `json:"next"`
+	// Level is the current log threshold. Below debug, most of what the sync
+	// path does is never written, so the overlay says so rather than looking
+	// like nothing is happening.
+	Level string `json:"level"`
+}
+
+// DevActivity returns the log lines buffered since the given sequence, starting
+// the buffer on the first call. Pass 0 to get everything still held.
+//
+// The lines are the same redacted text that reaches stderr and the log file, so
+// a registered secret is gone from all three.
+func (a *App) DevActivity(after uint64) (DevActivityDTO, error) {
+	if !a.DevToolsEnabled() {
+		return DevActivityDTO{}, errDevToolsDisabled
+	}
+	if a.logWriter == nil {
+		return DevActivityDTO{}, errors.New("desktop: no log writer")
+	}
+
+	lines, next := a.logWriter.Buffer(devLogBufferLines).Since(after)
+	out := make([]DevLogLineDTO, 0, len(lines))
+	for _, line := range lines {
+		out = append(out, DevLogLineDTO{Seq: line.Seq, Text: line.Text})
+	}
+	return DevActivityDTO{
+		Lines: out,
+		Next:  next,
+		Level: a.logWriter.Level().String(),
+	}, nil
+}
+
+// ClearDevActivity empties the activity buffer, for starting a fresh read of
+// one operation.
+func (a *App) ClearDevActivity() error {
+	if !a.DevToolsEnabled() {
+		return errDevToolsDisabled
+	}
+	if a.logWriter == nil {
+		return nil
+	}
+	a.logWriter.Buffer(devLogBufferLines).Clear()
+	return nil
+}
+
+// DevProcessDTO is what the process overlay shows: the Go runtime's own numbers
+// and what the app has put on disk.
+type DevProcessDTO struct {
+	Goroutines int `json:"goroutines"`
+	// HeapBytes is live heap (HeapAlloc), HeapSysBytes what the runtime has
+	// taken from the os. The gap between them is the runtime holding on to
+	// memory it may reuse, which is normal and not a leak.
+	HeapBytes    uint64 `json:"heapBytes"`
+	HeapSysBytes uint64 `json:"heapSysBytes"`
+	GCRuns       uint32 `json:"gcRuns"`
+	// DatabaseBytes is the .db file only. WAL and shm files sit next to it and
+	// are counted with it, since they are the same database.
+	DatabaseBytes    int64 `json:"databaseBytes"`
+	AttachmentsBytes int64 `json:"attachmentsBytes"`
+	DataDirBytes     int64 `json:"dataDirBytes"`
+	// UptimeSeconds is how long this process has been running.
+	UptimeSeconds int64 `json:"uptimeSeconds"`
+}
+
+// DevProcessStats samples the runtime and measures the app's directories.
+// Directory sizes are cached briefly, so polling this does not turn into a
+// continuous walk of the attachment tree.
+func (a *App) DevProcessStats() (DevProcessDTO, error) {
+	if !a.DevToolsEnabled() {
+		return DevProcessDTO{}, errDevToolsDisabled
+	}
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	out := DevProcessDTO{
+		Goroutines:    runtime.NumGoroutine(),
+		HeapBytes:     mem.HeapAlloc,
+		HeapSysBytes:  mem.HeapSys,
+		GCRuns:        mem.NumGC,
+		UptimeSeconds: int64(time.Since(a.startedAt).Seconds()),
+	}
+	if a.store != nil {
+		out.DatabaseBytes = databaseSize(a.store.Path())
+		out.AttachmentsBytes = a.cachedDirSize(a.store.AttachmentsDir())
+	}
+	if a.dataDir != "" {
+		out.DataDirBytes = a.cachedDirSize(a.dataDir)
+	}
+	return out, nil
+}
+
+// measuredDir is one measured directory and when it was measured.
+type measuredDir struct {
+	bytes int64
+	at    time.Time
+}
+
+// cachedDirSize returns the size of dir, remeasuring only once the last figure
+// has gone stale. A directory that cannot be read reports 0 rather than failing
+// the whole overlay.
+func (a *App) cachedDirSize(dir string) int64 {
+	a.dirSizesMu.Lock()
+	defer a.dirSizesMu.Unlock()
+
+	if cached, ok := a.dirSizes[dir]; ok && time.Since(cached.at) < devDirSizeTTL {
+		return cached.bytes
+	}
+	size := treeSize(dir)
+	if a.dirSizes == nil {
+		a.dirSizes = make(map[string]measuredDir)
+	}
+	a.dirSizes[dir] = measuredDir{bytes: size, at: time.Now()}
+	return size
+}
+
+// treeSize adds up the regular files under dir and everything below it, unlike
+// dirSize which only reads one level. Unreadable entries are skipped: an
+// incomplete figure is more useful here than none.
+func treeSize(dir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dir, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil //nolint:nilerr // a directory we cannot read is skipped, not fatal
+		}
+		if info, err := entry.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// databaseSize adds the WAL and shared-memory files to the main database file.
+// In WAL mode a busy database can hold a lot of its recent size in the -wal
+// file, and reporting only the .db would understate it.
+func databaseSize(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	var total int64
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if info, err := os.Stat(path + suffix); err == nil {
+			total += info.Size()
+		}
+	}
+	return total
+}

--- a/internal/desktop/bind_devtools_test.go
+++ b/internal/desktop/bind_devtools_test.go
@@ -1,0 +1,161 @@
+package desktop
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/TRC-Loop/Pelton/internal/logging"
+)
+
+func newDevToolsApp(t *testing.T) *App {
+	t.Helper()
+	w := logging.NewWriter()
+	return &App{logWriter: w, log: w.Logger(), startedAt: time.Now()}
+}
+
+// The overlays read log lines, which carry mailbox names and addresses. Off is
+// the default and no setting can change it, so the only thing to pin is that a
+// plain run really is off and every binding refuses.
+func TestDevToolsOffWithoutTheEnvironment(t *testing.T) {
+	t.Setenv("PELTON_DEV", "")
+	t.Setenv(devToolsEnvVar, "")
+	a := newDevToolsApp(t)
+
+	if a.DevToolsEnabled() {
+		t.Fatal("developer tools are enabled on a plain run")
+	}
+	if _, err := a.DevActivity(0); !errors.Is(err, errDevToolsDisabled) {
+		t.Errorf("DevActivity err = %v, want errDevToolsDisabled", err)
+	}
+	if _, err := a.DevProcessStats(); !errors.Is(err, errDevToolsDisabled) {
+		t.Errorf("DevProcessStats err = %v, want errDevToolsDisabled", err)
+	}
+	if err := a.ClearDevActivity(); !errors.Is(err, errDevToolsDisabled) {
+		t.Errorf("ClearDevActivity err = %v, want errDevToolsDisabled", err)
+	}
+}
+
+func TestDevToolsEnabledByEitherVariable(t *testing.T) {
+	for _, name := range []string{"PELTON_DEV", devToolsEnvVar} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("PELTON_DEV", "")
+			t.Setenv(devToolsEnvVar, "")
+			t.Setenv(name, "1")
+
+			if !newDevToolsApp(t).DevToolsEnabled() {
+				t.Errorf("%s did not enable the developer tools", name)
+			}
+		})
+	}
+}
+
+// Nothing is buffered until the overlay asks, and once it does the app's own
+// log lines are what it sees.
+func TestDevActivityReadsTheAppLog(t *testing.T) {
+	t.Setenv(devToolsEnvVar, "1")
+	a := newDevToolsApp(t)
+
+	a.log.Info("syncing", "folder", "INBOX")
+
+	first, err := a.DevActivity(0)
+	if err != nil {
+		t.Fatalf("DevActivity: %v", err)
+	}
+	// the line above was written before anything asked for a buffer, so it is
+	// gone; what matters is that lines written from here on arrive.
+	a.log.Info("fetched", "count", 3)
+
+	second, err := a.DevActivity(first.Next)
+	if err != nil {
+		t.Fatalf("DevActivity: %v", err)
+	}
+	if len(second.Lines) != 1 {
+		t.Fatalf("got %d new lines, want 1: %v", len(second.Lines), second.Lines)
+	}
+	if !strings.Contains(second.Lines[0].Text, "fetched") {
+		t.Errorf("line = %q, want the fetched line", second.Lines[0].Text)
+	}
+	if second.Level == "" {
+		t.Error("no log level reported")
+	}
+}
+
+func TestClearDevActivityEmptiesTheBuffer(t *testing.T) {
+	t.Setenv(devToolsEnvVar, "1")
+	a := newDevToolsApp(t)
+
+	if _, err := a.DevActivity(0); err != nil {
+		t.Fatalf("DevActivity: %v", err)
+	}
+	a.log.Info("before the clear")
+	if err := a.ClearDevActivity(); err != nil {
+		t.Fatalf("ClearDevActivity: %v", err)
+	}
+
+	got, err := a.DevActivity(0)
+	if err != nil {
+		t.Fatalf("DevActivity: %v", err)
+	}
+	if len(got.Lines) != 0 {
+		t.Errorf("lines = %v, want none after the clear", got.Lines)
+	}
+}
+
+func TestDevProcessStatsReportsTheRuntime(t *testing.T) {
+	t.Setenv(devToolsEnvVar, "1")
+	a := newDevToolsApp(t)
+
+	stats, err := a.DevProcessStats()
+	if err != nil {
+		t.Fatalf("DevProcessStats: %v", err)
+	}
+	if stats.Goroutines < 1 {
+		t.Errorf("Goroutines = %d, want at least the one running this test", stats.Goroutines)
+	}
+	if stats.HeapBytes == 0 {
+		t.Error("HeapBytes = 0, want the live heap")
+	}
+}
+
+// The database is more than the .db file in WAL mode, and reporting only that
+// would understate it.
+func TestDatabaseSizeCountsTheWalFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pelton.db")
+	for suffix, size := range map[string]int{"": 100, "-wal": 40, "-shm": 10} {
+		if err := os.WriteFile(path+suffix, make([]byte, size), 0o600); err != nil {
+			t.Fatalf("write %s: %v", suffix, err)
+		}
+	}
+
+	if got := databaseSize(path); got != 150 {
+		t.Errorf("databaseSize = %d, want 150", got)
+	}
+	if got := databaseSize(filepath.Join(dir, "missing.db")); got != 0 {
+		t.Errorf("databaseSize of a missing file = %d, want 0", got)
+	}
+}
+
+// treeSize walks the whole tree, unlike dirSize, because attachments are nested
+// per account and per message.
+func TestTreeSizeWalksSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "1", "2")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "a.bin"), make([]byte, 64), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := treeSize(dir); got != 64 {
+		t.Errorf("treeSize = %d, want 64", got)
+	}
+	if got := treeSize(filepath.Join(dir, "nope")); got != 0 {
+		t.Errorf("treeSize of a missing dir = %d, want 0", got)
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -41,6 +41,9 @@ type Writer struct {
 	// level is referenced by the handler options, so changing it takes effect
 	// on loggers that were already built.
 	level slog.LevelVar
+	// ring buffers recent lines in memory for the developer overlays. Nil
+	// unless something asked for it, so a normal run allocates nothing.
+	ring *Ring
 }
 
 // NewWriter returns a Writer logging to stderr only, at info level.
@@ -101,6 +104,18 @@ func (w *Writer) Disable() error {
 	return err
 }
 
+// Buffer starts keeping the most recent lines in memory and returns the Ring
+// holding them. Calling it again returns the same Ring rather than starting a
+// second one, so every reader sees the same history.
+func (w *Writer) Buffer(capacity int) *Ring {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.ring == nil {
+		w.ring = NewRing(capacity)
+	}
+	return w.ring
+}
+
 // Enabled reports whether lines are currently reaching a file.
 func (w *Writer) Enabled() bool {
 	w.mu.Lock()
@@ -118,10 +133,14 @@ func (w *Writer) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	file := w.file
 	stderr := w.stderr
+	ring := w.ring
 	w.mu.Unlock()
 
 	if stderr != nil {
 		stderr.Write(clean)
+	}
+	if ring != nil {
+		ring.Add(string(clean))
 	}
 	if file != nil {
 		if _, err := file.Write(clean); err != nil {

--- a/internal/logging/ring.go
+++ b/internal/logging/ring.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"strings"
+	"sync"
+)
+
+// Ring keeps the most recent log lines in memory so something can read them
+// back without opening a file, which the developer overlays do (#188). It is
+// fed the same redacted bytes that reach stderr and the log file, so a secret
+// stripped from one is stripped from all three.
+//
+// Nothing is written to disk here and nothing leaves the process. The buffer is
+// fixed size: once full, the oldest line is dropped rather than the app growing
+// a memory leak on a long session.
+type Ring struct {
+	mu    sync.Mutex
+	lines []Line
+	// next is the sequence number the next line gets. It counts every line ever
+	// added, including the ones already dropped, so a reader can tell that it
+	// missed some rather than silently seeing a gap.
+	next  uint64
+	first int
+	count int
+}
+
+// Line is one buffered log line with the sequence number it was given.
+type Line struct {
+	Seq  uint64 `json:"seq"`
+	Text string `json:"text"`
+}
+
+// NewRing returns a Ring holding at most capacity lines. A capacity below one
+// is treated as one.
+func NewRing(capacity int) *Ring {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &Ring{lines: make([]Line, capacity)}
+}
+
+// Add buffers one line, dropping the oldest when full. Trailing newlines are
+// stripped, since a reader wants the line rather than the framing.
+func (r *Ring) Add(text string) {
+	text = strings.TrimRight(text, "\r\n")
+	if text == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	pos := (r.first + r.count) % len(r.lines)
+	r.lines[pos] = Line{Seq: r.next, Text: text}
+	r.next++
+	if r.count == len(r.lines) {
+		r.first = (r.first + 1) % len(r.lines)
+		return
+	}
+	r.count++
+}
+
+// Since returns the buffered lines with a sequence number at or after seq, plus
+// the sequence to ask for next. Passing 0 returns everything still buffered.
+//
+// Lines that were dropped before the reader got to them are simply not there;
+// the gap is visible in the sequence numbers, which is the point of keeping
+// them.
+func (r *Ring) Since(seq uint64) ([]Line, uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]Line, 0, r.count)
+	for i := range r.count {
+		line := r.lines[(r.first+i)%len(r.lines)]
+		if line.Seq >= seq {
+			out = append(out, line)
+		}
+	}
+	return out, r.next
+}
+
+// Clear empties the buffer. Sequence numbers keep counting, so a reader holding
+// an old one is not sent back through lines it already has.
+func (r *Ring) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.first = 0
+	r.count = 0
+}

--- a/internal/logging/ring_test.go
+++ b/internal/logging/ring_test.go
@@ -1,0 +1,110 @@
+package logging
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRingKeepsRecentLines(t *testing.T) {
+	r := NewRing(3)
+	for _, line := range []string{"one", "two", "three"} {
+		r.Add(line)
+	}
+
+	lines, next := r.Since(0)
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3", len(lines))
+	}
+	if lines[0].Text != "one" || lines[2].Text != "three" {
+		t.Errorf("lines = %v, want one..three in order", lines)
+	}
+	if next != 3 {
+		t.Errorf("next = %d, want 3", next)
+	}
+}
+
+// The buffer is fixed size on purpose: a long session must not grow it.
+func TestRingDropsOldestWhenFull(t *testing.T) {
+	r := NewRing(2)
+	for _, line := range []string{"one", "two", "three", "four"} {
+		r.Add(line)
+	}
+
+	lines, next := r.Since(0)
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	if lines[0].Text != "three" || lines[1].Text != "four" {
+		t.Errorf("lines = %v, want the last two", lines)
+	}
+	// the sequence keeps counting through the dropped lines, so a reader can
+	// see that two went missing rather than believing it has everything.
+	if lines[0].Seq != 2 {
+		t.Errorf("first Seq = %d, want 2", lines[0].Seq)
+	}
+	if next != 4 {
+		t.Errorf("next = %d, want 4", next)
+	}
+}
+
+func TestRingSinceReturnsOnlyNewLines(t *testing.T) {
+	r := NewRing(10)
+	r.Add("one")
+	r.Add("two")
+
+	_, next := r.Since(0)
+	r.Add("three")
+
+	lines, _ := r.Since(next)
+	if len(lines) != 1 || lines[0].Text != "three" {
+		t.Errorf("lines = %v, want only three", lines)
+	}
+}
+
+func TestRingClearKeepsCounting(t *testing.T) {
+	r := NewRing(10)
+	r.Add("one")
+	r.Clear()
+
+	lines, next := r.Since(0)
+	if len(lines) != 0 {
+		t.Errorf("lines = %v, want none after Clear", lines)
+	}
+	if next != 1 {
+		t.Errorf("next = %d, want the sequence to keep counting", next)
+	}
+}
+
+// The overlay reads the same bytes the log file gets, so a password stripped
+// from one has to be stripped from all of them.
+func TestBufferedLinesAreRedacted(t *testing.T) {
+	t.Cleanup(secrets.Reset)
+	Register("hunter2")
+
+	w := NewWriter()
+	w.stderr = nil
+	ring := w.Buffer(10)
+
+	slog.New(slog.NewTextHandler(w, nil)).Info("login", "cmd", "LOGIN user hunter2")
+
+	lines, _ := ring.Since(0)
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(lines))
+	}
+	if strings.Contains(lines[0].Text, "hunter2") {
+		t.Errorf("the buffered line kept the password: %q", lines[0].Text)
+	}
+}
+
+// Buffering is opt-in: a normal run must not allocate a buffer or collect
+// anything in memory.
+func TestWriterDoesNotBufferUntilAsked(t *testing.T) {
+	w := NewWriter()
+	if w.ring != nil {
+		t.Error("a new Writer is already buffering")
+	}
+	if first, second := w.Buffer(5), w.Buffer(5); first != second {
+		t.Error("Buffer started a second ring instead of returning the first")
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -55,6 +55,7 @@ type execer interface {
 // on disk attachments root.
 type DB struct {
 	sql            *sql.DB
+	path           string
 	attachmentsDir string
 }
 
@@ -114,8 +115,14 @@ func Open(path string) (*DB, error) {
 
 	return &DB{
 		sql:            sqlDB,
+		path:           path,
 		attachmentsDir: filepath.Join(baseDir, attachmentsDirName),
 	}, nil
+}
+
+// Path returns the database file this DB was opened on.
+func (d *DB) Path() string {
+	return d.path
 }
 
 // dataSourceName builds the dsn. the pragmas are set as query params so they


### PR DESCRIPTION
Part of #188. I am leaving the issue open for the richer per-IMAP-command activity feed and moving it to 2026.4.1.

Three overlays on F6, F7 and F8. They are draggable, several can be open at once, and they always start closed.

- F6 activity: the app's own log, live. It taps the existing log stream, so it shows the same redacted lines that reach stderr and the log file and there is no second reporting path to drift. Detail follows the log level, so PELTON_DEBUG=1 for the full sync.
- F7 process: goroutines, live heap and heap from the os, gc runs, database size including the WAL files, attachments and data dir. Directory sizes are cached for 10s so polling does not walk the attachment tree every tick.
- F8 frames: frame timing. A plain fps readout says nothing in a webview, so it reports the worst frame in the last second and counts frames that missed their slot, measured against the display's own refresh rate rather than an assumed 60Hz.

Availability is PELTON_DEV or PELTON_DEVTOOLS, nothing else. No setting can turn it on, every binding refuses when it is off, and the panels are code-split so a normal build does not download them. The activity log carries mailbox names, which is why it is env only.

The webview inspector is not in here. Wails only exposes it as a build tag, with no runtime API to open it, so F12 stays the browser's own key in a dev build. Documented that way in docs/shortcuts.md along with the three keys.

The overlay text is English only. It is a developer tool behind an env var and the labels are Go runtime names.