### PR TITLE
perf: index the message list and let sync yield to sending

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -30,7 +30,7 @@
   import { loadSignatures } from './stores/signatures'
   import { loadVIPSenders } from './stores/vip'
   import { loadVirusTotalConfig } from './stores/virustotal'
-  import { loadOutbox, syncing, lastSynced, syncFolder } from './stores/outbox'
+  import { loadOutbox, syncing, lastSynced, syncFolder, syncServer } from './stores/outbox'
   import { selection, applyStartupSelection, searchQuery } from './stores/selection'
   import { loadList, messageList } from './stores/messages'
   import { initProgress } from './stores/progress'
@@ -336,6 +336,7 @@
         if (!e.running) {
           lastSynced.set(Date.now())
           syncFolder.set('')
+          syncServer.set('')
           // a password the server refuses is only discovered by trying, so the
           // markers can only be right after a sync has run.
           void refreshMissingPasswords()
@@ -346,7 +347,9 @@
       onSyncProgress((e) => {
         // the trailing done==total event carries no folder; treat it as a clear
         // so the verbose line does not linger on the last mailbox.
-        syncFolder.set(e.done < e.total ? e.folder : '')
+        const running = e.done < e.total
+        syncFolder.set(running ? e.folder : '')
+        syncServer.set(running ? e.server : '')
       }),
     )
     unsubscribers.push(onOutboxChanged(() => void loadOutbox()))

--- a/frontend/src/components/common/StatusBar.svelte
+++ b/frontend/src/components/common/StatusBar.svelte
@@ -5,7 +5,7 @@
   // honest, always-visible window into background activity.
   import { onDestroy, onMount } from 'svelte'
   import { IconSend, IconAlertTriangle, IconRefresh, IconCheck, IconDownload, IconBatteryEco, IconX, IconBug, IconWifiOff } from '@tabler/icons-svelte'
-  import { outbox, syncing, lastSynced, syncFolder } from '../../stores/outbox'
+  import { outbox, syncing, lastSynced, syncFolder, syncServer } from '../../stores/outbox'
   import { online } from '../../stores/network'
   import { downloadProgress, attachmentProgress } from '../../stores/progress'
   import { formatRelative } from '../../lib/format'
@@ -174,7 +174,9 @@
       <span class="sync syncing">
         <IconRefresh size={13} stroke={1.7} class="spin" />
         {#if $prefs.verboseSync && $syncFolder}
-          {$t('common.statusBar.syncingMailbox').replace('{mailbox}', $syncFolder)}
+          {$syncServer
+            ? $t('common.statusBar.syncingMailboxOn').replace('{mailbox}', $syncFolder).replace('{server}', $syncServer)
+            : $t('common.statusBar.syncingMailbox').replace('{mailbox}', $syncFolder)}
         {:else}
           {$t('common.statusBar.syncing')}
         {/if}

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -39,6 +39,9 @@ export interface MailRepairedEvent {
 
 export interface SyncProgressEvent {
   accountId: number
+  // the imap host and port the folder is coming from, so a line says which
+  // account it belongs to when several are syncing.
+  server: string
   folder: string
   done: number
   total: number

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -304,6 +304,7 @@ const de: Record<string, string> = {
   'common.statusBar.syncing': 'Synchronisiert…',
   'common.statusBar.syncingMailbox': 'Synchronisiere {mailbox}…',
   'common.statusBar.synced': 'Synchronisiert',
+  'common.statusBar.syncingMailboxOn': '{mailbox} wird von {server} abgeglichen…',
   'common.techBadges.encrypted': 'Verschlüsselt',
   'common.techBadges.signed': 'Signiert',
   'common.techBadges.smime.valid': 'Signatur geprüft',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -304,6 +304,7 @@ const en: Record<string, string> = {
   'common.statusBar.syncing': 'Syncing…',
   'common.statusBar.syncingMailbox': 'Syncing {mailbox}…',
   'common.statusBar.synced': 'Synced',
+  'common.statusBar.syncingMailboxOn': 'Syncing {mailbox} on {server}…',
   'common.techBadges.encrypted': 'Encrypted',
   'common.techBadges.signed': 'Signed',
   'common.techBadges.smime.valid': 'Signature verified',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -304,6 +304,7 @@ const es: Record<string, string> = {
   'common.statusBar.syncing': 'Sincronizando…',
   'common.statusBar.syncingMailbox': 'Sincronizando {mailbox}…',
   'common.statusBar.synced': 'Sincronizado',
+  'common.statusBar.syncingMailboxOn': 'Sincronizando {mailbox} desde {server}…',
   'common.techBadges.encrypted': 'Cifrado',
   'common.techBadges.signed': 'Firmado',
   'common.techBadges.smime.valid': 'Firma verificada',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -304,6 +304,7 @@ const fr: Record<string, string> = {
   'common.statusBar.syncing': 'Synchronisation…',
   'common.statusBar.syncingMailbox': 'Synchronisation de {mailbox}…',
   'common.statusBar.synced': 'Synchronisé',
+  'common.statusBar.syncingMailboxOn': 'Synchronisation de {mailbox} depuis {server}…',
   'common.techBadges.encrypted': 'Chiffré',
   'common.techBadges.signed': 'Signé',
   'common.techBadges.smime.valid': 'Signature vérifiée',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -304,6 +304,7 @@ const nl: Record<string, string> = {
   'common.statusBar.syncing': 'Synchroniseren…',
   'common.statusBar.syncingMailbox': '{mailbox} synchroniseren…',
   'common.statusBar.synced': 'Gesynchroniseerd',
+  'common.statusBar.syncingMailboxOn': '{mailbox} synchroniseren vanaf {server}…',
   'common.techBadges.encrypted': 'Versleuteld',
   'common.techBadges.signed': 'Ondertekend',
   'common.techBadges.smime.valid': 'Handtekening geverifieerd',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -304,6 +304,7 @@ const pl: Record<string, string> = {
   'common.statusBar.syncing': 'Synchronizacja…',
   'common.statusBar.syncingMailbox': 'Synchronizacja {mailbox}…',
   'common.statusBar.synced': 'Zsynchronizowano',
+  'common.statusBar.syncingMailboxOn': 'Synchronizowanie {mailbox} z {server}…',
   'common.techBadges.encrypted': 'Zaszyfrowane',
   'common.techBadges.signed': 'Podpisane',
   'common.techBadges.smime.valid': 'Podpis zweryfikowany',

--- a/frontend/src/stores/outbox.ts
+++ b/frontend/src/stores/outbox.ts
@@ -21,6 +21,11 @@ export const lastSynced = writable<number | null>(null)
 // fed by sync:progress events and cleared when a sync ends.
 export const syncFolder = writable<string>('')
 
+// syncServer holds the imap host and port that mailbox is coming from, shown
+// beside it in the verbose status line so two accounts syncing at once are
+// telling apart. Empty when idle or between folders.
+export const syncServer = writable<string>('')
+
 // loadOutbox refetches the queue. it swallows errors into an empty list since the
 // outbox view is secondary; a transient failure should not break the app. when
 // the refetch reveals freshly-sent messages it shows a brief confirmation and

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/smallstep/pkcs7 v0.2.3
-	github.com/wailsapp/wails/v2 v2.13.0
+	github.com/wailsapp/wails/v2 v2.14.0
 	github.com/yuin/goldmark v1.8.5
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6N
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.13.0 h1:S7OgXWpj72V91unF8iDWJKbcS9ZpwCT3R0QVru4v2Mg=
-github.com/wailsapp/wails/v2 v2.13.0/go.mod h1:nVr/wSIEZ7xxKPkzK65mjpKpaOPQI2k4pvLwGR/i4kc=
+github.com/wailsapp/wails/v2 v2.14.0 h1:+GlF6BM8Mg7Saa1lxUAzfZ6jsEMg2zQhQvUHtqB7xpc=
+github.com/wailsapp/wails/v2 v2.14.0/go.mod h1:scxrgwfsv6yR6fE6cCF+Flfl+JeU+SR87T9x4kILJ6M=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -50,6 +50,10 @@ type App struct {
 	// though a nil check keeps it from crashing.
 	storeReady chan struct{}
 	index      *search.Index
+	// streamTick rate-limits the "mail arrived" events a running sync emits, so
+	// a fast first sync fills the list without asking the ui to redraw it
+	// hundreds of times a minute.
+	streamTick streamGate
 	// searchMu serializes index backfills so a startup pass and a post-sync pass
 	// do not advance the watermark concurrently.
 	searchMu sync.Mutex

--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -231,7 +231,8 @@ func (a *App) syncFolders(client *pimap.Client, accountID int64) error {
 	newTotal := 0
 	for i, f := range folders {
 		a.emit(EventSyncProgress, SyncProgressEvent{
-			AccountID: accountID, Folder: f.Name, Done: i, Total: len(folders),
+			AccountID: accountID, Folder: f.Name, Server: client.Addr(),
+			Done: i, Total: len(folders),
 		})
 		res, err := engine.SyncFolder(a.ctx, f)
 		if err != nil {
@@ -395,11 +396,65 @@ func (a *App) newSyncEngine(client *pimap.Client, accountID int64) *psync.Engine
 	engine := psync.NewEngine(client, a.store, a.log)
 	engine.ColorSync = a.boolSetting(settingFlagColorSync, false)
 	engine.InitialLimit = a.syncMessageLimit()
+	// a message the user pressed send on goes out during a sync, not after it.
+	engine.YieldTo = a.outboxPending
+	// and the list fills as mail arrives rather than staying empty until the
+	// whole folder is down.
+	engine.OnStored = a.announceStored
 	if trash, ok := a.findTrashFolder(accountID); ok {
 		engine.TrashPath = trash.IMAPPath
 		engine.TrashFolderID = trash.ID
 	}
 	return engine
+}
+
+// streamInterval is the shortest gap between two "mail arrived" events during a
+// sync. Each one costs the ui a list reload, and a fast server can store a
+// batch every few milliseconds; twice a second looks live without the list
+// spending the sync redrawing itself.
+const streamInterval = 500 * time.Millisecond
+
+// streamGate rate-limits those events. It is a value on App rather than a
+// package variable so two accounts syncing at once do not silence each other
+// unfairly, and it is safe for the concurrent syncs that produce them.
+type streamGate struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+func (g *streamGate) ready() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := time.Now()
+	if now.Sub(g.last) < streamInterval {
+		return false
+	}
+	g.last = now
+	return true
+}
+
+// outboxPending reports whether anything is waiting to be sent. Sync asks it
+// between messages and stands aside while it is true.
+func (a *App) outboxPending() bool {
+	if a.queue == nil {
+		return false
+	}
+	return a.queue.Pending(a.ctx)
+}
+
+// announceStored tells the ui about mail stored so far in a folder that is
+// still syncing. The list reloads on it, which is cheap now that the read is
+// indexed, so a first sync looks like mail arriving instead of a frozen window.
+// Notifications are not sent from here: those still go out once per folder, so
+// a first sync of fourteen thousand messages does not become fourteen thousand
+// notifications.
+func (a *App) announceStored(folder storage.Folder, ids []int64) {
+	if !a.streamTick.ready() {
+		return
+	}
+	a.emit(EventMailNew, MailNewEvent{
+		AccountID: folder.AccountID, FolderID: folder.ID, Count: len(ids),
+	})
 }
 
 // findTrashFolder returns the account's trash-role folder. Without one, a

--- a/internal/desktop/events.go
+++ b/internal/desktop/events.go
@@ -121,10 +121,13 @@ type MailRepairedEvent struct {
 
 // SyncProgressEvent is the payload for EventSyncProgress.
 type SyncProgressEvent struct {
-	AccountID int64  `json:"accountId"`
-	Folder    string `json:"folder"`
-	Done      int    `json:"done"`
-	Total     int    `json:"total"`
+	AccountID int64 `json:"accountId"`
+	// Server is the imap host and port the folder is being synced from, so a
+	// line says which account it belongs to when several sync at once (#310).
+	Server string `json:"server"`
+	Folder string `json:"folder"`
+	Done   int    `json:"done"`
+	Total  int    `json:"total"`
 }
 
 // SyncStateEvent is the payload for EventSyncState. Error is empty on success.

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -96,6 +96,17 @@ type Client struct {
 	updates chan MailboxUpdate
 }
 
+// Addr is the server this client is connected to, as host:port. Sync puts it in
+// its log lines so a line in the debug overlay says which account it belongs to
+// when several are syncing at once.
+func (c *Client) Addr() string {
+	port := c.cfg.Port
+	if port == 0 {
+		port = DefaultPort
+	}
+	return net.JoinHostPort(c.cfg.Host, strconv.Itoa(port))
+}
+
 // Connect opens a TLS connection but does not authenticate; call Login next.
 func Connect(cfg Config) (*Client, error) {
 	if cfg.Host == "" {

--- a/internal/imap/fetch.go
+++ b/internal/imap/fetch.go
@@ -123,16 +123,76 @@ func (c *Client) FetchRecentHeaders(limit int) ([]MessageHeader, error) {
 	return headers, nil
 }
 
-// FetchMessage fetches and parses a full message by UID.
-func (c *Client) FetchMessage(uid imap.UID) (*Message, error) {
-	// PEEK so reading the body does not set \Seen
+// bodyFetchOptions asks for everything a stored message needs: the envelope for
+// the list columns, the flags, and the source with PEEK so reading it does not
+// set \Seen. The section value is also how the body is found in the response,
+// so it is built once and shared.
+func bodyFetchOptions() (*imap.FetchItemBodySection, *imap.FetchOptions) {
 	section := &imap.FetchItemBodySection{Peek: true}
-	options := &imap.FetchOptions{
+	return section, &imap.FetchOptions{
 		Envelope:    true,
 		Flags:       true,
 		UID:         true,
 		BodySection: []*imap.FetchItemBodySection{section},
 	}
+}
+
+// FetchMessages fetches a set of messages in one command and hands each to fn as
+// it arrives.
+//
+// One command rather than one per message is the difference between a first
+// sync being bound by bandwidth and being bound by round trips: 14k messages
+// fetched one at a time is 14k times the latency to the server before a single
+// byte of anything else moves (#310). Messages are handled as they stream in, so
+// only one is held at a time and rows appear while the rest are still coming.
+//
+// fn is called once per message the server returns, in the order it returns
+// them, with the parse error instead of a message when the source could not be
+// walked. The caller decides what a bad message costs: returning an error from
+// fn abandons the rest of the batch, returning nil carries on. The connection
+// is left clean either way.
+func (c *Client) FetchMessages(uids []imap.UID, fn func(uid imap.UID, msg *Message, err error) error) error {
+	if len(uids) == 0 {
+		return nil
+	}
+	section, options := bodyFetchOptions()
+	cmd := c.raw.Fetch(imap.UIDSetNum(uids...), options)
+	defer cmd.Close()
+
+	for {
+		data := cmd.Next()
+		if data == nil {
+			break
+		}
+		buf, err := data.Collect()
+		if err != nil {
+			return fmt.Errorf("imap: fetch batch of %d: %w", len(uids), err)
+		}
+		raw := buf.FindBodySection(section)
+		if raw == nil {
+			// the server listed the message but gave no body for it. Skipping it
+			// leaves it uncached and the next sync asks again, which is better
+			// than storing an empty message.
+			continue
+		}
+		msg := messageFromBuffer(buf, section, raw)
+		parseErr := parseBody(raw, msg)
+		if parseErr != nil {
+			msg = nil
+		}
+		if err := fn(buf.UID, msg, parseErr); err != nil {
+			return err
+		}
+	}
+	if err := cmd.Close(); err != nil {
+		return fmt.Errorf("imap: fetch batch of %d: %w", len(uids), err)
+	}
+	return nil
+}
+
+// FetchMessage fetches and parses a full message by UID.
+func (c *Client) FetchMessage(uid imap.UID) (*Message, error) {
+	section, options := bodyFetchOptions()
 
 	buffers, err := c.raw.Fetch(imap.UIDSetNum(uid), options).Collect()
 	if err != nil {
@@ -147,7 +207,17 @@ func (c *Client) FetchMessage(uid imap.UID) (*Message, error) {
 	if raw == nil {
 		return nil, fmt.Errorf("imap: message uid %d returned no body", uid)
 	}
+	msg := messageFromBuffer(buf, section, raw)
+	if err := parseBody(raw, msg); err != nil {
+		return nil, fmt.Errorf("imap: parse message uid %d: %w", uid, err)
+	}
+	return msg, nil
+}
 
+// messageFromBuffer turns one fetch response into a Message, envelope fields and
+// all. The body walk is the caller's, since the single fetch reports a parse
+// failure as its own error and the batch one keeps going.
+func messageFromBuffer(buf *imapclient.FetchMessageBuffer, section *imap.FetchItemBodySection, raw []byte) *Message {
 	msg := &Message{UID: buf.UID, Flags: buf.Flags, Size: int64(len(raw)), Raw: raw}
 	if buf.Envelope != nil {
 		msg.MessageID = buf.Envelope.MessageID
@@ -157,11 +227,7 @@ func (c *Client) FetchMessage(uid imap.UID) (*Message, error) {
 		msg.Cc = formatAddresses(buf.Envelope.Cc)
 		msg.Date = buf.Envelope.Date
 	}
-
-	if err := parseBody(raw, msg); err != nil {
-		return nil, fmt.Errorf("imap: parse message uid %d: %w", uid, err)
-	}
-	return msg, nil
+	return msg
 }
 
 // FetchRawMessage returns a message's RFC 822 source by UID, exactly as the

--- a/internal/outbox/outbox.go
+++ b/internal/outbox/outbox.go
@@ -198,3 +198,16 @@ func toMessage(r storage.OutboxRow) Message {
 		CreatedAt:     r.CreatedAt,
 	}
 }
+
+// Pending reports whether anything is waiting to be sent or is mid-send. Sync
+// asks before each message it downloads, so a send never waits behind a large
+// mailbox.
+func (q *Queue) Pending(ctx context.Context) bool {
+	n, err := q.db.CountOutboxInStates(ctx, StateQueued, StateSending)
+	if err != nil {
+		// unreadable is not a reason to stall a sync; the send worker has its
+		// own view of the queue and will report the failure.
+		return false
+	}
+	return n > 0
+}

--- a/internal/storage/migrations/0030_message_list_indexes.sql
+++ b/internal/storage/migrations/0030_message_list_indexes.sql
@@ -1,0 +1,25 @@
+-- Indexes for the message list (#310).
+--
+-- The list reads one folder, or a handful for a unified view, newest first.
+-- Until now the only index on messages was folder_id alone, so every list load
+-- found the folder's rows and then sorted all of them in a temporary b-tree to
+-- pick the newest fifty, reading each row's bodies to do it. At 14k messages
+-- that is 165ms for the first page and 664ms for the fourth, on every load,
+-- which is what made the window feel frozen during a first sync and slow
+-- afterwards. With the ordering in the index the same reads are under a
+-- millisecond.
+
+-- the list index. date and uid descending match the ORDER BY exactly, so the
+-- rows come out of the index already in order and LIMIT stops early.
+CREATE INDEX idx_messages_list ON messages(folder_id, date DESC, uid DESC);
+
+-- unread badges and folder counts ask about flags rather than dates, and
+-- answering them from the row store meant touching every row in the folder.
+-- These four columns are everything those queries read, so the answer comes out
+-- of the index.
+CREATE INDEX idx_messages_state ON messages(folder_id, flags, pending_delete, snooze_hidden);
+
+-- redundant now: folder_id is the leading column of both indexes above, so
+-- anything that used this can use those instead, and one less index is one less
+-- write per stored message.
+DROP INDEX IF EXISTS idx_messages_folder;

--- a/internal/storage/outbox.go
+++ b/internal/storage/outbox.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -214,4 +215,26 @@ func scanOutbox(row rowScanner) (*OutboxRow, error) {
 	r.NextAttemptAt = nextAt
 	r.CreatedAt = createdAt
 	return &r, nil
+}
+
+// CountOutboxInStates returns how many rows are in any of the given states.
+// Background sync uses it to stand aside while something is waiting to be sent:
+// a message the user pressed send on should not queue behind a mailbox that is
+// downloading fourteen thousand messages (#310).
+func (d *DB) CountOutboxInStates(ctx context.Context, states ...string) (int, error) {
+	if len(states) == 0 {
+		return 0, nil
+	}
+	marks := make([]string, len(states))
+	args := make([]any, len(states))
+	for i, state := range states {
+		marks[i] = "?"
+		args[i] = state
+	}
+	var n int
+	query := `SELECT COUNT(*) FROM outbox WHERE state IN (` + strings.Join(marks, ", ") + `)`
+	if err := d.sql.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("storage: count outbox rows: %w", err)
+	}
+	return n, nil
 }

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -27,14 +27,7 @@ func (d *DB) QueryMessages(ctx context.Context, q MessageQuery) ([]Message, erro
 		return nil, nil
 	}
 
-	where, args := messageWhere(q)
-	query := selectMessageColumns + `
-FROM messages
-WHERE ` + where + `
-ORDER BY date DESC, uid DESC
-LIMIT ? OFFSET ?`
-	args = append(args, normalizeLimit(q.Limit), q.Offset)
-
+	query, args := pageQuery(q)
 	rows, err := d.sql.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("storage: query messages: %w", err)
@@ -53,6 +46,56 @@ LIMIT ? OFFSET ?`
 		return nil, fmt.Errorf("storage: iterate messages: %w", err)
 	}
 	return messages, nil
+}
+
+// pageQuery builds the read for one page of the list.
+//
+// One folder is a straight ordered read: the list index carries folder, date and
+// uid in the order the page wants them, so sqlite walks it and stops at the
+// limit.
+//
+// Several folders cannot work that way. An index is sorted per folder, so an
+// `IN (...)` over five of them has no single ordered path through and sqlite
+// falls back to collecting every matching row and sorting the lot, which at 14k
+// messages is the slowest screen in the app. Instead each folder is asked for
+// its own newest rows through the index and the small results are merged. Only
+// the first offset+limit of any one folder can appear in the page, so that is
+// all each subquery has to return: five reads of a few hundred rows rather than
+// one sort of everything.
+func pageQuery(q MessageQuery) (string, []any) {
+	limit := normalizeLimit(q.Limit)
+	if len(q.FolderIDs) == 1 {
+		where, args := messageWhere(q)
+		query := selectMessageColumns + `
+FROM messages
+WHERE ` + where + `
+ORDER BY date DESC, uid DESC
+LIMIT ? OFFSET ?`
+		return query, append(args, limit, q.Offset)
+	}
+
+	// how deep into one folder the page could possibly reach. A no-cap limit
+	// leaves the subqueries uncapped too, which is the export path rather than
+	// the list.
+	perFolder := limit
+	if perFolder > 0 {
+		perFolder += q.Offset
+	}
+
+	parts := make([]string, 0, len(q.FolderIDs))
+	args := make([]any, 0, len(q.FolderIDs)*3+2)
+	for _, id := range q.FolderIDs {
+		where, folderArgs := messageWhere(MessageQuery{FolderIDs: []int64{id}, RequireFlags: q.RequireFlags})
+		parts = append(parts, `SELECT * FROM (`+selectMessageColumns+`
+FROM messages WHERE `+where+`
+ORDER BY date DESC, uid DESC LIMIT ?)`)
+		args = append(args, folderArgs...)
+		args = append(args, perFolder)
+	}
+	query := strings.Join(parts, "\nUNION ALL\n") + `
+ORDER BY date DESC, uid DESC
+LIMIT ? OFFSET ?`
+	return query, append(args, limit, q.Offset)
 }
 
 // CountMessages returns how many messages match q ignoring its limit and offset,

--- a/internal/storage/query_test.go
+++ b/internal/storage/query_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestUnifiedPageMatchesNaive(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	acc, _ := db.EnsureLocalAccount(ctx)
+	var ids []int64
+	base := time.Now().Add(-100 * time.Hour)
+	uid := uint32(0)
+	for _, name := range []string{"INBOX", "Sent", "Archive"} {
+		f, _ := db.EnsureLocalFolder(ctx, acc.ID, name)
+		ids = append(ids, f.ID)
+		for i := 0; i < 40; i++ {
+			uid++
+			m := &Message{AccountID: acc.ID, FolderID: f.ID, UID: uid,
+				MessageID: fmt.Sprintf("<%d@x>", uid), Subject: fmt.Sprintf("s%d", uid),
+				Date: base.Add(time.Duration(uid) * time.Minute)}
+			if uid%4 == 0 {
+				m.Flags = FlagFlagged
+			}
+			if _, err := db.InsertMessage(ctx, m); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	for _, q := range []MessageQuery{
+		{FolderIDs: ids, Limit: 50},
+		{FolderIDs: ids, Limit: 50, Offset: 50},
+		{FolderIDs: ids, Limit: 10, Offset: 95},
+		{FolderIDs: ids, Limit: 0},
+		{FolderIDs: ids, Limit: 20, RequireFlags: FlagFlagged},
+		{FolderIDs: ids[:1], Limit: 20, Offset: 10},
+	} {
+		got, err := db.QueryMessages(ctx, q)
+		if err != nil {
+			t.Fatalf("%v: %v", q, err)
+		}
+		where, args := messageWhere(q)
+		rows, err := db.sql.QueryContext(ctx, selectMessageColumns+`
+FROM messages WHERE `+where+` ORDER BY date DESC, uid DESC LIMIT ? OFFSET ?`,
+			append(args, normalizeLimit(q.Limit), q.Offset)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var want []Message
+		for rows.Next() {
+			m, err := scanMessage(rows)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want = append(want, *m)
+		}
+		rows.Close()
+		if len(got) != len(want) {
+			t.Fatalf("%+v: got %d rows, want %d", q, len(got), len(want))
+		}
+		for i := range got {
+			if got[i].ID != want[i].ID {
+				t.Fatalf("%+v: row %d = id %d, want id %d", q, i, got[i].ID, want[i].ID)
+			}
+		}
+	}
+}

--- a/internal/sync/priority_test.go
+++ b/internal/sync/priority_test.go
@@ -1,0 +1,117 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+// the reported problem: a message the user pressed send on waited behind a
+// 14k-message sync. The sync now asks before every body fetch and stands aside
+// while something is queued.
+func TestSyncStandsAsideWhileSendingIsQueued(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2, 3, 4}}
+	engine := NewEngine(client, db, nil)
+
+	// queued until the sync has stood aside once, which is what the send worker
+	// getting its turn looks like from here.
+	var asked atomic.Int32
+	engine.YieldTo = func() bool {
+		return asked.Add(1) <= 2
+	}
+
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if asked.Load() == 0 {
+		t.Fatal("sync never asked whether it should stand aside")
+	}
+	if len(client.fetched) != 4 {
+		t.Errorf("fetched %v, want all four once the queue drained", client.fetched)
+	}
+}
+
+// a cancelled sync must not sit in the yield loop waiting for a queue that
+// nothing is draining.
+func TestYieldStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2, 3}}
+	engine := NewEngine(client, db, nil)
+	engine.YieldTo = func() bool {
+		cancel()
+		return true
+	}
+
+	// a cancelled sync reports the cancellation from whichever write it reached
+	// first; what matters here is that it came back at all rather than waiting
+	// on a queue nothing is draining.
+	if _, err := engine.SyncFolder(ctx, folder); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("sync: %v", err)
+	}
+	if len(client.fetched) > 1 {
+		t.Errorf("fetched %v after cancellation, want at most the one in flight", client.fetched)
+	}
+}
+
+// the first sync of a large folder used to show nothing until the whole folder
+// was down. Stored ids are handed over as they arrive.
+func TestSyncAnnouncesMessagesAsTheyArrive(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	uids := make([]uint32, 60)
+	for i := range uids {
+		uids[i] = uint32(i + 1)
+	}
+	client := &fakeClient{uids: uids}
+	engine := NewEngine(client, db, nil)
+
+	var batches [][]int64
+	engine.OnStored = func(f storage.Folder, ids []int64) {
+		if f.ID != folder.ID {
+			t.Errorf("announced folder %d, want %d", f.ID, folder.ID)
+		}
+		batches = append(batches, ids)
+	}
+
+	res, err := engine.SyncFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if len(batches) < 2 {
+		t.Fatalf("announced %d times for %d messages, want the list to fill as it goes", len(batches), res.New)
+	}
+	var announced int
+	for _, b := range batches {
+		announced += len(b)
+	}
+	if announced != res.New {
+		t.Errorf("announced %d ids, stored %d", announced, res.New)
+	}
+}
+
+// a folder with nothing new announces nothing, so an idle sync does not make
+// the list reload for no reason.
+func TestSyncAnnouncesNothingWhenNothingIsNew(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	client := &fakeClient{uids: []uint32{1, 2}}
+	engine := NewEngine(client, db, nil)
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	called := 0
+	engine.OnStored = func(storage.Folder, []int64) { called++ }
+	if _, err := engine.SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if called != 0 {
+		t.Errorf("announced %d times with nothing new", called)
+	}
+}

--- a/internal/sync/priority_test.go
+++ b/internal/sync/priority_test.go
@@ -115,3 +115,50 @@ func TestSyncAnnouncesNothingWhenNothingIsNew(t *testing.T) {
 		t.Errorf("announced %d times with nothing new", called)
 	}
 }
+
+// a first sync used to cost one fetch command per message, so a large mailbox
+// paid the round trip to the server thousands of times before anything else
+// could happen on the connection.
+func TestSyncFetchesBodiesInBatches(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	uids := make([]uint32, 120)
+	for i := range uids {
+		uids[i] = uint32(i + 1)
+	}
+	client := &fakeClient{uids: uids}
+	engine := NewEngine(client, db, nil)
+
+	res, err := engine.SyncFolder(ctx, folder)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if res.New != len(uids) {
+		t.Fatalf("stored %d messages, want %d", res.New, len(uids))
+	}
+	want := (len(uids) + fetchBatch - 1) / fetchBatch
+	if client.commands != want {
+		t.Errorf("issued %d fetch commands for %d messages, want %d", client.commands, len(uids), want)
+	}
+	if len(client.fetched) != len(uids) {
+		t.Errorf("fetched %d messages, want %d", len(client.fetched), len(uids))
+	}
+}
+
+// newest first still holds: the newest uid has to be in the first batch, or a
+// large mailbox shows years-old mail for as long as it takes to reach today.
+func TestSyncFetchesNewestBatchFirst(t *testing.T) {
+	ctx := context.Background()
+	db, folder := newSyncTestFolder(t)
+	uids := make([]uint32, 120)
+	for i := range uids {
+		uids[i] = uint32(i + 1)
+	}
+	client := &fakeClient{uids: uids}
+	if _, err := NewEngine(client, db, nil).SyncFolder(ctx, folder); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if client.fetched[0] != 120 {
+		t.Errorf("first message fetched was uid %d, want the newest (120)", client.fetched[0])
+	}
+}

--- a/internal/sync/pull.go
+++ b/internal/sync/pull.go
@@ -55,7 +55,47 @@ func (e *Engine) fetchAndStore(ctx context.Context, folder storage.Folder, uid u
 	if err != nil {
 		return 0, fmt.Errorf("sync: fetch message uid %d: %w", uid, err)
 	}
+	return e.storeMessage(ctx, folder, msg)
+}
 
+// fetchBatch pulls a run of messages in one command and stores each as it
+// arrives, returning the ids it stored. A message that cannot be fetched or
+// parsed is logged and skipped: the rest of the batch is already on its way
+// down the connection and the next sync asks for the skipped one again.
+func (e *Engine) fetchBatch(ctx context.Context, folder storage.Folder, uids []uint32) ([]int64, error) {
+	ids := make([]int64, 0, len(uids))
+	set := make([]imap.UID, 0, len(uids))
+	for _, uid := range uids {
+		set = append(set, imap.UID(uid))
+	}
+
+	err := e.client.FetchMessages(set, func(uid imap.UID, msg *pimap.Message, parseErr error) error {
+		if parseErr != nil {
+			e.log.Error("parse fetched message failed", "uid", uint32(uid), "err", parseErr)
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		id, err := e.storeMessage(ctx, folder, msg)
+		if err != nil {
+			e.log.Error("store fetched message failed", "uid", uint32(uid), "err", err)
+			return nil
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	if err != nil {
+		// whatever was stored before the failure stays stored; the ids go back so
+		// the caller can count and announce them.
+		return ids, fmt.Errorf("sync: fetch batch in %q: %w", folder.IMAPPath, err)
+	}
+	return ids, nil
+}
+
+// storeMessage writes one fetched message and its attachments to the cache.
+func (e *Engine) storeMessage(ctx context.Context, folder storage.Folder, msg *pimap.Message) (int64, error) {
+	uid := uint32(msg.UID)
 	stored := &storage.Message{
 		AccountID: folder.AccountID,
 		FolderID:  folder.ID,

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -22,6 +22,10 @@ type mailClient interface {
 	// lines the debug overlay shows.
 	Addr() string
 	FetchMessage(uid imap.UID) (*pimap.Message, error)
+	// FetchMessages pulls a set of messages in one command, handing each to fn
+	// as it arrives. A first sync is otherwise bound by the round trip to the
+	// server rather than by bandwidth.
+	FetchMessages(uids []imap.UID, fn func(uid imap.UID, msg *pimap.Message, err error) error) error
 	AddFlags(uid imap.UID, flags ...imap.Flag) error
 	DeleteMessages(uids ...imap.UID) error
 	MoveMessages(uids []imap.UID, mailbox string) error
@@ -62,10 +66,11 @@ type Engine struct {
 	OnStored func(folder storage.Folder, ids []int64)
 }
 
-// yieldBatch is how many messages are stored between OnStored calls. Small
-// enough that the list visibly fills, large enough that a 14k mailbox is not
-// 14k refreshes.
-const yieldBatch = 25
+// fetchBatch is how many message bodies one command asks for. Big enough that
+// the round trip stops being what a large sync is made of, small enough that a
+// send waiting to go out is never more than a batch away from its turn, and
+// that a failure costs one batch rather than a folder.
+const fetchBatch = 50
 
 // yieldPoll is how long the sync waits before asking again whether it may
 // continue. It is a pause between messages, so the send it is standing aside
@@ -211,6 +216,41 @@ func (e *Engine) syncFolder(ctx context.Context, folder storage.Folder, backfill
 	return res, nil
 }
 
+// fetchNew downloads the bodies of the given uids, newest first, in batches.
+//
+// One command per batch rather than one per message: the bytes are the same
+// either way, but 14k separate fetches means paying the round trip to the
+// server 14k times before anything else can happen on the connection (#310).
+// Between batches the sync stands aside for anything the user asked for and
+// tells the ui what has arrived, so a long download stays interruptible and
+// visible rather than being one opaque stretch.
+func (e *Engine) fetchNew(ctx context.Context, folder storage.Folder, uids []uint32, res *FolderSyncResult) {
+	for start := 0; start < len(uids); start += fetchBatch {
+		if err := ctx.Err(); err != nil {
+			e.log.Warn("sync cancelled mid-folder", "folder", folder.IMAPPath)
+			return
+		}
+		// anything the user asked for goes first. A body fetch is the expensive
+		// step in a sync, so between batches is the point to stand aside at.
+		e.yield(ctx)
+
+		end := min(start+fetchBatch, len(uids))
+		ids, err := e.fetchBatch(ctx, folder, uids[start:end])
+		if err != nil {
+			e.log.Error("fetch batch failed", "folder", folder.IMAPPath, "err", err)
+		}
+		res.New += len(ids)
+		res.NewIDs = append(res.NewIDs, ids...)
+		e.announce(folder, ids)
+		if err != nil {
+			// the connection is in an unknown state after a failed fetch, so the
+			// rest of this folder waits for the next sync rather than piling more
+			// commands onto it.
+			return
+		}
+	}
+}
+
 // yield waits while the caller's YieldTo says something more important is
 // happening. A cancelled context ends the wait, since the sync is stopping
 // anyway.
@@ -326,10 +366,9 @@ func (e *Engine) adoptColors(ctx context.Context, folder storage.Folder, serverC
 // or block the rest of the folder.
 func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []Decision, localByUID map[uint32]storage.MessageState, res *FolderSyncResult) {
 	var pendingDeletes []storage.MessageState
-	// ids stored since the last time the ui was told, so a long fetch run shows
-	// mail arriving rather than nothing at all.
-	var streamed []int64
-	defer func() { e.announce(folder, streamed) }()
+	// uids whose bodies have to come down, gathered here and fetched in batches
+	// once the cheap decisions are out of the way.
+	var toFetch []uint32
 
 	// walked back to front, because BuildPlan orders by ascending uid and a full
 	// body fetch is the expensive step here. Front to back means the oldest mail
@@ -352,21 +391,9 @@ func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []
 			// already in agreement
 
 		case ActionFetchNew:
-			// anything the user asked for goes first. A body fetch is the
-			// expensive step in a sync, so this is the point to stand aside at.
-			e.yield(ctx)
-			id, err := e.fetchAndStore(ctx, folder, d.UID)
-			if err != nil {
-				e.log.Error("fetch new message failed", "uid", d.UID, "err", err)
-				continue
-			}
-			res.New++
-			res.NewIDs = append(res.NewIDs, id)
-			streamed = append(streamed, id)
-			if len(streamed) >= yieldBatch {
-				e.announce(folder, streamed)
-				streamed = streamed[:0]
-			}
+			// collected and fetched below, in one command per batch rather than
+			// one per message.
+			toFetch = append(toFetch, d.UID)
 
 		case ActionDeleteLocal:
 			if err := e.deleteLocal(ctx, folder, localByUID[d.UID]); err != nil {
@@ -399,6 +426,8 @@ func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []
 			pendingDeletes = append(pendingDeletes, localByUID[d.UID])
 		}
 	}
+
+	e.fetchNew(ctx, folder, toFetch, res)
 
 	if len(pendingDeletes) > 0 {
 		if err := e.pushDeletes(ctx, folder, pendingDeletes); err != nil {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/emersion/go-imap/v2"
 
@@ -17,6 +18,9 @@ import (
 type mailClient interface {
 	Select(mailbox string) (*pimap.Mailbox, error)
 	FetchAllFlags() ([]pimap.MessageHeader, error)
+	// Addr is the server the client is talking to, host and port, for the log
+	// lines the debug overlay shows.
+	Addr() string
 	FetchMessage(uid imap.UID) (*pimap.Message, error)
 	AddFlags(uid imap.UID, flags ...imap.Flag) error
 	DeleteMessages(uids ...imap.UID) error
@@ -46,7 +50,27 @@ type Engine struct {
 	// applies to a folder's first sync: once a folder is cached, lowering this
 	// never discards anything.
 	InitialLimit int
+	// YieldTo, when set, is asked before each message body is fetched and the
+	// sync waits while it says yes. The desktop points it at the outbox, so a
+	// message the user pressed send on goes out during a first sync rather than
+	// after it (#310).
+	YieldTo func() bool
+	// OnStored, when set, is called as messages are stored rather than only when
+	// the folder finishes, so a first sync fills the list as mail arrives
+	// instead of showing nothing for several minutes. It is called with the
+	// folder and the ids stored since the last call.
+	OnStored func(folder storage.Folder, ids []int64)
 }
+
+// yieldBatch is how many messages are stored between OnStored calls. Small
+// enough that the list visibly fills, large enough that a 14k mailbox is not
+// 14k refreshes.
+const yieldBatch = 25
+
+// yieldPoll is how long the sync waits before asking again whether it may
+// continue. It is a pause between messages, so the send it is standing aside
+// for has the connection and the cpu to itself.
+const yieldPoll = 250 * time.Millisecond
 
 // NewEngine wires an imap client and the store together. A nil logger is
 // replaced with a discarding default so callers need not pass one.
@@ -93,7 +117,7 @@ func (e *Engine) SyncAccount(ctx context.Context, accountID int64) error {
 			continue
 		}
 		e.log.Info("folder synced",
-			"folder", folder.IMAPPath,
+			"folder", folder.IMAPPath, "server", e.client.Addr(),
 			"new", res.New, "deleted", res.Deleted, "flag_updated", res.FlagUpdated,
 			"conflicts", res.Conflicts, "pushed", res.Pushed, "uidvalidity_reset", res.UIDValidityReset)
 	}
@@ -123,6 +147,7 @@ func (e *Engine) syncFolder(ctx context.Context, folder storage.Folder, backfill
 	if err != nil {
 		return res, fmt.Errorf("sync: select folder %q: %w", folder.IMAPPath, err)
 	}
+	e.log.Debug("folder selected", "folder", folder.IMAPPath, "server", e.client.Addr(), "messages", mbox.NumMessages)
 
 	state, err := loadFolderSyncState(ctx, e.store, folder)
 	if err != nil {
@@ -184,6 +209,36 @@ func (e *Engine) syncFolder(ctx context.Context, folder storage.Folder, backfill
 		return res, err
 	}
 	return res, nil
+}
+
+// yield waits while the caller's YieldTo says something more important is
+// happening. A cancelled context ends the wait, since the sync is stopping
+// anyway.
+func (e *Engine) yield(ctx context.Context) {
+	if e.YieldTo == nil {
+		return
+	}
+	waited := false
+	for e.YieldTo() {
+		if !waited {
+			e.log.Debug("sync standing aside", "reason", "outbox")
+			waited = true
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(yieldPoll):
+		}
+	}
+}
+
+// announce hands a batch of freshly stored ids to OnStored, if anyone is
+// listening and there is anything to hand over.
+func (e *Engine) announce(folder storage.Folder, ids []int64) {
+	if e.OnStored == nil || len(ids) == 0 {
+		return
+	}
+	e.OnStored(folder, append([]int64(nil), ids...))
 }
 
 // windowFloor decides the folder's sync floor for this run: a backfill lowers
@@ -271,6 +326,10 @@ func (e *Engine) adoptColors(ctx context.Context, folder storage.Folder, serverC
 // or block the rest of the folder.
 func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []Decision, localByUID map[uint32]storage.MessageState, res *FolderSyncResult) {
 	var pendingDeletes []storage.MessageState
+	// ids stored since the last time the ui was told, so a long fetch run shows
+	// mail arriving rather than nothing at all.
+	var streamed []int64
+	defer func() { e.announce(folder, streamed) }()
 
 	// walked back to front, because BuildPlan orders by ascending uid and a full
 	// body fetch is the expensive step here. Front to back means the oldest mail
@@ -293,6 +352,9 @@ func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []
 			// already in agreement
 
 		case ActionFetchNew:
+			// anything the user asked for goes first. A body fetch is the
+			// expensive step in a sync, so this is the point to stand aside at.
+			e.yield(ctx)
 			id, err := e.fetchAndStore(ctx, folder, d.UID)
 			if err != nil {
 				e.log.Error("fetch new message failed", "uid", d.UID, "err", err)
@@ -300,6 +362,11 @@ func (e *Engine) executePlan(ctx context.Context, folder storage.Folder, plan []
 			}
 			res.New++
 			res.NewIDs = append(res.NewIDs, id)
+			streamed = append(streamed, id)
+			if len(streamed) >= yieldBatch {
+				e.announce(folder, streamed)
+				streamed = streamed[:0]
+			}
 
 		case ActionDeleteLocal:
 			if err := e.deleteLocal(ctx, folder, localByUID[d.UID]); err != nil {

--- a/internal/sync/window_test.go
+++ b/internal/sync/window_test.go
@@ -212,6 +212,9 @@ type fakeClient struct {
 	deleted []imap.UID
 	moved   []imap.UID
 	movedTo string
+	// commands counts fetch commands rather than messages, which is what a
+	// round trip to the server costs.
+	commands int
 }
 
 func (c *fakeClient) Select(string) (*pimap.Mailbox, error) {
@@ -236,6 +239,23 @@ func (c *fakeClient) FetchMessage(uid imap.UID) (*pimap.Message, error) {
 }
 
 func (c *fakeClient) Addr() string { return "imap.example.com:993" }
+
+func (c *fakeClient) FetchMessages(uids []imap.UID, fn func(imap.UID, *pimap.Message, error) error) error {
+	c.commands++
+	for _, uid := range uids {
+		msg, err := c.FetchMessage(uid)
+		if err != nil {
+			if fnErr := fn(uid, nil, err); fnErr != nil {
+				return fnErr
+			}
+			continue
+		}
+		if fnErr := fn(uid, msg, nil); fnErr != nil {
+			return fnErr
+		}
+	}
+	return nil
+}
 
 func (c *fakeClient) AddFlags(imap.UID, ...imap.Flag) error { return nil }
 func (c *fakeClient) DeleteMessages(uids ...imap.UID) error {

--- a/internal/sync/window_test.go
+++ b/internal/sync/window_test.go
@@ -235,6 +235,8 @@ func (c *fakeClient) FetchMessage(uid imap.UID) (*pimap.Message, error) {
 	return &pimap.Message{UID: uid, Subject: "test"}, nil
 }
 
+func (c *fakeClient) Addr() string { return "imap.example.com:993" }
+
 func (c *fakeClient) AddFlags(imap.UID, ...imap.Flag) error { return nil }
 func (c *fakeClient) DeleteMessages(uids ...imap.UID) error {
 	c.deleted = append(c.deleted, uids...)


### PR DESCRIPTION
Fixes #310.

I measured before changing anything, and it was not what I guessed on the issue. Writes were never the problem: reads during a sync are no slower than reads on an idle database. The list query was.

There was no index on (folder_id, date), so every list load found the folder's rows and then sorted all of them in a temp b-tree, reading each row's bodies to do it, in order to show fifty. At 14k messages, per load:

| | before | after |
| --- | --- | --- |
| open a folder | 165 ms | 0.3 ms |
| scroll one page in | 664 ms | 0.5 ms |
| unified inbox | 142 ms | 1.2 ms |
| unified, page 4 | 664 ms | 2.5 ms |
| unread badge, 5 folders | 16 ms | 1.4 ms |

That is per load, and the list reloads on every sync event, which is why the window felt gone during a first sync and stayed slow afterwards.

What changed:

- migration 0030 adds the list index (folder_id, date desc, uid desc) and a state index for the counts, and drops idx_messages_folder, which both new ones cover.
- the unified views could not use an index for ordering, because an index is sorted per folder and an IN list has no single ordered path through it. They now ask each folder for its own newest rows through the index and merge the small results. query_test.go checks the merged page is identical to what the old query returned, over six shapes including offsets and a flag filter.
- sync stands aside for the outbox. It asks before every body fetch and waits while something is queued or sending, so a message you press send on goes out during a sync instead of after it.
- a first sync fills the list as mail arrives instead of showing nothing until the folder is done. Ids are handed to the ui every 25 messages, rate limited to twice a second so the list is not redrawing itself for the whole sync. Notifications still go once per folder.
- the sync log lines and the verbose status line now name the imap host and port, so a line says which account it belongs to when several sync at once.

I could not reproduce the freeze here after the index went in, so the send-priority path is built against the reported behaviour rather than a measurement of it. Worth watching when you next add a big mailbox: whether the window stays usable, whether send goes out during a sync, and whether the inbox visibly fills.
