### PR TITLE
Delete on backspace, and shortcut hints in the right-click menu

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -61,7 +61,7 @@ App passwords required by most large providers. iCloud: appleid.apple.com > App-
 
 ## Default shortcuts
 
-mod = Cmd on macOS, Ctrl elsewhere. mod+N compose, mod+F search, mod+R sync, mod+M add mailbox, mod+, settings, mod+P export PDF, mod+Z undo send/delete/archive, Ctrl+Cmd+F fullscreen. Message-level actions (reply, reply-all, forward, read/unread, flag, snooze, archive, delete, offline download) are unbound by default; user binds them in Settings > Shortcuts.
+mod = Cmd on macOS, Ctrl elsewhere. mod+N compose, mod+F search, mod+R sync, mod+M add mailbox, mod+, settings, mod+P export PDF, mod+Z undo send/delete/archive, Ctrl+Cmd+F fullscreen. Backspace deletes the selection, or the open message when nothing is selected, and Delete does the same until the binding is changed. The other message-level actions (reply, reply-all, forward, read/unread, flag, snooze, archive, offline download) are unbound by default; user binds them in Settings > Shortcuts. A bound action shows its key beside the matching right-click entry and in the toolbar tooltip, unless Settings > Shortcuts > "Show keyboard shortcut hints in the app" is off.
 
 ## Theme format (.peltontheme)
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -18,6 +18,7 @@ Pelton uses ++cmd++ on macOS and ++ctrl++ on Windows and Linux for the same bind
 | ++cmd+h++ | Hide window (macOS) |
 | ++cmd+w++ | Close the front compose window, settings, or the window itself |
 | ++cmd+q++ | Quit |
+| ++backspace++ | Delete the selected messages, or the open one |
 
 ## Menu bar access keys
 
@@ -29,7 +30,11 @@ macOS has no such convention and does not use them.
 
 ## Message actions
 
-Reply, reply all, forward, mark read or unread, flag, snooze, archive, delete and download-for-offline ship unbound so they cannot collide with anything. Bind them to whatever you like under **Settings, Shortcuts**; each one acts on the currently open message.
+Delete is bound: ++backspace++, and ++delete++ does the same thing until you change the binding. It moves what you have selected to Trash, or the open message when nothing is selected, and ++cmd+z++ brings it back.
+
+Reply, reply all, forward, mark read or unread, flag, snooze, archive and download-for-offline ship unbound so they cannot collide with anything. Bind them to whatever you like under **Settings, Shortcuts**. Each one acts on the messages you have selected, or on the open one when nothing is selected.
+
+Whatever you bind shows up next to the matching entry when you right-click a message, and in the toolbar tooltips. Turn that off under **Settings, Shortcuts** with "Show keyboard shortcut hints in the app".
 
 ## Reading tabs
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -598,7 +598,12 @@
   // message, mirroring the right-click menu. it no-ops (with a hint) when
   // neither exists.
   async function messageAction(action: ShortcutAction): Promise<void> {
-    if (selectedMessages.length > 1 && bulkAction(action, selectedMessages)) {
+    // one selected row counts as a selection, not as nothing. Opening a message
+    // does not select it, so a selection of one only exists because it was
+    // picked deliberately, and the right-click menu already acts on it. Without
+    // this, selecting a row and pressing delete answered "open a message
+    // first" (#329).
+    if (selectedMessages.length >= 1 && bulkAction(action, selectedMessages)) {
       return
     }
     const msg = currentMessage()

--- a/frontend/src/components/common/ContextMenu.svelte
+++ b/frontend/src/components/common/ContextMenu.svelte
@@ -96,6 +96,9 @@
             <span class="icon"><svelte:component this={entry.icon} size={15} stroke={1.7} /></span>
           {/if}
           <span class="label">{entry.label}</span>
+          {#if entry.hint}
+            <kbd class="hint">{entry.hint}</kbd>
+          {/if}
         </button>
       {/if}
     {/each}
@@ -155,6 +158,21 @@
 
   .item:hover .icon {
     color: inherit;
+  }
+
+  /* the hint sits at the right edge, so the keys line up down the menu however
+     long the labels are. */
+  .hint {
+    margin-left: auto;
+    padding-left: var(--space-4);
+    font-family: inherit;
+    font-size: var(--fz-meta);
+    color: var(--text-tertiary);
+    white-space: nowrap;
+  }
+
+  .item:hover .hint {
+    color: var(--text-secondary);
   }
 
   .sep {

--- a/frontend/src/components/list/MessageList.svelte
+++ b/frontend/src/components/list/MessageList.svelte
@@ -78,6 +78,8 @@
   import { recordDeleted } from '../../stores/undodelete'
   import { recordArchived } from '../../stores/undoarchive'
   import { openContextMenu, type MenuEntry } from '../../stores/contextmenu'
+  import { menuHint } from '../../stores/shortcuts'
+  import type { ShortcutAction } from '../../lib/shortcuts'
   import { openInTab } from '../../stores/tabs'
   import { errorMessage, toastError } from '../../stores/toast'
   import { isVIPAddress } from '../../stores/vip'
@@ -155,6 +157,14 @@
       viewportHeight = listEl.clientHeight || viewportHeight
     }
   })
+
+  // withHint appends an action's shortcut to a button tooltip, so hovering the
+  // delete button says which key does the same thing (#329). Unbound actions,
+  // and hints turned off, leave the tooltip as it was.
+  function withHint(label: string, action: ShortcutAction): string {
+    const hint = menuHint(action)
+    return hint ? `${label}  ${hint}` : label
+  }
 
   // selectionKey identifies a selection so we reload only when it actually
   // changes, not on unrelated store updates.
@@ -530,14 +540,14 @@
         // and applies to the same selection they name.
         { kind: 'colors', current: 0, onPick: (color) => void bulkSetColor(color) },
         'separator',
-        { label: $t('messageList.bulk.snoozeCount').replace('{n}', n), icon: IconClockPause, action: bulkSnooze },
-        { label: $t('messageList.bulk.moveCount').replace('{n}', n), icon: IconFolderSymlink, action: bulkMove },
-        { label: $t('messageList.bulk.archiveCount').replace('{n}', n), icon: IconArchive, action: () => void bulkArchiveSelection() },
+        { label: $t('messageList.bulk.snoozeCount').replace('{n}', n), icon: IconClockPause, hint: menuHint('snooze'), action: bulkSnooze },
+        { label: $t('messageList.bulk.moveCount').replace('{n}', n), icon: IconFolderSymlink, hint: menuHint('move-to'), action: bulkMove },
+        { label: $t('messageList.bulk.archiveCount').replace('{n}', n), icon: IconArchive, hint: menuHint('archive'), action: () => void bulkArchiveSelection() },
         anyOnline
           ? { label: $t('messageList.bulk.downloadCount').replace('{n}', n), icon: IconDownload, action: () => void bulkSetOfflineCopies(true) }
           : { label: $t('messageList.bulk.removeOfflineCount').replace('{n}', n), icon: IconDownloadOff, action: () => void bulkSetOfflineCopies(false) },
         'separator',
-        { label: $t('messageList.bulk.deleteCount').replace('{n}', n), icon: IconTrash, danger: true, action: () => void bulkDelete() },
+        { label: $t('messageList.bulk.deleteCount').replace('{n}', n), icon: IconTrash, danger: true, hint: menuHint('delete-message'), action: () => void bulkDelete() },
       ]
       openContextMenu(event.clientX, event.clientY, entries)
       return
@@ -552,28 +562,28 @@
     const entries: MenuEntry[] = [
       { label: $t('messageList.menu.open'), icon: IconMail, action: () => open(items.indexOf(item)) },
       { label: $t('messageList.menu.openInTab'), icon: IconLayoutColumns, action: () => openInTab(item.id, item.subject) },
-      { label: $t('action.reply'), icon: IconArrowBackUp, action: () => void replyTo(item, false) },
-      { label: $t('shortcut.replyAll'), icon: IconArrowBackUp, action: () => void replyTo(item, true) },
-      { label: $t('action.forward'), icon: IconArrowForwardUp, action: () => void forward(item) },
+      { label: $t('action.reply'), icon: IconArrowBackUp, hint: menuHint('reply'), action: () => void replyTo(item, false) },
+      { label: $t('shortcut.replyAll'), icon: IconArrowBackUp, hint: menuHint('reply-all'), action: () => void replyTo(item, true) },
+      { label: $t('action.forward'), icon: IconArrowForwardUp, hint: menuHint('forward'), action: () => void forward(item) },
       'separator',
       item.seen
-        ? { label: $t('shortcut.markUnread'), icon: IconMailFilled, action: () => void toggleSeen(item) }
-        : { label: $t('shortcut.markRead'), icon: IconMailOpened, action: () => void toggleSeen(item) },
+        ? { label: $t('shortcut.markUnread'), icon: IconMailFilled, hint: menuHint('mark-unread'), action: () => void toggleSeen(item) }
+        : { label: $t('shortcut.markRead'), icon: IconMailOpened, hint: menuHint('mark-read'), action: () => void toggleSeen(item) },
       item.flagged
-        ? { label: $t('messageList.unflag'), icon: IconFlag, action: () => void toggleFlag(item) }
-        : { label: $t('messageList.flag'), icon: IconFlagFilled, action: () => void toggleFlag(item) },
+        ? { label: $t('messageList.unflag'), icon: IconFlag, hint: menuHint('flag'), action: () => void toggleFlag(item) }
+        : { label: $t('messageList.flag'), icon: IconFlagFilled, hint: menuHint('flag'), action: () => void toggleFlag(item) },
       { kind: 'colors', current: item.flagColor, onPick: (color) => void setColor(item, color) },
       isVIPAddress(item.fromAddress)
         ? { label: $t('vip.unmark'), icon: IconStar, action: () => void toggleVIP(item) }
         : { label: $t('vip.mark'), icon: IconStarFilled, action: () => void toggleVIP(item) },
       'separator',
-      { label: $t('messageList.menu.snooze'), icon: IconClockPause, action: () => openSnooze(item.id, item.subject) },
-      { label: $t('messageList.menu.moveTo'), icon: IconFolderSymlink, action: () => openMove(item) },
+      { label: $t('messageList.menu.snooze'), icon: IconClockPause, hint: menuHint('snooze'), action: () => openSnooze(item.id, item.subject) },
+      { label: $t('messageList.menu.moveTo'), icon: IconFolderSymlink, hint: menuHint('move-to'), action: () => openMove(item) },
       item.offline
-        ? { label: $t('messageList.menu.removeOffline'), icon: IconDownloadOff, action: () => void toggleOffline(item) }
-        : { label: $t('shortcut.downloadOffline'), icon: IconDownload, action: () => void toggleOffline(item) },
+        ? { label: $t('messageList.menu.removeOffline'), icon: IconDownloadOff, hint: menuHint('remove-offline'), action: () => void toggleOffline(item) }
+        : { label: $t('shortcut.downloadOffline'), icon: IconDownload, hint: menuHint('download-offline'), action: () => void toggleOffline(item) },
       'separator',
-      { label: $t('action.delete'), icon: IconTrash, danger: true, action: () => void remove(item) },
+      { label: $t('action.delete'), icon: IconTrash, danger: true, hint: menuHint('delete-message'), action: () => void remove(item) },
     ]
     openContextMenu(event.clientX, event.clientY, entries)
   }
@@ -650,30 +660,30 @@
       {/if}
       <span class="sel-spacer"></span>
       {#if selectedItems.some((m) => !m.seen)}
-        <button type="button" class="act" title={$t('shortcut.markRead')} on:click={() => bulkSetSeen(true)}>
+        <button type="button" class="act" title={withHint($t('shortcut.markRead'), 'mark-read')} on:click={() => bulkSetSeen(true)}>
           <IconMailOpened size={16} stroke={1.7} />
         </button>
       {:else}
-        <button type="button" class="act" title={$t('shortcut.markUnread')} on:click={() => bulkSetSeen(false)}>
+        <button type="button" class="act" title={withHint($t('shortcut.markUnread'), 'mark-unread')} on:click={() => bulkSetSeen(false)}>
           <IconMailFilled size={16} stroke={1.7} />
         </button>
       {/if}
       {#if selectedItems.some((m) => !m.flagged)}
-        <button type="button" class="act" title={$t('messageList.flag')} on:click={() => bulkSetFlagged(true)}>
+        <button type="button" class="act" title={withHint($t('messageList.flag'), 'flag')} on:click={() => bulkSetFlagged(true)}>
           <IconFlagFilled size={16} stroke={1.7} />
         </button>
       {:else}
-        <button type="button" class="act" title={$t('messageList.unflag')} on:click={() => bulkSetFlagged(false)}>
+        <button type="button" class="act" title={withHint($t('messageList.unflag'), 'flag')} on:click={() => bulkSetFlagged(false)}>
           <IconFlag size={16} stroke={1.7} />
         </button>
       {/if}
-      <button type="button" class="act" title={$t('action.archive')} on:click={bulkArchiveSelection}>
+      <button type="button" class="act" title={withHint($t('action.archive'), 'archive')} on:click={bulkArchiveSelection}>
         <IconArchive size={16} stroke={1.7} />
       </button>
-      <button type="button" class="act" title={$t('messageList.menu.moveTo')} on:click={bulkMove}>
+      <button type="button" class="act" title={withHint($t('messageList.menu.moveTo'), 'move-to')} on:click={bulkMove}>
         <IconFolderSymlink size={16} stroke={1.7} />
       </button>
-      <button type="button" class="act danger" title={$t('action.delete')} on:click={bulkDelete}>
+      <button type="button" class="act danger" title={withHint($t('action.delete'), 'delete-message')} on:click={bulkDelete}>
         <IconTrash size={16} stroke={1.7} />
       </button>
     </div>

--- a/frontend/src/components/settings/ShortcutSettings.svelte
+++ b/frontend/src/components/settings/ShortcutSettings.svelte
@@ -93,6 +93,12 @@
           <span class="recording">{$t('shortcuts.pressKeys')} <kbd>Esc</kbd> {$t('shortcuts.toCancel')}</span>
         {:else if $bindings[sc.action]}
           <kbd>{shortcutLabel($bindings[sc.action])}</kbd>
+          <!-- an action with an alternate answers to both keys until it is
+               rebound, so listing only one would be a half truth. -->
+          {#if sc.alt && $bindings[sc.action] === sc.combo}
+            <span class="alt-sep">{$t('shortcuts.or')}</span>
+            <kbd>{shortcutLabel(sc.alt)}</kbd>
+          {/if}
         {:else}
           <span class="unset">{$t('shortcuts.notSet')}</span>
         {/if}
@@ -226,6 +232,11 @@
     border: var(--hairline) solid var(--border-default);
     border-radius: var(--radius-control);
     padding: 2px var(--space-2);
+  }
+
+  .alt-sep {
+    font-size: var(--fz-meta);
+    color: var(--text-tertiary);
   }
 
   .recording {

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -139,6 +139,9 @@ export function shortcutLabel(combo: string): string {
       if (part === 'shift') return isMac ? '⇧' : 'Shift'
       if (part === 'alt') return isMac ? '⌥' : 'Alt'
       if (part === 'space') return 'Space'
+      // the two delete keys have glyphs on macOS and names everywhere else.
+      if (part === 'backspace') return isMac ? '⌫' : 'Backspace'
+      if (part === 'delete') return isMac ? '⌦' : 'Delete'
       return part.length === 1 ? part.toUpperCase() : part
     })
     .join(isMac ? '' : '+')

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -531,6 +531,7 @@ const de: Record<string, string> = {
   'shortcuts.pressKeys': 'Tasten drücken…',
   'shortcuts.toCancel': 'zum Abbrechen',
   'shortcuts.notSet': 'Nicht festgelegt',
+  'shortcuts.or': 'oder',
   'shortcuts.recording': 'Aufzeichnung läuft',
   'shortcuts.change': 'Ändern',
   'shortcuts.resetToDefault': 'Auf Standard zurücksetzen',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -531,6 +531,7 @@ const en: Record<string, string> = {
   'shortcuts.pressKeys': 'Press keys…',
   'shortcuts.toCancel': 'to cancel',
   'shortcuts.notSet': 'Not set',
+  'shortcuts.or': 'or',
   'shortcuts.recording': 'Recording',
   'shortcuts.change': 'Change',
   'shortcuts.resetToDefault': 'Reset to default',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -531,6 +531,7 @@ const es: Record<string, string> = {
   'shortcuts.pressKeys': 'Pulsa las teclas…',
   'shortcuts.toCancel': 'para cancelar',
   'shortcuts.notSet': 'Sin definir',
+  'shortcuts.or': 'o',
   'shortcuts.recording': 'Grabando',
   'shortcuts.change': 'Cambiar',
   'shortcuts.resetToDefault': 'Restablecer valor predeterminado',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -531,6 +531,7 @@ const fr: Record<string, string> = {
   'shortcuts.pressKeys': 'Appuie sur les touches…',
   'shortcuts.toCancel': 'pour annuler',
   'shortcuts.notSet': 'Non défini',
+  'shortcuts.or': 'ou',
   'shortcuts.recording': 'Enregistrement',
   'shortcuts.change': 'Modifier',
   'shortcuts.resetToDefault': 'Réinitialiser par défaut',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -531,6 +531,7 @@ const nl: Record<string, string> = {
   'shortcuts.pressKeys': 'Druk op toetsen…',
   'shortcuts.toCancel': 'om te annuleren',
   'shortcuts.notSet': 'Niet ingesteld',
+  'shortcuts.or': 'of',
   'shortcuts.recording': 'Opnemen',
   'shortcuts.change': 'Wijzigen',
   'shortcuts.resetToDefault': 'Terugzetten naar standaard',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -531,6 +531,7 @@ const pl: Record<string, string> = {
   'shortcuts.pressKeys': 'Naciśnij klawisze…',
   'shortcuts.toCancel': 'aby anulować',
   'shortcuts.notSet': 'Nie ustawiono',
+  'shortcuts.or': 'lub',
   'shortcuts.recording': 'Nagrywanie',
   'shortcuts.change': 'Zmień',
   'shortcuts.resetToDefault': 'Przywróć domyślny',

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -66,6 +66,15 @@ export interface Shortcut {
   action: ShortcutAction
   combo: string
   labelKey: string
+  /**
+   * A second key that fires the same action while the binding is untouched.
+   * It exists for actions where two platforms disagree about which key is
+   * obvious and neither key does anything else: delete is Backspace on macOS
+   * and Delete elsewhere, and the key you reach for should work whichever
+   * machine you learned it on. Rebinding the action replaces the pair, since
+   * at that point you have said which key you want.
+   */
+  alt?: string
 }
 
 // the default registry, also used to seed the editable bindings and render the
@@ -95,7 +104,10 @@ export const shortcuts: Shortcut[] = [
   { action: 'flag', combo: '', labelKey: 'shortcut.flag' },
   { action: 'snooze', combo: '', labelKey: 'shortcut.snooze' },
   { action: 'download-offline', combo: '', labelKey: 'shortcut.downloadOffline' },
-  { action: 'delete-message', combo: '', labelKey: 'shortcut.deleteMessage' },
+  // bound by default, unlike the rest of the message actions: every mail client
+  // deletes on this key, neither key types anything in a list, and delete means
+  // move to trash with one undo behind it (#329).
+  { action: 'delete-message', combo: 'backspace', alt: 'delete', labelKey: 'shortcut.deleteMessage' },
   { action: 'archive', combo: '', labelKey: 'shortcut.archive' },
   { action: 'unsubscribe', combo: '', labelKey: 'shortcut.unsubscribe' },
   // saved views (preset searches), unbound by default so the user opts in.
@@ -216,6 +228,12 @@ export function matchShortcut(
       continue
     }
     if (comboMatches(event, combo)) {
+      return action as ShortcutAction
+    }
+    // the alternate key, only while the binding is still the default one: a
+    // rebound action answers to what it was rebound to and nothing else.
+    const def = shortcuts.find((s) => s.action === action)
+    if (def?.alt && combo === def.combo && comboMatches(event, def.alt)) {
       return action as ShortcutAction
     }
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -389,7 +389,8 @@ export interface UIPrefs {
   sendDelaySeconds: number
   // flagHighlight controls how flagged rows stand out: flag, left, both, off.
   flagHighlight: string
-  // showShortcutHints toggles inline keyboard shortcut chips (off by default).
+  // showShortcutHints toggles the keyboard shortcut shown beside a context-menu
+  // entry that has one. On by default.
   showShortcutHints: boolean
   // showAccountEmail shows the account email instead of its name in the sidebar.
   showAccountEmail: boolean

--- a/frontend/src/stores/contextmenu.ts
+++ b/frontend/src/stores/contextmenu.ts
@@ -12,6 +12,12 @@ export interface MenuItem {
   action: () => void
   icon?: ComponentType
   danger?: boolean
+  /**
+   * The keyboard shortcut for this entry, already rendered for display. Build
+   * it with menuHint so an unbound action leaves it empty and the row simply
+   * has no hint.
+   */
+  hint?: string
 }
 
 // a color-swatch row for picking a message flag color inline. current is the

--- a/frontend/src/stores/prefs.ts
+++ b/frontend/src/stores/prefs.ts
@@ -28,7 +28,7 @@ const defaults: UIPrefs = {
   listWidth: 380,
   sendDelaySeconds: 0,
   flagHighlight: 'flag',
-  showShortcutHints: false,
+  showShortcutHints: true,
   showAccountEmail: false,
   alwaysLoadImages: false,
   blockTrackingPixels: false,

--- a/frontend/src/stores/shortcuts.ts
+++ b/frontend/src/stores/shortcuts.ts
@@ -7,6 +7,8 @@
 import { writable, get } from 'svelte/store'
 import { getSetting, setSetting } from '../lib/api'
 import { shortcuts as defaults, type ShortcutAction } from '../lib/shortcuts'
+import { shortcutLabel } from '../lib/i18n'
+import { prefs } from './prefs'
 
 const KEY = 'keyboard_shortcuts'
 
@@ -86,4 +88,16 @@ export function conflictsFor(action: ShortcutAction, combo: string): ShortcutAct
     }
   }
   return null
+}
+
+// menuHint renders an action's current shortcut for a context-menu row, or an
+// empty string when the action is unbound or hints are turned off. Menus pass
+// it straight into MenuItem.hint, so an unbound action simply has no hint
+// rather than an empty box (#329).
+export function menuHint(action: ShortcutAction): string {
+  if (!get(prefs).showShortcutHints) {
+    return ''
+  }
+  const combo = get(bindings)[action]
+  return combo ? shortcutLabel(combo) : ''
 }

--- a/internal/desktop/bind_settings.go
+++ b/internal/desktop/bind_settings.go
@@ -403,7 +403,7 @@ func (a *App) GetUIPrefs() (UIPrefsDTO, error) {
 		ListWidth:           a.intSetting(settingListWidth, defaultListWidth),
 		SendDelaySeconds:    a.intSetting(settingSendDelay, 0),
 		FlagHighlight:       a.stringSetting(settingFlagHighlight, defaultFlagHighlight),
-		ShowShortcutHints:   a.boolSetting(settingShortcutHints, false),
+		ShowShortcutHints:   a.boolSetting(settingShortcutHints, true),
 		ShowAccountEmail:    a.boolSetting(settingAccountEmail, false),
 		AlwaysLoadImages:    a.boolSetting(settingRemoteAlways, false),
 		BlockTrackingPixels: a.blockTrackers(),


### PR DESCRIPTION
Closes #329.

delete-message existed as an action but shipped unbound, and nothing anywhere said so. It is bound to Backspace now, and Delete does the same until the binding is changed, so the key you reach for works whichever machine you learned it on. Rebinding replaces the pair, since at that point you have said which key you want. That needed a new optional "alt" combo on a shortcut definition; it only applies while the binding is still the default.

The other half of the issue was that nothing surfaced the key. A bound action now shows it beside the matching right-click entry and in the toolbar tooltip. This is what the "Show keyboard shortcut hints in the app" setting controls, which until now was wired to nothing at all, so I made it mean something and turned it on by default. Nobody's install changes behaviour they had chosen, since the pref did nothing before either. Everywhere else it still does nothing is #332.

One behaviour change beyond the ask: a message action with exactly one row selected used to say "open a message first", because only a selection of two or more counted. Opening a message does not select it, so a selection of one only exists because it was picked deliberately, and the right-click menu already acted on it. Selecting a row and pressing delete now deletes that row.

Delete means move to Trash with cmd+z behind it, and more than one still confirms with the count.