### PR TITLE
chore: stamp 2026.4 in the appstream release history

### DIFF
--- a/build/linux/pelton.metainfo.xml
+++ b/build/linux/pelton.metainfo.xml
@@ -77,6 +77,6 @@
   </screenshots>
 
   <releases>
-    <release version="2026.3.3" date="2026-08-08" />
+    <release version="2026.4" date="2026-08-27" />
   </releases>
 </component>


### PR DESCRIPTION
The deb and rpm jobs copy build/linux/pelton.metainfo.xml verbatim (release.yml:409), so without this the Linux packages for v2026.4 advertise 2026.3.3 to GNOME Software and Discover. Only the flatpak job rewrites the version from the tag.

Worth automating the same way for the deb and rpm, but I am not touching the release workflow minutes before running it. Filing that separately.