### PR TITLE
fix: quote display names in address headers

### DIFF
--- a/internal/smtp/headers.go
+++ b/internal/smtp/headers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"mime"
+	"net/mail"
 	"strings"
 	"time"
 )
@@ -47,19 +48,27 @@ func writeHeader(b *strings.Builder, key, value string) {
 	b.WriteString(crlf)
 }
 
-// encodeWord RFC2047-encodes a header value (a subject or display name) when it
+// encodeWord RFC2047-encodes a header value (a subject) when it
 // contains non-ASCII, leaving plain ASCII untouched.
 func encodeWord(s string) string {
 	return mime.QEncoding.Encode("utf-8", s)
 }
 
-// formatAddress renders one address with an optional RFC2047-encoded display
-// name, for example: =?utf-8?q?Ann=C3=A9?= <ann@example.com>.
+// formatAddress renders one address with its display name.
+//
+// The name goes through net/mail rather than being pasted in, because RFC 5322
+// gives several characters a meaning inside an address list and a name carrying
+// one has to be quoted. A comma is the dangerous one: "Kock, Arne" pasted in
+// bare reads as two addresses, which a strict server rejects outright ("multiple
+// addresses in From header MUST have a Sender header") and a lax one delivers
+// with the sender mangled. Parentheses are a comment and would silently drop
+// what is inside them. Address.String also handles the non-ascii case, encoding
+// the name as an rfc 2047 word.
 func formatAddress(a Address) string {
 	if a.Name == "" {
 		return a.Email
 	}
-	return encodeWord(a.Name) + " <" + a.Email + ">"
+	return (&mail.Address{Name: a.Name, Address: a.Email}).String()
 }
 
 // formatAddressList renders a comma-separated address header value.

--- a/internal/smtp/headers_test.go
+++ b/internal/smtp/headers_test.go
@@ -1,0 +1,118 @@
+package smtp
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/crypto"
+)
+
+// Every address header we generate has to parse back as the number of
+// addresses we put in it. A display name carrying an rfc 5322 special, a comma
+// above all, silently becomes a second address when it is not quoted: a strict
+// server answers "multiple addresses in From header MUST have a Sender header"
+// and a lax one delivers with the sender mangled. Round-tripping through
+// net/mail is what catches it, so the tests do that rather than compare against
+// a string somebody wrote out by hand.
+func TestFormatAddressRoundTrips(t *testing.T) {
+	cases := []struct {
+		name    string
+		display string
+	}{
+		{"plain", "Ann Sender"},
+		{"trailing dot", "Arne K."},
+		{"comma", "Kock, Arne"},
+		{"comma and more", "Arne K., Stellar Foundry"},
+		{"parentheses", "Support (Billing)"},
+		{"angle brackets", "The <Team>"},
+		{"quotes", `Say "hi"`},
+		{"colon and semicolon", "Group: members;"},
+		{"at sign", "arne@work"},
+		{"backslash", `Path\Name`},
+		{"non-ascii", "Anné Sénder"},
+		{"non-ascii with comma", "Müller, Jürgen"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAddress(Address{Name: tc.display, Email: "a@b.c"})
+
+			list, err := mail.ParseAddressList(got)
+			if err != nil {
+				t.Fatalf("generated %q, which will not parse: %v", got, err)
+			}
+			if len(list) != 1 {
+				t.Fatalf("generated %q, which parses as %d addresses", got, len(list))
+			}
+			if list[0].Address != "a@b.c" {
+				t.Errorf("address came back as %q from %q", list[0].Address, got)
+			}
+			if list[0].Name != tc.display {
+				t.Errorf("display name came back as %q, want %q (from %q)", list[0].Name, tc.display, got)
+			}
+		})
+	}
+}
+
+// An address with no display name stays a bare address, which is what most
+// recipients are and what the envelope uses.
+func TestFormatAddressWithoutName(t *testing.T) {
+	if got := formatAddress(Address{Email: "a@b.c"}); got != "a@b.c" {
+		t.Errorf("got %q, want the bare address", got)
+	}
+}
+
+// A list has to survive the same round trip: a comma in one recipient's name
+// would otherwise split it into two recipients, so the mail goes somewhere
+// nobody asked for.
+func TestFormatAddressListRoundTrips(t *testing.T) {
+	addrs := []Address{
+		{Name: "Kock, Arne", Email: "arne@example.com"},
+		{Email: "plain@example.com"},
+		{Name: "Anné", Email: "anne@example.com"},
+		{Name: "Support (Billing)", Email: "billing@example.com"},
+	}
+	got := formatAddressList(addrs)
+
+	list, err := mail.ParseAddressList(got)
+	if err != nil {
+		t.Fatalf("generated %q, which will not parse: %v", got, err)
+	}
+	if len(list) != len(addrs) {
+		t.Fatalf("generated %q, which parses as %d addresses, want %d", got, len(list), len(addrs))
+	}
+	for i, want := range addrs {
+		if list[i].Address != want.Email {
+			t.Errorf("address %d came back as %q, want %q", i, list[i].Address, want.Email)
+		}
+		if list[i].Name != want.Name {
+			t.Errorf("name %d came back as %q, want %q", i, list[i].Name, want.Name)
+		}
+	}
+}
+
+// The header as it is actually written into the message, not just the helper's
+// return, since that is what the server reads.
+func TestBuiltFromHeaderIsOneAddress(t *testing.T) {
+	msg := baseMessage()
+	msg.From = Address{Name: "Kock, Arne", Email: "arne@example.com"}
+	msg.To = []Address{{Name: "Müller, Jürgen", Email: "jm@example.com"}}
+
+	raw, err := BuildRaw(msg, nil, crypto.ModeNone, crypto.Options{})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	parsed, err := mail.ReadMessage(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("read built message: %v", err)
+	}
+	for _, header := range []string{"From", "To"} {
+		list, err := parsed.Header.AddressList(header)
+		if err != nil {
+			t.Fatalf("%s header %q will not parse: %v", header, parsed.Header.Get(header), err)
+		}
+		if len(list) != 1 {
+			t.Errorf("%s header %q parses as %d addresses, want 1", header, parsed.Header.Get(header), len(list))
+		}
+	}
+}


### PR DESCRIPTION
Closes #312.

formatAddress pasted the display name straight into the header and only rfc2047-encoded it, which leaves plain ascii alone. So a name with a comma went out bare and the server read it as an address separator, which is why sending failed with "multiple addresses in From header MUST have a Sender header".

It goes through net/mail.Address.String now, which quotes when it has to and still encodes a non-ascii name. One code path, and the rule is the standard library's rather than ours.

Turned out to be wider than the comma. Running the new tests against the old code, seven of the twelve names failed to parse back: a comma, parentheses, angle brackets, quotes, a colon or semicolon, an at sign in the name, a backslash. Parentheses were the quiet one, since they are a comment in rfc 5322, so "Support (Billing)" arrived as "Support" with no error anywhere.

To and Cc had the same fault through formatAddressList, so a comma in a recipient's name would have split it into two recipients and sent the mail somewhere nobody asked for. Same fix covers them.

The tests round-trip what we generate back through net/mail rather than comparing against a hand-written string, which is what caught this in the first place. There is one on the built message too, since the header as written is what the server actually reads.

Left alone: internal/imap/util.go and bind_pdf.go build a similar-looking string, but those are display, not wire headers.
