### PR TITLE
fix: keep the draft release tagged when updating its notes

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -156,7 +156,20 @@ jobs:
             const existing = releases.find((r) => r.tag_name === CURRENT_TAG) || null;
 
             if (existing) {
-              await github.rest.repos.updateRelease({ owner, repo, release_id: existing.id, body });
+              // tag_name and name are resent even though only the body changed.
+              // Updating a draft without them drops the draft's tag, leaving it
+              // as "untagged-<hash>", and then `gh release upload <tag>` cannot
+              // find it: that is how the 2026.4 linux assets failed to upload
+              // with "release not found" while macos and windows, which ran
+              // before the changelog step, succeeded.
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: existing.id,
+                tag_name: CURRENT_TAG,
+                name: existing.name || CURRENT_TAG,
+                body,
+              });
             } else {
               await github.rest.repos.createRelease({
                 owner, repo, tag_name: CURRENT_TAG, name: CURRENT_TAG, body, draft: true,


### PR DESCRIPTION
updateRelease with only a body drops a draft's tag, so it becomes untagged-<hash>. `gh release upload <tag>` then fails with "release not found", which is how the 2026.4 linux assets were lost while macos and windows, uploading before the changelog step ran, succeeded. Resending tag_name and name keeps it.