### PR TITLE
fix: build the flatpak with the wails desktop and production tags

### DIFF
--- a/packaging/flatpak/sh.arne.Pelton.yml
+++ b/packaging/flatpak/sh.arne.Pelton.yml
@@ -66,7 +66,13 @@ modules:
       # The tag is read from the VERSION file the release workflow puts in the
       # tarball, so a version bump here is only ever the url and its checksum
       # and the external data checker can do it unattended.
-      - go build -tags webkit2_41 -ldflags "-s -w -X main.version=$(cat VERSION)" -o pelton .
+      # desktop and production are the tags `wails build` adds on its own; this
+      # manifest calls go build directly so it has to add them itself. Without
+      # production, wails links in a stub whose Run() only returns "Wails
+      # applications will not build without the correct build tags", so the
+      # build succeeds and the app fails at launch.
+      - go build -tags desktop,production,webkit2_41 -ldflags "-s -w -X
+        main.version=$(cat VERSION)" -o pelton .
       - install -Dm755 pelton /app/bin/pelton
       - install -Dm644 build/icons/pelton-512.png
         /app/share/icons/hicolor/512x512/apps/sh.arne.Pelton.png


### PR DESCRIPTION
The flatpak built but would not launch: `Wails applications will not build without the correct build tags`.

`wails build` adds `desktop` (its output type) and `production` on top of any user tags. The manifest calls `go build` directly so it builds offline, so it has to add them itself. With neither, wails links internal/app/app_default_unix.go, a stub whose Run() only returns that error.

Caught building the manifest locally before submitting, so the flathub branch never carried it into review.