### PR TITLE
chore: change emails to @pelton.app addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-pelton@arne.sh.
+conduct@pelton.app.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The first release of a quarter (INCR `0`) drops the trailing `.0`, so it reads a
 ## <img src="https://api.iconify.design/tabler/messages.svg?color=white" width="26" style="vertical-align: -4px;"> Contact & Community
 
 * **Discord:** Join the discussion at [discord.gg/UzPNGZYy6V](https://discord.gg/UzPNGZYy6V)
-* **Email:** Reach out directly via [pelton@arne.sh](mailto:pelton@arne.sh)
+* **Email:** Reach out directly via [contact@pelton.app](mailto:contact@pelton.app)
 
 ## <img src="https://api.iconify.design/tabler/users.svg?color=white" width="26" style="vertical-align: -4px;"> Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Two ways, either is fine:
 
 - [Open a private security advisory](https://github.com/TRC-Loop/Pelton/security/advisories/new)
   on GitHub.
-- Email <pelton@arne.sh> with `security` in the subject.
+- Email <security@pelton.app>.
 
 Please include, as far as you can:
 


### PR DESCRIPTION
Moves the project contact addresses off arne.sh.

README now points at contact@pelton.app, SECURITY.md at security@pelton.app and CODE_OF_CONDUCT.md at conduct@pelton.app. Also dropped the "with `security` in the subject" note, which is redundant now that the address itself says it.

Same change as #360, cherry-picked onto main so the published docs carry the new addresses without waiting on the rest of dev.
