### PR TITLE
fix: snooze picker placement, toasts behind modals, search bar wrapping

### DIFF
--- a/frontend/src/components/common/DateTimePicker.svelte
+++ b/frontend/src/components/common/DateTimePicker.svelte
@@ -188,8 +188,28 @@
     const vh = window.innerHeight / scale
     const maxLeft = vw - panelW - margin
     const maxTop = vh - panelH - margin
-    panelLeft = Math.min(Math.max(triggerLeft, margin), Math.max(margin, maxLeft))
-    panelTop = Math.min(Math.max(triggerBottom + 4, margin), Math.max(margin, maxTop))
+    const wantLeft = Math.min(Math.max(triggerLeft, margin), Math.max(margin, maxLeft))
+    const wantTop = Math.min(Math.max(triggerBottom + 4, margin), Math.max(margin, maxTop))
+    panelLeft = wantLeft
+    panelTop = wantTop
+
+    // `position: fixed` is only relative to the viewport while no ancestor has
+    // a transform. Modal and the snooze dialog both centre with
+    // translate(-50%, -50%), which makes the dialog the containing block, so
+    // the coordinates above get re-anchored to its top-left corner and the
+    // panel lands half a dialog away - off screen entirely in the snooze
+    // dialog (#170 follow-up). Rather than forbid transforms on every dialog
+    // that might ever hold a picker, measure where the panel actually ended up
+    // and shift it by the difference. The correction is zero when there is no
+    // transformed ancestor, so the common case is unchanged.
+    await tick()
+    const placed = panelEl.getBoundingClientRect()
+    const offLeft = placed.left / scale - wantLeft
+    const offTop = placed.top / scale - wantTop
+    if (Math.abs(offLeft) > 0.5 || Math.abs(offTop) > 0.5) {
+      panelLeft = wantLeft - offLeft
+      panelTop = wantTop - offTop
+    }
   }
 
   // weekday header letters, monday-first; the reference week (2023-01-02 was

--- a/frontend/src/components/common/Toasts.svelte
+++ b/frontend/src/components/common/Toasts.svelte
@@ -55,7 +55,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-    z-index: 200;
+    /* above the whole modal band. Modals layer from 300 upwards (300 + depth *
+       4, see Modal.svelte), so a toast at 200 sat behind the blurred backdrop
+       of any open dialog - and a dialog is exactly where an error toast is
+       most likely to be raised, which made the error invisible. */
+    z-index: 600;
     padding: var(--space-5);
     pointer-events: none;
   }

--- a/frontend/src/components/detail/SnoozeDialog.svelte
+++ b/frontend/src/components/detail/SnoozeDialog.svelte
@@ -85,7 +85,14 @@
     if (!target || busy) {
       return
     }
-    if (when.getTime() <= Date.now()) {
+    // the picker only offers minute granularity, so a time picked inside the
+    // current minute comes back with :00 seconds and reads as a few seconds
+    // ago. Comparing against the start of the current minute is what makes
+    // "in three minutes" behave like three minutes rather than being rejected
+    // for being in the past.
+    const thisMinute = new Date()
+    thisMinute.setSeconds(0, 0)
+    if (when.getTime() <= thisMinute.getTime()) {
       toastError($t('detail.snooze.pickFutureTime'))
       return
     }

--- a/frontend/src/components/list/SearchBar.svelte
+++ b/frontend/src/components/list/SearchBar.svelte
@@ -199,6 +199,10 @@
     clearTimeout(timer)
     text = ''
     chips = []
+    // the popover's own pickers, or reopening it offers the dates that were
+    // just cleared as though they were still applied.
+    afterDate = ''
+    beforeDate = ''
     dispatch('search', '')
     dispatch('filter', { ...emptyFilter })
   }
@@ -352,10 +356,19 @@
     flex: 1;
     min-width: 0;
     display: flex;
-    flex-wrap: wrap;
+    /* one row, always. A before: and an after: chip together are wider than
+       the field, and wrapping made the whole search bar grow a second line and
+       shove the list down. Chips scroll sideways instead. */
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
     align-items: center;
     gap: var(--space-1);
     padding: 3px 0;
+  }
+
+  .field::-webkit-scrollbar {
+    display: none;
   }
 
   .chip {

--- a/frontend/src/stores/messages.ts
+++ b/frontend/src/stores/messages.ts
@@ -323,9 +323,19 @@ function searchPage(
 // query and the structured chip constraints.
 export async function runSearch(query: string, filter: SearchFilter = emptyFilter): Promise<void> {
   currentSearch = { query, filter }
+  // the same generation guard every other loader here uses. Without it a search
+  // that resolves after the list has moved on writes its results over whatever
+  // is showing now: clearing the search bar fires both a query change and a
+  // filter change, so the old filtered search and the fresh folder load are in
+  // flight together, and the search landing second put the list back into a
+  // result set nobody had asked for.
+  const generation = ++loadGeneration
   messageList.update((s) => loading(s))
   try {
     const { messages, total } = await searchPage(query, filter, 0)
+    if (generation !== loadGeneration) {
+      return
+    }
     // search runs over the local index, so backfilling older mail from the
     // server is not part of it: hasOlder stays false and the list shows no
     // "load older" affordance on a result set.
@@ -342,6 +352,9 @@ export async function runSearch(query: string, filter: SearchFilter = emptyFilte
       }),
     )
   } catch (err) {
+    if (generation !== loadGeneration) {
+      return
+    }
     messageList.set(failed(errorMessage(err)))
   }
 }

--- a/internal/desktop/window.go
+++ b/internal/desktop/window.go
@@ -6,10 +6,15 @@ import wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 // tray, by the single-instance handler (a second launch surfaces the running
 // window), and by the macOS mailto url handler. A nil context means the webview
 // is not up yet, so there is nothing to show.
+//
+// Show before unminimise: a window hidden by close-to-tray is hidden, not
+// minimised, and unminimising a hidden window on Windows can leave it mapped
+// but never painted.
 func (a *App) showWindow() {
 	if a.ctx == nil {
 		return
 	}
-	wailsruntime.WindowUnminimise(a.ctx)
 	wailsruntime.WindowShow(a.ctx)
+	wailsruntime.WindowUnminimise(a.ctx)
+	bringToFront(a.ctx)
 }

--- a/internal/desktop/window_other.go
+++ b/internal/desktop/window_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package desktop
+
+import "context"
+
+// bringToFront is a no-op away from Windows. macOS and the Linux window
+// managers both raise a window that is shown, and forcing always-on-top there
+// would reorder Pelton against other applications for no reason. See
+// window_windows.go for why Windows needs the nudge.
+func bringToFront(context.Context) {}

--- a/internal/desktop/window_windows.go
+++ b/internal/desktop/window_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package desktop
+
+import (
+	"context"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// bringToFront raises the window above every other application.
+//
+// WindowShow maps the window but does not necessarily raise it. Windows refuses
+// to let a process that does not own the foreground steal it, and when a second
+// launch surfaces the running instance the caller is the new process while the
+// window belongs to the old one, so nothing comes forward: double-clicking the
+// desktop icon with Pelton in the tray appeared to do nothing at all.
+//
+// Making the window topmost and immediately dropping it back goes through
+// SetWindowPos, which has no such restriction, and leaves the z-order with
+// Pelton on top. There is no always-on-top preference for this to fight with.
+func bringToFront(ctx context.Context) {
+	wailsruntime.WindowSetAlwaysOnTop(ctx, true)
+	wailsruntime.WindowSetAlwaysOnTop(ctx, false)
+}


### PR DESCRIPTION
Six things you found before the nightly.

**Snooze date picker opened off screen.** The picker panel is position: fixed and
clamped to the viewport, but Modal and the snooze dialog both centre with
translate(-50%, -50%), and a transformed ancestor becomes the containing block
for a fixed child. So the clamped coordinates were re-anchored to the dialog's
corner and the panel flew off. It now measures where it actually landed and
shifts by the difference, which is a no-op when there is no transform, so every
other picker is unchanged. This affected pickers in any modal, not just snooze.

**Three minutes in the future was rejected as being in the past.** The picker has
minute granularity, so a time in the current minute arrives with :00 seconds and
is a few seconds behind now. The check compares against the start of the current
minute instead.

**Error toasts appeared behind the blurred backdrop.** Toasts were at z-index 200
and modals layer from 300 up, so an error raised from inside a dialog was
invisible, which is exactly where errors get raised. Toasts are at 600 now.

**Search bar grew a second line.** A before: and an after: chip together are wider
than the field and it was set to wrap, so the bar got taller and pushed the list
down. Chips stay on one row and scroll sideways.

**Clearing the search left the select-all checkbox behind.** The real cause was a
stale write: runSearch was the only loader in messages.ts without the generation
guard the others all have. Clearing the bar fires a query change and a filter
change, so the old filtered search and the new folder load were in flight
together, and the search landing second put the list back into a result set.
Guarded now. Also clears the popover's own date pickers.

**Double-clicking the desktop icon did nothing with Pelton in the tray on
Windows.** WindowShow maps the window but Windows will not let a process that
does not own the foreground raise it, and on a second launch the caller is the
new process while the window belongs to the old one. A brief always-on-top
toggle goes through SetWindowPos, which has no such restriction. Windows only;
no-op elsewhere.

Tested: build, vet, tests, windows and linux cross-compiles, windows vet,
svelte-check 0/0, frontend build. The Windows and snooze behaviour want your
eyes since I cannot click them here.
