### PR TITLE
Make the sidebar layout follow the profile

### DIFF
--- a/frontend/src/components/settings/ProfilesSection.svelte
+++ b/frontend/src/components/settings/ProfilesSection.svelte
@@ -20,7 +20,7 @@
   import type { Account, Profile, ProfileDraft, ProfileStart } from '../../lib/types'
 
   // the areas a profile can own or share, in the order the form lists them.
-  const areas = ['settings', 'signatures', 'views'] as const
+  const areas = ['settings', 'signatures', 'views', 'layout'] as const
   type Area = (typeof areas)[number]
 
   const starts: ProfileStart[] = ['share', 'copy', 'fresh']
@@ -68,6 +68,9 @@
       startSettings: 'copy',
       startSignatures: 'fresh',
       startViews: 'fresh',
+      // a new working context arranges its own sidebar, but starting from the
+      // arrangement you already have beats starting from nothing.
+      startLayout: 'copy',
     })
   }
 
@@ -83,6 +86,7 @@
       startSettings: profile.shareSettings ? 'share' : 'fresh',
       startSignatures: profile.shareSignatures ? 'share' : 'fresh',
       startViews: profile.shareViews ? 'share' : 'fresh',
+      startLayout: profile.shareLayout ? 'share' : 'fresh',
     })
   }
 
@@ -105,8 +109,10 @@
       draft.startSettings = value
     } else if (area === 'signatures') {
       draft.startSignatures = value
-    } else {
+    } else if (area === 'views') {
       draft.startViews = value
+    } else {
+      draft.startLayout = value
     }
   }
 
@@ -114,7 +120,13 @@
     if (!draft) {
       return 'fresh'
     }
-    return area === 'settings' ? draft.startSettings : area === 'signatures' ? draft.startSignatures : draft.startViews
+    if (area === 'settings') {
+      return draft.startSettings
+    }
+    if (area === 'signatures') {
+      return draft.startSignatures
+    }
+    return area === 'views' ? draft.startViews : draft.startLayout
   }
 
   // the row at the top of the form: one click to put every area on the same

--- a/frontend/src/lib/locales/de.ts
+++ b/frontend/src/lib/locales/de.ts
@@ -842,6 +842,7 @@ const de: Record<string, string> = {
   'profiles.area.settings': 'Einstellungen',
   'profiles.area.signatures': 'Signaturen',
   'profiles.area.views': 'Gespeicherte Ansichten',
+  'profiles.area.layout': 'Aufbau der Seitenleiste',
   'profiles.start.share': 'Teilen',
   'profiles.start.copy': 'Kopieren',
   'profiles.start.fresh': 'Neu',

--- a/frontend/src/lib/locales/en.ts
+++ b/frontend/src/lib/locales/en.ts
@@ -842,6 +842,7 @@ const en: Record<string, string> = {
   'profiles.area.settings': 'Settings',
   'profiles.area.signatures': 'Signatures',
   'profiles.area.views': 'Saved views',
+  'profiles.area.layout': 'Sidebar layout',
   'profiles.start.share': 'Share',
   'profiles.start.copy': 'Copy',
   'profiles.start.fresh': 'Fresh',

--- a/frontend/src/lib/locales/es.ts
+++ b/frontend/src/lib/locales/es.ts
@@ -842,6 +842,7 @@ const es: Record<string, string> = {
   'profiles.area.settings': 'Ajustes',
   'profiles.area.signatures': 'Firmas',
   'profiles.area.views': 'Vistas guardadas',
+  'profiles.area.layout': 'Disposición de la barra lateral',
   'profiles.start.share': 'Compartir',
   'profiles.start.copy': 'Copiar',
   'profiles.start.fresh': 'Vacío',

--- a/frontend/src/lib/locales/fr.ts
+++ b/frontend/src/lib/locales/fr.ts
@@ -842,6 +842,7 @@ const fr: Record<string, string> = {
   'profiles.area.settings': 'Réglages',
   'profiles.area.signatures': 'Signatures',
   'profiles.area.views': 'Vues enregistrées',
+  'profiles.area.layout': 'Disposition de la barre latérale',
   'profiles.start.share': 'Partager',
   'profiles.start.copy': 'Copier',
   'profiles.start.fresh': 'Vierge',

--- a/frontend/src/lib/locales/nl.ts
+++ b/frontend/src/lib/locales/nl.ts
@@ -842,6 +842,7 @@ const nl: Record<string, string> = {
   'profiles.area.settings': 'Instellingen',
   'profiles.area.signatures': 'Ondertekeningen',
   'profiles.area.views': 'Opgeslagen weergaven',
+  'profiles.area.layout': 'Indeling van de zijbalk',
   'profiles.start.share': 'Delen',
   'profiles.start.copy': 'Kopiëren',
   'profiles.start.fresh': 'Leeg',

--- a/frontend/src/lib/locales/pl.ts
+++ b/frontend/src/lib/locales/pl.ts
@@ -840,6 +840,7 @@ const pl: Record<string, string> = {
   'profiles.area.settings': 'Ustawienia',
   'profiles.area.signatures': 'Podpisy',
   'profiles.area.views': 'Zapisane widoki',
+  'profiles.area.layout': 'Układ panelu bocznego',
   'profiles.start.share': 'Współdziel',
   'profiles.start.copy': 'Kopiuj',
   'profiles.start.fresh': 'Puste',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -996,6 +996,9 @@ export interface Profile {
   shareSettings: boolean
   shareSignatures: boolean
   shareViews: boolean
+  // the sidebar layout: which folders are pinned, and the order of folders and
+  // account sections.
+  shareLayout: boolean
   accountIds: number[]
 }
 
@@ -1012,4 +1015,5 @@ export interface ProfileDraft {
   startSettings: ProfileStart
   startSignatures: ProfileStart
   startViews: ProfileStart
+  startLayout: ProfileStart
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1267,6 +1267,7 @@ export namespace desktop {
 	    shareSettings: boolean;
 	    shareSignatures: boolean;
 	    shareViews: boolean;
+	    shareLayout: boolean;
 	    accountIds: number[];
 	
 	    static createFrom(source: any = {}) {
@@ -1283,6 +1284,7 @@ export namespace desktop {
 	        this.shareSettings = source["shareSettings"];
 	        this.shareSignatures = source["shareSignatures"];
 	        this.shareViews = source["shareViews"];
+	        this.shareLayout = source["shareLayout"];
 	        this.accountIds = source["accountIds"];
 	    }
 	}
@@ -1294,6 +1296,7 @@ export namespace desktop {
 	    startSettings: string;
 	    startSignatures: string;
 	    startViews: string;
+	    startLayout: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new ProfileRequest(source);
@@ -1308,6 +1311,7 @@ export namespace desktop {
 	        this.startSettings = source["startSettings"];
 	        this.startSignatures = source["startSignatures"];
 	        this.startViews = source["startViews"];
+	        this.startLayout = source["startLayout"];
 	    }
 	}
 	export class RecipientKeyDTO {

--- a/internal/desktop/bind_profile_layout_test.go
+++ b/internal/desktop/bind_profile_layout_test.go
@@ -1,0 +1,169 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+// layoutTestFolder creates an account with two folders and returns their ids.
+func layoutTestFolder(t *testing.T, a *App) (int64, int64) {
+	t.Helper()
+	accountID, err := a.store.CreateAccount(a.ctx, &storage.Account{Email: "me@example.com"})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	inbox := storage.Folder{AccountID: accountID, Name: "INBOX", IMAPPath: "INBOX"}
+	work := storage.Folder{AccountID: accountID, Name: "Work", IMAPPath: "Work"}
+	for _, f := range []*storage.Folder{&inbox, &work} {
+		if _, err := a.store.CreateFolder(a.ctx, f); err != nil {
+			t.Fatalf("create folder %q: %v", f.Name, err)
+		}
+	}
+	return inbox.ID, work.ID
+}
+
+// TestSwitchProfileSwitchesTheLayout is the whole of #325 from the outside: the
+// pins and the order follow the profile you are in.
+func TestSwitchProfileSwitchesTheLayout(t *testing.T) {
+	a := newProfileApp(t)
+	inbox, work := layoutTestFolder(t, a)
+
+	if err := a.store.SetFolderPinned(a.ctx, work, true); err != nil {
+		t.Fatalf("pin Work: %v", err)
+	}
+	if err := a.store.SetFolderPositions(a.ctx, []int64{work, inbox}); err != nil {
+		t.Fatalf("reorder: %v", err)
+	}
+
+	created, err := a.CreateProfile(ProfileRequest{Name: "work", StartLayout: startFresh})
+	if err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	if created.ShareLayout {
+		t.Errorf("a fresh layout profile reports shareLayout %v, want false", created.ShareLayout)
+	}
+	switchTo(t, a, created.ID)
+
+	pinned, err := a.store.ListPinnedFolders(a.ctx)
+	if err != nil {
+		t.Fatalf("list pinned: %v", err)
+	}
+	if len(pinned) != 0 {
+		t.Errorf("the new profile has %d pinned folders, want none", len(pinned))
+	}
+	folders, err := a.store.ListFolders(a.ctx, pinnedAccountOf(t, a, inbox))
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	if len(folders) != 2 || folders[0].ID != inbox {
+		t.Errorf("the new profile lists %v first, want the untouched discovery order", folders[0].Name)
+	}
+}
+
+// TestCreateProfileCopiesTheLayout covers the default a new profile is made
+// with: its own layout, starting from a copy of main's.
+func TestCreateProfileCopiesTheLayout(t *testing.T) {
+	a := newProfileApp(t)
+	inbox, work := layoutTestFolder(t, a)
+	if err := a.store.SetFolderPositions(a.ctx, []int64{work, inbox}); err != nil {
+		t.Fatalf("reorder: %v", err)
+	}
+
+	created, err := a.CreateProfile(ProfileRequest{Name: "work", StartLayout: startCopy})
+	if err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	switchTo(t, a, created.ID)
+
+	folders, err := a.store.ListFolders(a.ctx, pinnedAccountOf(t, a, inbox))
+	if err != nil {
+		t.Fatalf("list folders: %v", err)
+	}
+	if folders[0].ID != work {
+		t.Errorf("copied layout lists %q first, want Work", folders[0].Name)
+	}
+
+	// a copy is a snapshot: rearranging it leaves main where it was.
+	if err := a.store.SetFolderPositions(a.ctx, []int64{inbox, work}); err != nil {
+		t.Fatalf("rearrange copy: %v", err)
+	}
+	main, err := a.store.MainProfile(a.ctx)
+	if err != nil {
+		t.Fatalf("main profile: %v", err)
+	}
+	switchTo(t, a, main.ID)
+	folders, err = a.store.ListFolders(a.ctx, pinnedAccountOf(t, a, inbox))
+	if err != nil {
+		t.Fatalf("list folders in main: %v", err)
+	}
+	if folders[0].ID != work {
+		t.Errorf("main lists %q first after the copy was rearranged, want Work", folders[0].Name)
+	}
+}
+
+// TestSharingTheLayoutKeepsTheProfilesOwn: ticking the box in the editor makes
+// the profile follow main, and unticking brings its own arrangement back.
+func TestSharingTheLayoutKeepsTheProfilesOwn(t *testing.T) {
+	a := newProfileApp(t)
+	inbox, work := layoutTestFolder(t, a)
+	if err := a.store.SetFolderPositions(a.ctx, []int64{work, inbox}); err != nil {
+		t.Fatalf("reorder main: %v", err)
+	}
+
+	created, err := a.CreateProfile(ProfileRequest{Name: "work", StartLayout: startFresh})
+	if err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	switchTo(t, a, created.ID)
+	if err := a.store.SetFolderPositions(a.ctx, []int64{inbox, work}); err != nil {
+		t.Fatalf("reorder in profile: %v", err)
+	}
+
+	shared, err := a.UpdateProfile(ProfileRequest{ID: created.ID, Name: "work", StartLayout: startShare})
+	if err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	if !shared.ShareLayout {
+		t.Fatal("UpdateProfile did not record the share")
+	}
+	folders, err := a.store.ListFolders(a.ctx, pinnedAccountOf(t, a, inbox))
+	if err != nil {
+		t.Fatalf("list folders while sharing: %v", err)
+	}
+	if folders[0].ID != work {
+		t.Errorf("while sharing, first folder is %q, want main's Work", folders[0].Name)
+	}
+
+	if _, err := a.UpdateProfile(ProfileRequest{ID: created.ID, Name: "work", StartLayout: startFresh}); err != nil {
+		t.Fatalf("UpdateProfile unshare: %v", err)
+	}
+	folders, err = a.store.ListFolders(a.ctx, pinnedAccountOf(t, a, inbox))
+	if err != nil {
+		t.Fatalf("list folders after unshare: %v", err)
+	}
+	if folders[0].ID != inbox {
+		t.Errorf("after unsharing, first folder is %q, want the profile's own INBOX", folders[0].Name)
+	}
+}
+
+// switchTo switches profile and stops the session the switch started. These
+// tests only care where the store is pointed, and a background sync outliving
+// the test leaves wal files behind that t.TempDir then cannot remove.
+func switchTo(t *testing.T, a *App, id int64) {
+	t.Helper()
+	if err := a.SwitchProfile(id); err != nil {
+		t.Fatalf("SwitchProfile: %v", err)
+	}
+	a.endProfileSession()
+}
+
+// pinnedAccountOf returns the account a folder belongs to.
+func pinnedAccountOf(t *testing.T, a *App, folderID int64) int64 {
+	t.Helper()
+	folder, err := a.store.GetFolder(a.ctx, folderID)
+	if err != nil {
+		t.Fatalf("get folder: %v", err)
+	}
+	return folder.AccountID
+}

--- a/internal/desktop/bind_profiles.go
+++ b/internal/desktop/bind_profiles.go
@@ -55,6 +55,9 @@ type ProfileDTO struct {
 	ShareSettings   bool `json:"shareSettings"`
 	ShareSignatures bool `json:"shareSignatures"`
 	ShareViews      bool `json:"shareViews"`
+	// ShareLayout links the sidebar layout to main: pinned folders and the order
+	// of folders and account sections.
+	ShareLayout bool `json:"shareLayout"`
 	// AccountIDs are the accounts this profile shows.
 	AccountIDs []int64 `json:"accountIds"`
 }
@@ -74,6 +77,7 @@ type ProfileRequest struct {
 	StartSettings   string `json:"startSettings"`
 	StartSignatures string `json:"startSignatures"`
 	StartViews      string `json:"startViews"`
+	StartLayout     string `json:"startLayout"`
 }
 
 // ListProfiles returns every profile on the install, main first.
@@ -131,6 +135,7 @@ func (a *App) CreateProfile(req ProfileRequest) (ProfileDTO, error) {
 		ShareSettings:   req.StartSettings == startShare,
 		ShareSignatures: req.StartSignatures == startShare,
 		ShareViews:      req.StartViews == startShare,
+		ShareLayout:     req.StartLayout == startShare,
 	}
 	if _, err := a.store.CreateProfile(a.ctx, &profile); err != nil {
 		return ProfileDTO{}, err
@@ -156,6 +161,7 @@ func (a *App) copyStartingRows(mainID, profileID int64, req ProfileRequest) erro
 		{req.StartSettings, a.store.CopyProfileSettings},
 		{req.StartSignatures, a.store.CopyProfileSignatures},
 		{req.StartViews, a.store.CopyProfileViews},
+		{req.StartLayout, a.store.CopyProfileLayout},
 	}
 	for _, c := range copies {
 		if c.mode != startCopy {
@@ -192,6 +198,7 @@ func (a *App) UpdateProfile(req ProfileRequest) (ProfileDTO, error) {
 		profile.ShareSettings = req.StartSettings == startShare
 		profile.ShareSignatures = req.StartSignatures == startShare
 		profile.ShareViews = req.StartViews == startShare
+		profile.ShareLayout = req.StartLayout == startShare
 	}
 	if err := a.store.UpdateProfile(a.ctx, *profile); err != nil {
 		return ProfileDTO{}, err
@@ -318,6 +325,7 @@ func (a *App) toProfileDTO(p storage.Profile) (ProfileDTO, error) {
 		ShareSettings:   p.ShareSettings,
 		ShareSignatures: p.ShareSignatures,
 		ShareViews:      p.ShareViews,
+		ShareLayout:     p.ShareLayout,
 		AccountIDs:      accounts,
 	}, nil
 }

--- a/internal/storage/accounts.go
+++ b/internal/storage/accounts.go
@@ -86,10 +86,24 @@ const LocalAccountName = "Local Folders"
 
 // accountColumns is the select list every account query shares, in the order
 // scanAccount reads them.
-const accountColumns = `id, email, display_name, username, imap_host, imap_port,
-       smtp_host, smtp_port, imap_tls, smtp_tls, created_at, position, is_local,
-       export_on_archive, export_dir, export_subfolders, export_name_template,
-       pgp_default, password_prompt_dismissed, local_label, use_local_label`
+// The sidebar rank comes from the layout join rather than the account row: the
+// order of the sections belongs to a profile (#325), which is also the only
+// place that can see the whole list.
+const accountColumns = `a.id, a.email, a.display_name, a.username, a.imap_host, a.imap_port,
+       a.smtp_host, a.smtp_port, a.imap_tls, a.smtp_tls, a.created_at,
+       coalesce(o.position, 0), a.is_local,
+       a.export_on_archive, a.export_dir, a.export_subfolders, a.export_name_template,
+       a.pgp_default, a.password_prompt_dismissed, a.local_label, a.use_local_label`
+
+// accountFrom joins an account to the active profile's section order. Every
+// query using accountColumns takes the layout profile id as its first argument.
+const accountFrom = `
+FROM accounts a
+LEFT JOIN profile_account_order o ON o.account_id = a.id AND o.profile_id = ?`
+
+// accountOrder puts the sections the user arranged first, then the rest by id,
+// so an install that never reordered keeps creation order.
+const accountOrder = `ORDER BY coalesce(o.position, 0) = 0, o.position, a.id`
 
 // CreateAccount inserts an account and returns its new id. CreatedAt is set to
 // now if the caller left it zero.
@@ -126,9 +140,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 // GetAccount returns one account by id, or ErrAccountNotFound.
 func (d *DB) GetAccount(ctx context.Context, id int64) (*Account, error) {
 	const query = `
-SELECT ` + accountColumns + `
-FROM accounts WHERE id = ?`
-	a, err := scanAccount(d.sql.QueryRowContext(ctx, query, id))
+SELECT ` + accountColumns + accountFrom + `
+WHERE a.id = ?`
+	a, err := scanAccount(d.sql.QueryRowContext(ctx, query, d.layoutProfile(), id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrAccountNotFound
 	}
@@ -142,11 +156,10 @@ FROM accounts WHERE id = ?`
 // reordered first, in that order, then the rest by id.
 func (d *DB) ListAccounts(ctx context.Context) ([]Account, error) {
 	const query = `
-SELECT ` + accountColumns + `
-FROM accounts
-WHERE id IN (SELECT account_id FROM profile_accounts WHERE profile_id = ?)
-ORDER BY position = 0, position, id`
-	return d.listAccounts(ctx, query, d.ScopedProfileID())
+SELECT ` + accountColumns + accountFrom + `
+WHERE a.id IN (SELECT account_id FROM profile_accounts WHERE profile_id = ?)
+` + accountOrder
+	return d.listAccounts(ctx, query, d.layoutProfile(), d.ScopedProfileID())
 }
 
 // ListAllAccounts returns every account on the install, whether or not the
@@ -154,9 +167,9 @@ ORDER BY position = 0, position, id`
 // this; everything else works with what the profile can see.
 func (d *DB) ListAllAccounts(ctx context.Context) ([]Account, error) {
 	const query = `
-SELECT ` + accountColumns + `
-FROM accounts ORDER BY position = 0, position, id`
-	return d.listAccounts(ctx, query)
+SELECT ` + accountColumns + accountFrom + `
+` + accountOrder
+	return d.listAccounts(ctx, query, d.layoutProfile())
 }
 
 func (d *DB) listAccounts(ctx context.Context, query string, args ...any) ([]Account, error) {
@@ -245,7 +258,11 @@ func (d *DB) SetAccountPasswordPromptDismissed(ctx context.Context, id int64, di
 // transaction. Accounts not listed keep their current position. Positions start
 // at 1, since 0 means "never reordered".
 func (d *DB) SetAccountPositions(ctx context.Context, orderedIDs []int64) error {
-	return d.setPositions(ctx, `UPDATE accounts SET position = ? WHERE id = ?`, orderedIDs, "accounts")
+	return d.setLayoutPositions(ctx, `
+INSERT INTO profile_account_order (profile_id, account_id, position)
+VALUES (?1, ?2, ?3)
+ON CONFLICT(profile_id, account_id) DO UPDATE SET position = excluded.position`,
+		orderedIDs, "accounts")
 }
 
 // rowScanner is satisfied by both *sql.Row and *sql.Rows.

--- a/internal/storage/folders.go
+++ b/internal/storage/folders.go
@@ -26,15 +26,25 @@ const (
 const attributeSeparator = " "
 
 // folderColumns is the select list every folder query shares, in the order
-// scanFolder reads them.
-const folderColumns = `id, account_id, name, imap_path, delimiter, parent_id,
-       attributes, uid_validity, position, pinned_position, role_override,
-       sync_excluded`
+// scanFolder reads them. The two ranks come from the layout join below rather
+// than from the folder row: they belong to a profile, not to the install
+// (#325). A folder the profile never arranged has no layout row, and coalesce
+// turns that into 0, which is what "never reordered" has always meant.
+const folderColumns = `f.id, f.account_id, f.name, f.imap_path, f.delimiter, f.parent_id,
+       f.attributes, f.uid_validity,
+       coalesce(l.position, 0), coalesce(l.pinned_position, 0),
+       f.role_override, f.sync_excluded`
+
+// folderFrom joins a folder to the active profile's layout. Every query using
+// folderColumns takes the layout profile id as its first argument.
+const folderFrom = `
+FROM folders f
+LEFT JOIN profile_sidebar_layout l ON l.folder_id = f.id AND l.profile_id = ?`
 
 // folderOrder sorts folders for display: reordered groups first in the order the
 // user chose, then everything untouched in discovery (id) order. In sqlite
 // `position = 0` is 1 for the untouched rows, which is why they sort last.
-const folderOrder = `ORDER BY position = 0, position, id`
+const folderOrder = `ORDER BY coalesce(l.position, 0) = 0, l.position, f.id`
 
 // Folder is one mailbox in an account's hierarchy.
 type Folder struct {
@@ -90,9 +100,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`
 // GetFolder returns one folder by id, or ErrFolderNotFound.
 func (d *DB) GetFolder(ctx context.Context, id int64) (*Folder, error) {
 	const query = `
-SELECT ` + folderColumns + `
-FROM folders WHERE id = ?`
-	f, err := scanFolder(d.sql.QueryRowContext(ctx, query, id))
+SELECT ` + folderColumns + folderFrom + `
+WHERE f.id = ?`
+	f, err := scanFolder(d.sql.QueryRowContext(ctx, query, d.layoutProfile(), id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrFolderNotFound
 	}
@@ -106,9 +116,9 @@ FROM folders WHERE id = ?`
 // user has reordered first, in that order, then the rest by id.
 func (d *DB) ListFolders(ctx context.Context, accountID int64) ([]Folder, error) {
 	const query = `
-SELECT ` + folderColumns + `
-FROM folders WHERE account_id = ? ` + folderOrder
-	rows, err := d.sql.QueryContext(ctx, query, accountID)
+SELECT ` + folderColumns + folderFrom + `
+WHERE f.account_id = ? ` + folderOrder
+	rows, err := d.sql.QueryContext(ctx, query, d.layoutProfile(), accountID)
 	if err != nil {
 		return nil, fmt.Errorf("storage: list folders for account %d: %w", accountID, err)
 	}
@@ -179,11 +189,10 @@ WHERE account_id = ? AND imap_path LIKE ? ESCAPE '\'`
 // so a caller can tear a subtree down parent-last or build it parent-first. The
 // folder itself is not included.
 func (d *DB) FolderDescendants(ctx context.Context, accountID int64, prefix string) ([]Folder, error) {
-	const query = `SELECT ` + folderColumns + `
-FROM folders
-WHERE account_id = ? AND imap_path LIKE ? ESCAPE '\'
-ORDER BY length(imap_path)`
-	rows, err := d.sql.QueryContext(ctx, query, accountID, escapeLike(prefix)+"%")
+	const query = `SELECT ` + folderColumns + folderFrom + `
+WHERE f.account_id = ? AND f.imap_path LIKE ? ESCAPE '\'
+ORDER BY length(f.imap_path)`
+	rows, err := d.sql.QueryContext(ctx, query, d.layoutProfile(), accountID, escapeLike(prefix)+"%")
 	if err != nil {
 		return nil, fmt.Errorf("storage: list folder descendants of %q: %w", prefix, err)
 	}
@@ -206,9 +215,9 @@ ORDER BY length(imap_path)`
 // ListPinnedFolders returns every pinned folder across all accounts in the order
 // the user arranged the Pinned group, shallowest rank first.
 func (d *DB) ListPinnedFolders(ctx context.Context) ([]Folder, error) {
-	const query = `SELECT ` + folderColumns + `
-FROM folders WHERE pinned_position > 0 ORDER BY pinned_position, id`
-	rows, err := d.sql.QueryContext(ctx, query)
+	const query = `SELECT ` + folderColumns + folderFrom + `
+WHERE l.pinned_position > 0 ORDER BY l.pinned_position, f.id`
+	rows, err := d.sql.QueryContext(ctx, query, d.layoutProfile())
 	if err != nil {
 		return nil, fmt.Errorf("storage: list pinned folders: %w", err)
 	}
@@ -233,15 +242,22 @@ FROM folders WHERE pinned_position > 0 ORDER BY pinned_position, id`
 // one sibling group; folders not listed keep their current position. Positions
 // start at 1, since 0 means "never reordered" (see folderOrder).
 func (d *DB) SetFolderPositions(ctx context.Context, orderedIDs []int64) error {
-	return d.setPositions(ctx, `UPDATE folders SET position = ? WHERE id = ?`, orderedIDs, "folders")
+	return d.setLayoutPositions(ctx, `
+INSERT INTO profile_sidebar_layout (profile_id, folder_id, position)
+VALUES (?1, ?2, ?3)
+ON CONFLICT(profile_id, folder_id) DO UPDATE SET position = excluded.position`,
+		orderedIDs, "folders")
 }
 
 // SetPinnedFolderPositions rewrites the order of the Pinned group in one
 // transaction. Every id passed must already be pinned; this only reorders, it
 // does not pin (see SetFolderPinned).
 func (d *DB) SetPinnedFolderPositions(ctx context.Context, orderedIDs []int64) error {
-	return d.setPositions(ctx,
-		`UPDATE folders SET pinned_position = ? WHERE id = ? AND pinned_position > 0`,
+	// no insert here: a folder with no layout row is not pinned, and reordering
+	// must not be a way to pin one.
+	return d.setLayoutPositions(ctx, `
+UPDATE profile_sidebar_layout SET pinned_position = ?3
+WHERE profile_id = ?1 AND folder_id = ?2 AND pinned_position > 0`,
 		orderedIDs, "pinned folders")
 }
 
@@ -250,33 +266,33 @@ func (d *DB) SetPinnedFolderPositions(ctx context.Context, orderedIDs []int64) e
 // reorder closes. Pinning an already-pinned folder (or unpinning an unpinned
 // one) is a no-op rather than an error.
 func (d *DB) SetFolderPinned(ctx context.Context, id int64, pinned bool) error {
+	// a folder the profile never arranged has no layout row at all, so neither
+	// branch below can tell a missing folder from an untouched one. Asking first
+	// keeps a pin against a deleted folder an error rather than a silent no-op.
+	if _, err := d.GetFolder(ctx, id); err != nil {
+		return err
+	}
+	profileID := d.layoutProfile()
 	if !pinned {
-		res, err := d.sql.ExecContext(ctx,
-			`UPDATE folders SET pinned_position = 0 WHERE id = ?`, id)
+		_, err := d.sql.ExecContext(ctx,
+			`UPDATE profile_sidebar_layout SET pinned_position = 0 WHERE profile_id = ? AND folder_id = ?`,
+			profileID, id)
 		if err != nil {
 			return fmt.Errorf("storage: unpin folder %d: %w", id, err)
 		}
-		return requireOneRow(res, ErrFolderNotFound)
+		return nil
 	}
 	// coalesce covers the empty-group case, where max() over no rows is null.
 	const query = `
-UPDATE folders
-SET pinned_position = (SELECT coalesce(max(pinned_position), 0) + 1 FROM folders)
-WHERE id = ? AND pinned_position = 0`
-	res, err := d.sql.ExecContext(ctx, query, id)
-	if err != nil {
+INSERT INTO profile_sidebar_layout (profile_id, folder_id, pinned_position)
+VALUES (?1, ?2, (SELECT coalesce(max(pinned_position), 0) + 1 FROM profile_sidebar_layout WHERE profile_id = ?1))
+ON CONFLICT(profile_id, folder_id) DO UPDATE
+SET pinned_position = (SELECT coalesce(max(pinned_position), 0) + 1 FROM profile_sidebar_layout WHERE profile_id = ?1)
+WHERE pinned_position = 0`
+	// zero rows means it was already pinned here, which the conflict clause
+	// leaves alone rather than moving it to the end of the group.
+	if _, err := d.sql.ExecContext(ctx, query, profileID, id); err != nil {
 		return fmt.Errorf("storage: pin folder %d: %w", id, err)
-	}
-	// zero rows means it was already pinned, which is not a failure. Only a
-	// missing folder is, so confirm the row exists before letting it pass.
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("storage: pin folder rows affected: %w", err)
-	}
-	if n == 0 {
-		if _, err := d.GetFolder(ctx, id); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -305,9 +321,12 @@ func (d *DB) SetFolderSyncExcluded(ctx context.Context, id int64, excluded bool)
 	return requireOneRow(res, ErrFolderNotFound)
 }
 
-// setPositions runs one position-rewriting statement per id inside a single
-// transaction. The statement takes the new position and the id, in that order.
-func (d *DB) setPositions(ctx context.Context, stmt string, orderedIDs []int64, what string) error {
+// setLayoutPositions runs one position-rewriting statement per id inside a
+// single transaction, so a drag persists all at once or not at all. The
+// statement takes the layout profile as ?1, the row id as ?2 and the new
+// position as ?3.
+func (d *DB) setLayoutPositions(ctx context.Context, stmt string, orderedIDs []int64, what string) error {
+	profileID := d.layoutProfile()
 	tx, err := d.sql.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("storage: begin reorder %s: %w", what, err)
@@ -315,7 +334,7 @@ func (d *DB) setPositions(ctx context.Context, stmt string, orderedIDs []int64, 
 	defer tx.Rollback()
 
 	for pos, id := range orderedIDs {
-		if _, err := tx.ExecContext(ctx, stmt, pos+1, id); err != nil {
+		if _, err := tx.ExecContext(ctx, stmt, profileID, id, pos+1); err != nil {
 			return fmt.Errorf("storage: reorder %s, id %d: %w", what, id, err)
 		}
 	}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -34,8 +34,9 @@ func (d *DB) EnsureLocalAccount(ctx context.Context) (Account, error) {
 // nothing has been imported yet. The sidebar shows the section only once this
 // exists, so an install that never imported anything never sees it.
 func (d *DB) LocalAccount(ctx context.Context) (Account, error) {
-	const query = `SELECT ` + accountColumns + ` FROM accounts WHERE is_local = 1 ORDER BY id LIMIT 1`
-	a, err := scanAccount(d.sql.QueryRowContext(ctx, query))
+	const query = `SELECT ` + accountColumns + accountFrom + `
+WHERE a.is_local = 1 ORDER BY a.id LIMIT 1`
+	a, err := scanAccount(d.sql.QueryRowContext(ctx, query, d.layoutProfile()))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Account{}, ErrAccountNotFound
 	}
@@ -49,8 +50,9 @@ func (d *DB) LocalAccount(ctx context.Context) (Account, error) {
 // creating it if it does not exist. Names are matched exactly, so importing
 // twice into the same name appends rather than making a second folder.
 func (d *DB) EnsureLocalFolder(ctx context.Context, accountID int64, name string) (Folder, error) {
-	const query = `SELECT ` + folderColumns + ` FROM folders WHERE account_id = ? AND imap_path = ?`
-	f, err := scanFolder(d.sql.QueryRowContext(ctx, query, accountID, name))
+	const query = `SELECT ` + folderColumns + folderFrom + `
+WHERE f.account_id = ? AND f.imap_path = ?`
+	f, err := scanFolder(d.sql.QueryRowContext(ctx, query, d.layoutProfile(), accountID, name))
 	if err == nil {
 		return *f, nil
 	}

--- a/internal/storage/migrations/0033_profile_sidebar_layout.sql
+++ b/internal/storage/migrations/0033_profile_sidebar_layout.sql
@@ -1,0 +1,51 @@
+-- The sidebar layout follows the profile (#325).
+--
+-- Pinned folders and the order of both folders and account sections were
+-- columns on the rows themselves, so they were one arrangement for the whole
+-- install. Profiles are meant to be separate working contexts, and they
+-- already show different sets of accounts, so an order shared across all of
+-- them orders a list you cannot see the whole of anyway.
+
+-- one row per folder the user has arranged, per profile. A folder nobody
+-- touched has no row and sorts by id, which is what position 0 used to mean.
+CREATE TABLE IF NOT EXISTS profile_sidebar_layout (
+    profile_id INTEGER NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    folder_id INTEGER NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
+    -- rank among siblings in the account tree, from 1.
+    position INTEGER NOT NULL DEFAULT 0,
+    -- rank in the Pinned group, from 1. 0 means not pinned in this profile.
+    pinned_position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (profile_id, folder_id)
+);
+
+-- the same for the account sections.
+CREATE TABLE IF NOT EXISTS profile_account_order (
+    profile_id INTEGER NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (profile_id, account_id)
+);
+
+-- whether this profile reads the main profile's layout instead of its own,
+-- alongside the switches for settings, signatures and views. Off by default:
+-- a new working context arranges itself. A profile that shares keeps its own
+-- rows untouched, so unticking the box brings its arrangement back.
+ALTER TABLE profiles ADD COLUMN share_layout INTEGER NOT NULL DEFAULT 0;
+
+-- every profile starts from the arrangement the install already had, so
+-- nothing looks like it was reset. Only folders and accounts the user actually
+-- moved are copied; the rest have no row and keep sorting by id.
+INSERT INTO profile_sidebar_layout (profile_id, folder_id, position, pinned_position)
+SELECT p.id, f.id, f.position, f.pinned_position
+FROM profiles p, folders f
+WHERE f.position > 0 OR f.pinned_position > 0;
+
+INSERT INTO profile_account_order (profile_id, account_id, position)
+SELECT p.id, a.id, a.position
+FROM profiles p, accounts a
+WHERE a.position > 0;
+
+-- the old columns would be a second, stale answer to the same question.
+ALTER TABLE folders DROP COLUMN position;
+ALTER TABLE folders DROP COLUMN pinned_position;
+ALTER TABLE accounts DROP COLUMN position;

--- a/internal/storage/profilelayout_test.go
+++ b/internal/storage/profilelayout_test.go
@@ -1,0 +1,232 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+// useProfile points the store at a profile the way the app does on a switch.
+func useProfile(t *testing.T, db *DB, p Profile) {
+	t.Helper()
+	main, err := db.MainProfile(context.Background())
+	if err != nil {
+		t.Fatalf("main profile: %v", err)
+	}
+	db.UseProfile(p, main.ID)
+}
+
+// newLayoutProfile creates a second profile and returns it.
+func newLayoutProfile(t *testing.T, db *DB, name string, shareLayout bool) Profile {
+	t.Helper()
+	p := Profile{Name: name, ShareLayout: shareLayout}
+	if _, err := db.CreateProfile(context.Background(), &p); err != nil {
+		t.Fatalf("create profile %q: %v", name, err)
+	}
+	return p
+}
+
+// TestFolderOrderIsPerProfile is what #325 asked for: arranging the sidebar in
+// one profile must not rearrange it in another.
+func TestFolderOrderIsPerProfile(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	accountID, ids := newFolderTestAccount(t, db, "/", "INBOX", "Sent", "Work")
+	if err := db.SetFolderPositions(ctx, []int64{ids["Work"], ids["Sent"], ids["INBOX"]}); err != nil {
+		t.Fatalf("set positions: %v", err)
+	}
+	assertPaths(t, mustListFolders(t, db, accountID), "Work", "Sent", "INBOX")
+
+	other := newLayoutProfile(t, db, "work", false)
+	useProfile(t, db, other)
+	// a profile that never arranged anything is back to discovery order rather
+	// than inheriting the arrangement.
+	assertPaths(t, mustListFolders(t, db, accountID), "INBOX", "Sent", "Work")
+
+	if err := db.SetFolderPositions(ctx, []int64{ids["Sent"], ids["INBOX"], ids["Work"]}); err != nil {
+		t.Fatalf("set positions in second profile: %v", err)
+	}
+	assertPaths(t, mustListFolders(t, db, accountID), "Sent", "INBOX", "Work")
+
+	main, err := db.MainProfile(ctx)
+	if err != nil {
+		t.Fatalf("main profile: %v", err)
+	}
+	useProfile(t, db, *main)
+	assertPaths(t, mustListFolders(t, db, accountID), "Work", "Sent", "INBOX")
+}
+
+// TestPinnedFoldersArePerProfile covers the other half: the Pinned group.
+func TestPinnedFoldersArePerProfile(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	_, ids := newFolderTestAccount(t, db, "/", "INBOX", "Work", "Notes")
+	if err := db.SetFolderPinned(ctx, ids["Work"], true); err != nil {
+		t.Fatalf("pin Work: %v", err)
+	}
+
+	other := newLayoutProfile(t, db, "private", false)
+	useProfile(t, db, other)
+	pinned, err := db.ListPinnedFolders(ctx)
+	if err != nil {
+		t.Fatalf("list pinned: %v", err)
+	}
+	if len(pinned) != 0 {
+		t.Fatalf("second profile has %d pinned folders, want none", len(pinned))
+	}
+
+	if err := db.SetFolderPinned(ctx, ids["Notes"], true); err != nil {
+		t.Fatalf("pin Notes: %v", err)
+	}
+	pinned, err = db.ListPinnedFolders(ctx)
+	if err != nil {
+		t.Fatalf("list pinned: %v", err)
+	}
+	assertPaths(t, pinned, "Notes")
+
+	main, err := db.MainProfile(ctx)
+	if err != nil {
+		t.Fatalf("main profile: %v", err)
+	}
+	useProfile(t, db, *main)
+	pinned, err = db.ListPinnedFolders(ctx)
+	if err != nil {
+		t.Fatalf("list pinned in main: %v", err)
+	}
+	assertPaths(t, pinned, "Work")
+}
+
+// TestAccountOrderIsPerProfile covers the account sections, which move with the
+// folders because profiles already show different sets of accounts.
+func TestAccountOrderIsPerProfile(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	var ids []int64
+	for _, email := range []string{"one@example.com", "two@example.com"} {
+		id, err := db.CreateAccount(ctx, &Account{Email: email})
+		if err != nil {
+			t.Fatalf("create account: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := db.SetAccountPositions(ctx, []int64{ids[1], ids[0]}); err != nil {
+		t.Fatalf("set account positions: %v", err)
+	}
+
+	accounts, err := db.ListAllAccounts(ctx)
+	if err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	if accounts[0].Email != "two@example.com" {
+		t.Fatalf("main accounts[0] = %q, want two@example.com", accounts[0].Email)
+	}
+
+	other := newLayoutProfile(t, db, "work", false)
+	useProfile(t, db, other)
+	accounts, err = db.ListAllAccounts(ctx)
+	if err != nil {
+		t.Fatalf("list accounts in second profile: %v", err)
+	}
+	if accounts[0].Email != "one@example.com" {
+		t.Errorf("second profile accounts[0] = %q, want creation order", accounts[0].Email)
+	}
+}
+
+// TestSharedLayoutReadsMainAndKeepsItsOwn is the share checkbox: while it is
+// on the profile follows main, and its own arrangement is still there when it
+// goes off again.
+func TestSharedLayoutReadsMainAndKeepsItsOwn(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	accountID, ids := newFolderTestAccount(t, db, "/", "INBOX", "Sent", "Work")
+	if err := db.SetFolderPositions(ctx, []int64{ids["Work"], ids["Sent"], ids["INBOX"]}); err != nil {
+		t.Fatalf("set main positions: %v", err)
+	}
+
+	other := newLayoutProfile(t, db, "work", false)
+	useProfile(t, db, other)
+	if err := db.SetFolderPositions(ctx, []int64{ids["Sent"], ids["Work"], ids["INBOX"]}); err != nil {
+		t.Fatalf("set own positions: %v", err)
+	}
+	assertPaths(t, mustListFolders(t, db, accountID), "Sent", "Work", "INBOX")
+
+	other.ShareLayout = true
+	if err := db.UpdateProfile(ctx, other); err != nil {
+		t.Fatalf("share layout: %v", err)
+	}
+	useProfile(t, db, other)
+	assertPaths(t, mustListFolders(t, db, accountID), "Work", "Sent", "INBOX")
+
+	other.ShareLayout = false
+	if err := db.UpdateProfile(ctx, other); err != nil {
+		t.Fatalf("unshare layout: %v", err)
+	}
+	useProfile(t, db, other)
+	assertPaths(t, mustListFolders(t, db, accountID), "Sent", "Work", "INBOX")
+}
+
+// TestCopyProfileLayoutIsASnapshot: a new profile starting from main's layout
+// gets a copy, not a link.
+func TestCopyProfileLayoutIsASnapshot(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	accountID, ids := newFolderTestAccount(t, db, "/", "INBOX", "Sent", "Work")
+	if err := db.SetFolderPositions(ctx, []int64{ids["Work"], ids["Sent"], ids["INBOX"]}); err != nil {
+		t.Fatalf("set main positions: %v", err)
+	}
+	if err := db.SetFolderPinned(ctx, ids["Work"], true); err != nil {
+		t.Fatalf("pin Work: %v", err)
+	}
+
+	main, err := db.MainProfile(ctx)
+	if err != nil {
+		t.Fatalf("main profile: %v", err)
+	}
+	other := newLayoutProfile(t, db, "work", false)
+	if err := db.CopyProfileLayout(ctx, main.ID, other.ID); err != nil {
+		t.Fatalf("copy layout: %v", err)
+	}
+
+	useProfile(t, db, other)
+	assertPaths(t, mustListFolders(t, db, accountID), "Work", "Sent", "INBOX")
+	pinned, err := db.ListPinnedFolders(ctx)
+	if err != nil {
+		t.Fatalf("list pinned: %v", err)
+	}
+	assertPaths(t, pinned, "Work")
+
+	// rearranging the copy leaves main alone.
+	if err := db.SetFolderPositions(ctx, []int64{ids["INBOX"], ids["Sent"], ids["Work"]}); err != nil {
+		t.Fatalf("rearrange copy: %v", err)
+	}
+	useProfile(t, db, *main)
+	assertPaths(t, mustListFolders(t, db, accountID), "Work", "Sent", "INBOX")
+}
+
+// TestDeletedFolderLeavesNoLayoutRow: the layout rows are keyed to folders, so
+// deleting one must not leave a rank behind that a new folder could inherit.
+func TestDeletedFolderLeavesNoLayoutRow(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	_, ids := newFolderTestAccount(t, db, "/", "INBOX", "Work")
+	if err := db.SetFolderPinned(ctx, ids["Work"], true); err != nil {
+		t.Fatalf("pin Work: %v", err)
+	}
+	if err := db.DeleteFolder(ctx, ids["Work"]); err != nil {
+		t.Fatalf("delete folder: %v", err)
+	}
+
+	var rows int
+	if err := db.sql.QueryRowContext(ctx,
+		`SELECT count(*) FROM profile_sidebar_layout WHERE folder_id = ?`, ids["Work"]).Scan(&rows); err != nil {
+		t.Fatalf("count layout rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("deleted folder left %d layout rows, want 0", rows)
+	}
+}

--- a/internal/storage/profiles.go
+++ b/internal/storage/profiles.go
@@ -36,11 +36,16 @@ type Profile struct {
 	ShareSettings   bool
 	ShareSignatures bool
 	ShareViews      bool
-	CreatedAt       time.Time
+	// ShareLayout does the same for the sidebar layout: which folders are
+	// pinned, and the order of folders and account sections. A profile that
+	// shares keeps its own layout rows, unused, so unticking it brings the
+	// arrangement back rather than starting over.
+	ShareLayout bool
+	CreatedAt   time.Time
 }
 
 const profileColumns = `id, name, icon, position, is_main, is_active,
-       share_settings, share_signatures, share_views, created_at`
+       share_settings, share_signatures, share_views, share_layout, created_at`
 
 // ListProfiles returns every profile, main first and the rest by position then
 // id, which is the order the switcher shows them in.
@@ -110,12 +115,12 @@ func (d *DB) MainProfile(ctx context.Context) (*Profile, error) {
 func (d *DB) CreateProfile(ctx context.Context, p *Profile) (int64, error) {
 	const query = `
 INSERT INTO profiles (name, icon, position, is_main, is_active,
-                      share_settings, share_signatures, share_views, created_at)
-VALUES (?, ?, ?, 0, 0, ?, ?, ?, ?)`
+                      share_settings, share_signatures, share_views, share_layout, created_at)
+VALUES (?, ?, ?, 0, 0, ?, ?, ?, ?, ?)`
 	res, err := d.sql.ExecContext(ctx, query,
 		p.Name, p.Icon, p.Position,
 		boolToInt(p.ShareSettings), boolToInt(p.ShareSignatures), boolToInt(p.ShareViews),
-		nowText())
+		boolToInt(p.ShareLayout), nowText())
 	if err != nil {
 		return 0, fmt.Errorf("storage: insert profile %q: %w", p.Name, err)
 	}
@@ -132,12 +137,12 @@ VALUES (?, ?, ?, 0, 0, ?, ?, ?, ?)`
 func (d *DB) UpdateProfile(ctx context.Context, p Profile) error {
 	const query = `
 UPDATE profiles
-SET name = ?, icon = ?, share_settings = ?, share_signatures = ?, share_views = ?
+SET name = ?, icon = ?, share_settings = ?, share_signatures = ?, share_views = ?, share_layout = ?
 WHERE id = ?`
 	res, err := d.sql.ExecContext(ctx, query,
 		p.Name, p.Icon,
 		boolToInt(p.ShareSettings), boolToInt(p.ShareSignatures), boolToInt(p.ShareViews),
-		p.ID)
+		boolToInt(p.ShareLayout), p.ID)
 	if err != nil {
 		return fmt.Errorf("storage: update profile %d: %w", p.ID, err)
 	}
@@ -211,9 +216,11 @@ func (d *DB) SetActiveProfile(ctx context.Context, id int64) error {
 	return nil
 }
 
-// SetProfilePositions rewrites the order the switcher lists profiles in.
+// SetProfilePositions rewrites the order the switcher lists profiles in. The
+// switcher is the one list that is not per profile, for the obvious reason, so
+// this ignores the layout profile the helper passes as ?1.
 func (d *DB) SetProfilePositions(ctx context.Context, orderedIDs []int64) error {
-	return d.setPositions(ctx, `UPDATE profiles SET position = ? WHERE id = ?`, orderedIDs, "profiles")
+	return d.setLayoutPositions(ctx, `UPDATE profiles SET position = ?3 WHERE id = ?2`, orderedIDs, "profiles")
 }
 
 // ProfileAccountIDs returns the accounts a profile shows.
@@ -315,6 +322,29 @@ FROM views WHERE profile_id = ?`
 	return nil
 }
 
+// CopyProfileLayout duplicates one profile's sidebar layout onto another: its
+// pinned folders, its folder order and its account section order. Like the
+// other copies it is a snapshot, so rearranging one afterwards leaves the other
+// alone.
+func (d *DB) CopyProfileLayout(ctx context.Context, from, to int64) error {
+	const folders = `
+INSERT INTO profile_sidebar_layout (profile_id, folder_id, position, pinned_position)
+SELECT ?, folder_id, position, pinned_position FROM profile_sidebar_layout WHERE profile_id = ?
+ON CONFLICT(profile_id, folder_id) DO UPDATE
+SET position = excluded.position, pinned_position = excluded.pinned_position`
+	if _, err := d.sql.ExecContext(ctx, folders, to, from); err != nil {
+		return fmt.Errorf("storage: copy folder layout %d to %d: %w", from, to, err)
+	}
+	const accounts = `
+INSERT INTO profile_account_order (profile_id, account_id, position)
+SELECT ?, account_id, position FROM profile_account_order WHERE profile_id = ?
+ON CONFLICT(profile_id, account_id) DO UPDATE SET position = excluded.position`
+	if _, err := d.sql.ExecContext(ctx, accounts, to, from); err != nil {
+		return fmt.Errorf("storage: copy account order %d to %d: %w", from, to, err)
+	}
+	return nil
+}
+
 func scanProfile(row rowScanner) (*Profile, error) {
 	var (
 		p          Profile
@@ -323,10 +353,11 @@ func scanProfile(row rowScanner) (*Profile, error) {
 		settings   int
 		signatures int
 		views      int
+		layout     int
 		created    string
 	)
 	if err := row.Scan(&p.ID, &p.Name, &p.Icon, &p.Position, &main, &active,
-		&settings, &signatures, &views, &created); err != nil {
+		&settings, &signatures, &views, &layout, &created); err != nil {
 		return nil, err
 	}
 	p.Main = main != 0
@@ -334,6 +365,7 @@ func scanProfile(row rowScanner) (*Profile, error) {
 	p.ShareSettings = settings != 0
 	p.ShareSignatures = signatures != 0
 	p.ShareViews = views != 0
+	p.ShareLayout = layout != 0
 	t, err := parseTime(created)
 	if err != nil {
 		return nil, err

--- a/internal/storage/profilescope.go
+++ b/internal/storage/profilescope.go
@@ -27,6 +27,7 @@ func (d *DB) UseProfile(p Profile, mainID int64) {
 	d.scope.settings.Store(owner(p.ID, mainID, p.ShareSettings))
 	d.scope.signatures.Store(owner(p.ID, mainID, p.ShareSignatures))
 	d.scope.views.Store(owner(p.ID, mainID, p.ShareViews))
+	d.scope.layout.Store(owner(p.ID, mainID, p.ShareLayout))
 }
 
 // UseActiveProfile points the store at whichever profile is marked active. It
@@ -61,6 +62,10 @@ func (d *DB) signaturesProfile() int64 { return orMain(d.scope.signatures.Load()
 
 func (d *DB) viewsProfile() int64 { return orMain(d.scope.views.Load()) }
 
+// layoutProfile owns the sidebar layout rows: which folders are pinned and the
+// order of folders and account sections.
+func (d *DB) layoutProfile() int64 { return orMain(d.scope.layout.Load()) }
+
 // owner picks whose rows an area reads.
 func owner(profileID, mainID int64, shared bool) int64 {
 	if shared {
@@ -87,4 +92,5 @@ type scope struct {
 	settings   atomic.Int64
 	signatures atomic.Int64
 	views      atomic.Int64
+	layout     atomic.Int64
 }


### PR DESCRIPTION
Closes #325.

Pinned folders and the order of folders and account sections were columns on the rows themselves, so there was one arrangement for the whole install. They move into two tables keyed by profile, and the folder and account queries read them through a join scoped to whichever profile the store is pointed at. Switching profile swaps the layout with it, no reload: the switch already re-scopes the store and reloads the sidebar.

Account sections move too, not just folders. Profiles show different sets of accounts, so one order across all of them was ordering a list you never see the whole of.

Every existing profile is seeded with the arrangement the install has today, so nothing looks like it reset. The old columns are dropped rather than left as a second, stale answer.

The profile editor gets a fourth area next to settings, signatures and views, with the same share / copy / fresh choice. New profiles default to a copy of main's layout: their own, but not starting from nothing. Sharing keeps the profile's own rows untouched, so unticking the box brings its arrangement back.

Migration 0033. Tests cover both halves being per profile, the account order, share and unshare, the copy being a snapshot, and a deleted folder leaving no layout row behind.