### PR TITLE
fix: windows notifications showing DefaultAppName and no icon

### DIFF
--- a/build/windows/installer/project.nsi
+++ b/build/windows/installer/project.nsi
@@ -45,6 +45,18 @@ Unicode true
 ####
 !include /NONFATAL "channel.nsh"
 ####
+## The AppUserModelID Pelton posts notifications under. Windows reads the name
+## and icon of a toast from this key, so the app registers it at startup (see
+## internal/desktop/notify_windows.go) rather than leaving it to the installer,
+## which would strand portable builds and every copy installed before that
+## change. The uninstaller removes it. Must match notifyAppName on the Go side.
+####
+!ifdef PELTON_NIGHTLY
+    !define PELTON_AUMID "Pelton Nightly"
+!else
+    !define PELTON_AUMID "Pelton"
+!endif
+####
 ## Include the wails tools
 ####
 !include "wails_tools.nsh"
@@ -245,6 +257,12 @@ Section "uninstall"
 
     !insertmacro wails.unassociateFiles
     !insertmacro wails.unassociateCustomProtocols
+
+    ; the notification registration Pelton writes at startup. Always HKCU, so
+    ; this only clears it for the account running the uninstaller; an all-users
+    ; install leaves the other accounts' keys behind, which are three inert
+    ; strings pointing at an executable that is gone.
+    DeleteRegKey HKCU "Software\Classes\AppUserModelId\${PELTON_AUMID}"
 
     !insertmacro wails.deleteUninstaller
 SectionEnd

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -67,7 +67,7 @@
   import { liabilityAccepted } from './lib/liability'
   import { setDemoActive } from './lib/demo'
   import { recordArchived } from './stores/undoarchive'
-  import { onMailNew, onMailRepaired, onSyncState, onSyncProgress, onOutboxChanged, onMenu, onViewsChanged, onProfileChanged, onMailtoCompose, onAgentProposals, type Unsubscribe, type MailtoDraft } from './lib/events'
+  import { onMailNew, onMailRepaired, onSyncState, onSyncProgress, onOutboxChanged, onMenu, onViewsChanged, onProfileChanged, onMailtoCompose, onAgentProposals, onOpenMessage, type Unsubscribe, type MailtoDraft } from './lib/events'
   import { loadViews, editingView, closeViewEditor, openViewEditor, views as savedViews } from './stores/views'
   import { selectSavedView } from './stores/selection'
   import { isMac } from './lib/i18n'
@@ -103,7 +103,7 @@
   import { previewTarget } from './stores/preview'
   import { openMove, openMoveMany } from './stores/move'
   import { selectedIds, clearSelection } from './stores/listselect'
-  import { selectFolder, selectView } from './stores/selection'
+  import { selectFolder, selectView, revealMessage } from './stores/selection'
   import { setTheme, setThemeId } from './stores/prefs'
   import { openCreateFolder, openRenameFolder, openDeleteFolder, openEmptyTrash } from './stores/folderdialog'
   import { setFolderPinned, listThemes } from './lib/api'
@@ -385,6 +385,11 @@
     unsubscribers.push(onMenu(handleMenu))
     // a mailto: link opened while the app is already running.
     unsubscribers.push(onMailtoCompose((draft) => openMailtoDraft(draft)))
+    // a clicked new-mail notification. the window is already back up by the
+    // time this arrives; all that is left is to go to the message.
+    unsubscribers.push(
+      onOpenMessage((e) => revealMessage(e.messageId, e.accountId, e.folderId, get(sidebar).data ?? null)),
+    )
 
     // a mailto: link that launched the app: the backend stashed it, so pick it
     // up now that the sidebar (and any accounts) have loaded. onboarding, if

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -22,6 +22,7 @@ export const EventNames = {
   profileChanged: 'profile:changed',
   importProgress: 'import:progress',
   agentProposals: 'agent:proposals',
+  openMessage: 'message:open',
 } as const
 
 // payloads, mirroring the go event structs.
@@ -134,6 +135,15 @@ export interface MailtoDraft {
   body: string
 }
 
+// OpenMessageEvent asks the ui to show one specific message, which today only
+// happens when a new-mail notification is clicked. The folder travels with it
+// so the list can move to where the message lives first.
+export interface OpenMessageEvent {
+  messageId: number
+  accountId: number
+  folderId: number
+}
+
 // Unsubscribe removes an event listener.
 export type Unsubscribe = () => void
 
@@ -220,4 +230,10 @@ export function onProfileChanged(cb: () => void): Unsubscribe {
 // or discarded, so the approval queue matches what is stored.
 export function onAgentProposals(cb: () => void): Unsubscribe {
   return EventsOn(EventNames.agentProposals, () => cb())
+}
+
+// onOpenMessage fires when something outside the ui asks for one message to be
+// shown. Today that is a clicked new-mail notification on Windows.
+export function onOpenMessage(cb: (e: OpenMessageEvent) => void): Unsubscribe {
+  return EventsOn(EventNames.openMessage, (e: OpenMessageEvent) => cb(e))
 }

--- a/frontend/src/stores/selection.ts
+++ b/frontend/src/stores/selection.ts
@@ -135,3 +135,23 @@ export function selectFolder(folder: Folder): void {
 export function openMessage(id: number): void {
   openMessageId.set(id)
 }
+
+// revealMessage moves the list to where a message lives and then opens it. It
+// is for requests that arrive from outside the ui, where the list is very
+// likely showing something else: a clicked new-mail notification is the only
+// one today. A folder that is not in the sidebar (removed since, or belonging
+// to an account this profile does not see) leaves the list where it is and just
+// opens the message, which is still what was asked for.
+export function revealMessage(
+  messageId: number,
+  accountId: number,
+  folderId: number,
+  data: SidebarData | null,
+): void {
+  const folder = data?.foldersByAccount[accountId]?.find((f) => f.id === folderId)
+  if (folder) {
+    // selectFolder clears the open message, so it has to happen first.
+    selectFolder(folder)
+  }
+  openMessage(messageId)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TRC-Loop/Pelton
 go 1.25.0
 
 require (
+	git.sr.ht/~jackmordaunt/go-toast v1.1.2
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/VirusTotal/vt-go v1.1.0
@@ -33,7 +34,6 @@ require (
 )
 
 require (
-	git.sr.ht/~jackmordaunt/go-toast v1.1.2 // indirect
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/JohannesKaufmann/dom v0.3.1 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.14.5 // indirect

--- a/internal/desktop/events.go
+++ b/internal/desktop/events.go
@@ -66,7 +66,19 @@ const (
 	// so the frontend reloads its preferences, sidebar, list and views rather
 	// than trying to patch them.
 	EventProfileChanged = "profile:changed"
+	// EventOpenMessage fires when something outside the ui asks for a specific
+	// message to be shown, which today means a clicked new-mail notification.
+	// It carries the folder as well as the message so the list can move to
+	// where the message actually lives rather than opening it out of context.
+	EventOpenMessage = "message:open"
 )
+
+// OpenMessageEvent is the payload for EventOpenMessage.
+type OpenMessageEvent struct {
+	MessageID int64 `json:"messageId"`
+	AccountID int64 `json:"accountId"`
+	FolderID  int64 `json:"folderId"`
+}
 
 // DownloadProgressEvent is the payload for EventDownloadProgress. Running is
 // false on the final event (done, cancelled, or failed); Error is set on failure.

--- a/internal/desktop/notify.go
+++ b/internal/desktop/notify.go
@@ -1,6 +1,7 @@
 package desktop
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/TRC-Loop/Pelton/internal/storage"
@@ -8,11 +9,54 @@ import (
 
 // Native OS notifications for new mail (#126). Delivery is per platform:
 // UserNotifications on macOS so the alert carries the app's own icon (#143),
-// and beeep elsewhere for a Windows toast or a Linux dbus notification. Neither
-// has a per-notification click callback, so a click does not open a specific
-// message; exact click-to-open would need more platform-specific code and is
-// tracked separately. Notifications only fire for INBOX so sent/archived mail
-// moved by a sync never notifies.
+// go-toast on Windows so the toast carries Pelton's name, icon and a click that
+// opens the message (#170), and beeep on Linux for a dbus notification.
+// Notifications only fire for INBOX so sent/archived mail moved by a sync never
+// notifies.
+
+// notifyAppName is the application name notifications are posted under. On
+// Linux it is the dbus app_name; on Windows it is the AppUserModelID, which is
+// also what the toast prints under itself. beeep defaults it to the literal
+// string "DefaultAppName", which is what Pelton's notifications used to be
+// labelled with everywhere (#170).
+const notifyAppName = "Pelton"
+
+// notification is one OS notification waiting to be delivered. The message id
+// travels with it so a platform that can report a click back (Windows) knows
+// which message the click was about.
+type notification struct {
+	title     string
+	body      string
+	messageID int64
+}
+
+// notifyArgPrefix marks a notification's activation argument as a message id.
+// The OS hands the string back verbatim on a click, so a prefix keeps a second
+// kind of notification, if there ever is one, from being read as a message.
+const notifyArgPrefix = "message:"
+
+// notifyArgs encodes which message a notification is about into the string the
+// OS hands back when it is clicked; notifyMessageID reads it back. The two
+// halves live together because nothing else checks they agree: get them out of
+// step and every click quietly opens nothing.
+func notifyArgs(messageID int64) string {
+	return notifyArgPrefix + strconv.FormatInt(messageID, 10)
+}
+
+// notifyMessageID reads a message id back out of an activation argument. ok is
+// false for anything else, including an empty string, which is what a click on
+// a toast from an older version arrives as.
+func notifyMessageID(args string) (int64, bool) {
+	rest, found := strings.CutPrefix(args, notifyArgPrefix)
+	if !found {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
 
 // notifyStrings holds the localizable text of a new-mail notification. Like the
 // native menu (see menu_i18n.go), notifications are built in the Go process, so
@@ -81,7 +125,7 @@ func (a *App) notifyNewMail(folder storage.Folder, ids []int64) {
 		if vip {
 			title = s.vipNewMail
 		}
-		a.sendNotification(title, notifyBody(m, s))
+		a.sendNotification(notification{title: title, body: notifyBody(m, s), messageID: m.ID})
 	}
 }
 
@@ -104,9 +148,34 @@ func notifyBody(m *storage.Message, s notifyStrings) string {
 
 // sendNotification raises one native OS notification, logging (not failing) on
 // error so a notification backend that is missing or busy never disrupts sync.
-// The delivery itself is per platform: see notify_darwin.go and notify_other.go.
-func (a *App) sendNotification(title, body string) {
-	if err := deliverNotification(title, body); err != nil {
+// The delivery itself is per platform: see notify_darwin.go, notify_windows.go
+// and notify_other.go.
+func (a *App) sendNotification(n notification) {
+	if err := a.deliverNotification(n); err != nil {
 		a.log.Warn("notify", "err", err)
 	}
+}
+
+// openFromNotification brings the window up and opens the message a clicked
+// notification was about. Only Windows can report a click back today; the other
+// two backends have no per-notification callback at all.
+//
+// The message is looked up rather than trusted: by the time a toast is clicked
+// it may have been deleted, moved, or left behind by a profile switch. Any of
+// those just show the window, which is what the click asked for first.
+func (a *App) openFromNotification(messageID int64) {
+	a.showWindow()
+	if a.store == nil {
+		return
+	}
+	m, err := a.store.GetMessage(a.ctx, messageID)
+	if err != nil {
+		a.log.Warn("open the message a notification was about", "id", messageID, "err", err)
+		return
+	}
+	a.emit(EventOpenMessage, OpenMessageEvent{
+		MessageID: m.ID,
+		AccountID: m.AccountID,
+		FolderID:  m.FolderID,
+	})
 }

--- a/internal/desktop/notify_darwin.go
+++ b/internal/desktop/notify_darwin.go
@@ -88,14 +88,19 @@ import (
 // the old path and so keep the wrong icon. Delivery is asynchronous once handed over, so
 // a rejected authorization or a failed post is not reported back here; a
 // notification is not worth failing a sync over.
-func deliverNotification(title, body string) error {
+//
+// No click callback is wired up, so the message id on the notification goes
+// unused here; that would need a UNUserNotificationCenter delegate on the
+// bundle, which is its own piece of work.
+func (a *App) deliverNotification(n notification) error {
 	if !bool(C.peltonCanNotify()) {
-		return beeep.Notify(title, body, "")
+		beeep.AppName = notifyAppName
+		return beeep.Notify(n.title, n.body, "")
 	}
 
-	cTitle := C.CString(title)
+	cTitle := C.CString(n.title)
 	defer C.free(unsafe.Pointer(cTitle))
-	cBody := C.CString(body)
+	cBody := C.CString(n.body)
 	defer C.free(unsafe.Pointer(cBody))
 
 	C.peltonNotify(cTitle, cBody)

--- a/internal/desktop/notify_other.go
+++ b/internal/desktop/notify_other.go
@@ -1,13 +1,19 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package desktop
 
 import "github.com/gen2brain/beeep"
 
-// deliverNotification raises one OS notification through beeep: a toast on
-// Windows, dbus on Linux. Both take the icon from the running executable, so
-// neither needs the platform-specific handling macOS does (see
-// notify_darwin.go).
-func deliverNotification(title, body string) error {
-	return beeep.Notify(title, body, "")
+// deliverNotification raises one OS notification through beeep, which on Linux
+// is a dbus notification. The icon comes from the running executable's desktop
+// file, so there is no icon to hand over here, but the app name is not
+// something beeep can work out: left alone it sends its own "DefaultAppName"
+// placeholder as the dbus app_name (#170).
+//
+// beeep has no per-notification click callback, so the message id on the
+// notification goes unused here. macOS and Windows have their own backends
+// (notify_darwin.go, notify_windows.go).
+func (a *App) deliverNotification(n notification) error {
+	beeep.AppName = notifyAppName
+	return beeep.Notify(n.title, n.body, "")
 }

--- a/internal/desktop/notify_test.go
+++ b/internal/desktop/notify_test.go
@@ -1,0 +1,80 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+func notifyTestMessage(name, address, subject string) *storage.Message {
+	return &storage.Message{FromName: name, FromAddress: address, Subject: subject}
+}
+
+// The two halves of the click argument are the whole of click-to-open (#170):
+// Windows hands back exactly what was put on the toast, and nothing else checks
+// that the writer and the reader still agree.
+func TestNotifyArgsRoundTrip(t *testing.T) {
+	for _, id := range []int64{1, 42, 9007199254740993} {
+		got, ok := notifyMessageID(notifyArgs(id))
+		if !ok {
+			t.Errorf("notifyMessageID(%q) refused its own encoding", notifyArgs(id))
+			continue
+		}
+		if got != id {
+			t.Errorf("round trip of %d = %d", id, got)
+		}
+	}
+}
+
+// A click Pelton cannot place must be reported as such rather than as message
+// zero: the caller opens the window and stops, instead of looking up a message
+// that does not exist.
+func TestNotifyMessageIDRejectsAnythingElse(t *testing.T) {
+	for _, args := range []string{
+		"",
+		"message:",
+		"message:nope",
+		"message:0",
+		"message:-3",
+		"12",
+		"compose:12",
+		" message:12",
+	} {
+		if id, ok := notifyMessageID(args); ok {
+			t.Errorf("notifyMessageID(%q) = %d, true; want it refused", args, id)
+		}
+	}
+}
+
+// The body is what the user actually reads, and both halves of it come from
+// headers a sender controls and can leave empty.
+func TestNotifyBodyFallsBackToPlaceholders(t *testing.T) {
+	s := notifyStringsFor("en")
+
+	full := notifyBody(notifyTestMessage("Arne Kock", "arne@example.com", "Potato harvest"), s)
+	if full != "Arne Kock\nPotato harvest" {
+		t.Errorf("body = %q", full)
+	}
+
+	noName := notifyBody(notifyTestMessage("", "arne@example.com", "Potato harvest"), s)
+	if noName != "arne@example.com\nPotato harvest" {
+		t.Errorf("body without a display name = %q, want the address", noName)
+	}
+
+	empty := notifyBody(notifyTestMessage("", "", ""), s)
+	if empty != s.fromUnknown+"\n"+s.noSubject {
+		t.Errorf("body of an empty message = %q, want both placeholders", empty)
+	}
+}
+
+// An unknown or missing language must not produce a blank notification.
+func TestNotifyStringsForFallsBackToEnglish(t *testing.T) {
+	for _, lang := range []string{"", "tlh", "de-CH"} {
+		if got := notifyStringsFor(lang); got.newMail != notifyLocales["en"].newMail {
+			t.Errorf("notifyStringsFor(%q).newMail = %q, want the english fallback", lang, got.newMail)
+		}
+	}
+	if got := notifyStringsFor("de"); got.newMail != notifyLocales["de"].newMail {
+		t.Error("a known language did not get its own table")
+	}
+}

--- a/internal/desktop/notify_windows.go
+++ b/internal/desktop/notify_windows.go
@@ -1,0 +1,127 @@
+//go:build windows
+
+package desktop
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"git.sr.ht/~jackmordaunt/go-toast"
+)
+
+// Windows notifications (#170). A toast does not carry a name or an icon of its
+// own: Windows looks both up from the AppUserModelID the toast was posted
+// under. An id nothing has registered gets the placeholder treatment, which is
+// how Pelton's toasts came to read "DefaultAppName" next to a grey grid - that
+// really is the string beeep posts under when nobody sets beeep.AppName.
+//
+// Registering the id is one write under HKCU\SOFTWARE\Classes\AppUserModelId,
+// and it is also what makes a click reach us: the same key holds the
+// CustomActivator that Windows calls back through. beeep exposes none of that,
+// so Windows talks to go-toast directly rather than through it.
+//
+// This is deliberately not left to the installer. A portable build, a dev run
+// and every copy installed before this change would all be left with the
+// placeholder, and none of them are reinstalling to fix a notification. The
+// uninstaller still removes the key (see build/windows/installer/project.nsi),
+// so an uninstall leaves nothing behind.
+
+// notifyIconFile is the icon written into the data directory for the registry
+// to point at. The .ico is only ever embedded in the binary, and IconUri needs
+// a path, so it is unpacked once and left there.
+const notifyIconFile = "notification.ico"
+
+// Toast setup is process-wide because the registry and go-toast's activation
+// callback are process-wide. There is exactly one App per process, so a
+// package-level once is the honest shape for it.
+var (
+	toastOnce  sync.Once
+	toastAppID string
+	toastIcon  string
+	toastExe   string
+)
+
+// prepareToasts registers the app id, unpacks the icon and wires the click
+// callback, once per run. Everything it does is idempotent, and go-toast skips
+// a registry write when the value is already there, so on every launch after
+// the first this is a few registry reads.
+func (a *App) prepareToasts() {
+	toastOnce.Do(func() {
+		// the registry DisplayName is set from the app id, so this string is
+		// what the user reads under the toast. Nightlies register their own for
+		// the same reason they carry their own tray icon: a nightly toast should
+		// never look like it came from the real install.
+		toastAppID = notifyAppName
+		if a.IsNightly() {
+			toastAppID = notifyAppName + " Nightly"
+		}
+		toastExe, _ = os.Executable()
+		toastIcon = a.unpackNotifyIcon()
+
+		toast.SetActivationCallback(a.toastActivated)
+
+		// no GUID: go-toast computes the CLSID key path from its default
+		// activator GUID at package init, so a custom one would register the
+		// activator under a path Windows never looks at.
+		if err := toast.SetAppData(toast.AppData{
+			AppID:         toastAppID,
+			IconPath:      toastIcon,
+			ActivationExe: toastExe,
+		}); err != nil {
+			// the toast still shows, it just shows under the placeholder name.
+			a.log.Warn("register the notification app id", "err", err)
+		}
+	})
+}
+
+// unpackNotifyIcon writes the embedded icon into the data directory and returns
+// its path, or "" when there is nothing to write or nowhere to write it. An
+// empty path means the toast goes out without an icon rather than not at all.
+func (a *App) unpackNotifyIcon() string {
+	if len(a.trayIcon) == 0 || a.dataDir == "" {
+		return ""
+	}
+	path := filepath.Join(a.dataDir, notifyIconFile)
+	// rewritten on every first-notification of a run rather than only when
+	// missing, so a build whose icon changed does not keep showing the old one.
+	if err := os.WriteFile(path, a.trayIcon, 0o600); err != nil {
+		a.log.Warn("write the notification icon", "path", path, "err", err)
+		return ""
+	}
+	return path
+}
+
+// toastActivated runs when a toast is clicked, on a callback goroutine of
+// go-toast's making. args is whatever was put on the notification.
+func (a *App) toastActivated(args string, _ []toast.UserData) {
+	id, ok := notifyMessageID(args)
+	if !ok {
+		// a click we cannot place still asked for Pelton, so bring it up.
+		a.showWindow()
+		return
+	}
+	a.openFromNotification(id)
+}
+
+// deliverNotification raises one Windows toast.
+//
+// Foreground activation is what enables the click callback at all; without it
+// Windows has nothing to invoke and a click only dismisses the toast. The audio
+// is silenced on purpose, matching macOS: what Pelton should make a noise about
+// is its own question (#240).
+func (a *App) deliverNotification(n notification) error {
+	a.prepareToasts()
+	t := toast.Notification{
+		AppID:               toastAppID,
+		Title:               n.title,
+		Body:                n.body,
+		Icon:                toastIcon,
+		ActivationType:      toast.Foreground,
+		ActivationArguments: notifyArgs(n.messageID),
+		ActivationExe:       toastExe,
+		Audio:               toast.Silent,
+		Duration:            toast.Short,
+	}
+	return t.Push()
+}


### PR DESCRIPTION
Fixes #170.

A Windows toast has no name or icon of its own. Windows looks both up from the
AppUserModelID the toast was posted under, and an id nobody has registered gets
the placeholder treatment. Pelton never set one, so every toast went out under
beeep's default, which is literally the string "DefaultAppName".

Registering the id is one key under HKCU\SOFTWARE\Classes\AppUserModelId, and
it is also what makes a click reach us, since the same key holds the activator
Windows calls back through. beeep exposes none of that, so Windows now talks to
go-toast directly instead of through beeep. macOS and Linux are unchanged apart
from setting the app name, which Linux was also sending as "DefaultAppName" on
dbus.

Clicking a toast now brings the window up, moves the list to the folder the
message is in, and opens it. The message is looked up rather than trusted, so
one that has since been deleted or moved out of the profile just opens the
window.

The app registers the key at startup rather than the installer doing it,
otherwise portable builds, dev runs and every copy installed before this change
would be stuck with the placeholder and would have to reinstall to fix a
notification. The uninstaller removes the key. Nightlies register their own
"Pelton Nightly" so a nightly toast is not mistaken for the real install, the
same reason they already carry their own tray icon.

The icon is unpacked out of the binary into the data directory, because the
registry needs a path and the .ico is only ever embedded.

Tested: build, vet, tests on macOS, cross-compile for windows and linux,
svelte-check 0/0, frontend build. The Windows behaviour itself I cannot test
from here, so the toast name, the icon and the click all want a look on your PC.

Happy to add a docs page on notifications if you want one, but I have not
written one.
