### PR TITLE
ops: added nix flake for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ frontend/package.json.md5
 /Pelton
 /Pelton.exe
 
+# nix build output symlink(s) (`nix build`, `packaging/nix/package.nix`)
+/result
+/result-*
+
 .DS_Store
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,windows,linux,go,node,visualstudiocode

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Pelton - email client (Wails + Svelte)
 
-.PHONY: build build-mac build-win build-linux dmg run run-nightly app-dev dev clean tidy deps licenses icon disclaimer
+.PHONY: build build-mac build-win build-linux build-nix dmg run run-nightly app-dev dev clean tidy deps licenses icon disclaimer
 
 # version string injected into the binary. it prefers the latest git tag (with a
 # short commit suffix on untagged commits) and falls back to "dev". it is wired
@@ -49,6 +49,11 @@ build-linux:
 	wails build -platform linux/amd64 -ldflags "$(LDFLAGS)"
 	cp build/linux/pelton.desktop build/bin/pelton.desktop
 	@echo "linux binary + pelton.desktop in build/bin (install the .desktop and an icon named 'pelton')"
+
+# nix packaging build: same as build-linux but tagged for nixpkgs'
+# webkitgtk_4_1 (nixpkgs dropped the older webkit2gtk 4.0 build)
+build-nix:
+	wails build -tags webkit2_41 -ldflags "$(LDFLAGS)" -o pelton
 
 # run the whole app in dev mode: make sure go + npm deps are present, regenerate
 # the typescript bindings from the go methods, then launch wails dev with hot

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,16 +43,17 @@ Every release ships builds for macOS, Windows and Linux on the [GitHub releases 
 
 === "Nix (flakes)"
 
-    Pelton ships a flake. With flakes enabled:
+    Pelton ships a flake. Point it at a release tag, not the bare repo, or
+    you will get unreleased code off the default branch:
 
     ```sh
-    nix run github:TRC-Loop/Pelton
+    nix run github:TRC-Loop/Pelton/v<version>
     ```
 
     or into your profile, for a `pelton` on `$PATH` and a desktop entry:
 
     ```sh
-    nix profile install github:TRC-Loop/Pelton
+    nix profile install github:TRC-Loop/Pelton/v<version>
     ```
 
     The underlying derivation also lives at `packaging/nix/package.nix` for

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,6 +41,24 @@ Every release ships builds for macOS, Windows and Linux on the [GitHub releases 
 
     You will not get automatic updates this way; download the next release yourself or enable the update check in Settings, which compares versions against the GitHub releases API and nothing else.
 
+=== "Nix (flakes)"
+
+    Pelton ships a flake. With flakes enabled:
+
+    ```sh
+    nix run github:TRC-Loop/Pelton
+    ```
+
+    or into your profile, for a `pelton` on `$PATH` and a desktop entry:
+
+    ```sh
+    nix profile install github:TRC-Loop/Pelton
+    ```
+
+    The underlying derivation also lives at `packaging/nix/package.nix` for
+    anyone who would rather `callPackage` it into their own nixpkgs-based
+    config. Linux only for now.
+
 ## Build from source
 
 You need Go, Node with pnpm, and the Wails CLI matching the version pinned in `go.mod`:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Pelton, a privacy-focused cross-platform desktop email client";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      version =
+        if self ? shortRev then
+          "2026.4+${self.shortRev}"
+        else
+          "2026.4+dirty${toString (self.lastModifiedDate or "unknown")}";
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          pelton = pkgs.callPackage ./packaging/nix/package.nix {
+            src = self;
+            inherit version;
+          };
+          default = self.packages.${system}.pelton;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        pelton = {
+          type = "app";
+          program = "${self.packages.${system}.pelton}/bin/pelton";
+        };
+        default = self.apps.${system}.pelton;
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.pelton ];
+            packages = with pkgs; [
+              go
+              gopls
+              pnpm_10
+              nodejs_22
+              wails
+            ];
+          };
+        }
+      );
+    };
+}

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -7,6 +7,7 @@
   pnpm_10,
   nodejs_22,
   wails,
+  gnumake,
   pkg-config,
   gtk3,
   webkitgtk_4_1,
@@ -30,7 +31,7 @@ buildGoModule (finalAttrs: {
 
   overrideModAttrs = {
     preBuild = ''
-      wails build -tags webkit2_41 -o pelton
+      make build-nix VERSION=${finalAttrs.version}
     '';
   };
 
@@ -40,6 +41,7 @@ buildGoModule (finalAttrs: {
     pnpm_10
     nodejs_22
     wails
+    gnumake
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     wrapGAppsHook3
@@ -67,7 +69,7 @@ buildGoModule (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    wails build -tags webkit2_41 -ldflags "-X main.version=${finalAttrs.version}" -o pelton
+    make build-nix VERSION=${finalAttrs.version}
 
     runHook postBuild
   '';
@@ -78,8 +80,8 @@ buildGoModule (finalAttrs: {
     runHook preInstall
 
     install -Dm755 build/bin/pelton $out/bin/pelton
-    install -Dm644 build/linux/pelton.desktop $out/share/applications/sh.arne.Pelton.desktop
-    install -Dm644 build/linux/pelton.metainfo.xml $out/share/metainfo/sh.arne.Pelton.metainfo.xml
+    install -Dm644 build/linux/pelton.desktop $out/share/applications/pelton.desktop
+    install -Dm644 build/linux/pelton.metainfo.xml $out/share/metainfo/pelton.metainfo.xml
     install -Dm644 build/icons/pelton-512.png $out/share/icons/hicolor/512x512/apps/pelton.png
 
     runHook postInstall
@@ -94,7 +96,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Privacy-focused, cross-platform desktop email client";
     homepage = "https://pelton.app";
-    changelog = "https://github.com/TRC-Loop/Pelton/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/TRC-Loop/Pelton/releases/tag/v${lib.head (lib.splitString "+" finalAttrs.version)}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     mainProgram = "pelton";

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs_22,
+  wails,
+  pkg-config,
+  gtk3,
+  webkitgtk_4_1,
+  glib-networking,
+  gsettings-desktop-schemas,
+  wrapGAppsHook3,
+  makeWrapper,
+  src ? lib.cleanSource ../..,
+  version ? "2026.4",
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pelton";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-+Hj1Oqw0Kr2EWSkZ1QxFMAY01WfEUgg5GanGkB8vjS8=";
+
+  overrideModAttrs = {
+    preBuild = ''
+      wails build -tags webkit2_41 -o pelton
+    '';
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    pnpmConfigHook
+    pnpm_10
+    nodejs_22
+    wails
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook3
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3
+    webkitgtk_4_1
+    glib-networking
+    gsettings-desktop-schemas
+  ];
+
+  env = {
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version;
+      src = "${finalAttrs.src}/frontend";
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      hash = "sha256-L/fNU53DCWv9fNyiQFD6VjiDjocx0vW61tMzQ8wiO20=";
+    };
+    pnpmRoot = "frontend";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    wails build -tags webkit2_41 -ldflags "-X main.version=${finalAttrs.version}" -o pelton
+
+    runHook postBuild
+  '';
+
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 build/bin/pelton $out/bin/pelton
+    install -Dm644 build/linux/pelton.desktop $out/share/applications/sh.arne.Pelton.desktop
+    install -Dm644 build/linux/pelton.metainfo.xml $out/share/metainfo/sh.arne.Pelton.metainfo.xml
+    install -Dm644 build/icons/pelton-512.png $out/share/icons/hicolor/512x512/apps/pelton.png
+
+    runHook postInstall
+  '';
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --set GIO_EXTRA_MODULES "${glib-networking}/lib/gio/modules"
+    )
+  '';
+
+  meta = {
+    description = "Privacy-focused, cross-platform desktop email client";
+    homepage = "https://pelton.app";
+    changelog = "https://github.com/TRC-Loop/Pelton/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "pelton";
+  };
+})


### PR DESCRIPTION
Self-explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a Nix flake for Pelton.
- Added Nix packages and applications for `x86_64-linux` and `aarch64-linux`.
- Added a Nix development shell with Go, Wails, Node.js, and pnpm.
- Added a `buildGoModule` package definition with Linux runtime dependencies and desktop integration.
- Documented `nix run` and `nix profile install`.
- Ignored Nix build output links in `.gitignore`.

## AI assistance

AI assistance is **Probably** likely. The change summaries use consistent, highly structured wording, but the available data does not show direct evidence of AI-generated comments, agent files, or commit attribution. The PR does not appear to be 100% agentic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->