### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every path is owned by the maintainer, so any pull request gets a review
+# request automatically. Later, more specific lines win over earlier ones, so
+# anything added below this must be narrower than the catch-all.
+* @TRC-Loop


### PR DESCRIPTION
Adds a catch-all CODEOWNERS so every pull request gets a review request without anyone having to remember to add one.

One line, the whole tree. Anything more specific added later has to go below the catch-all to take effect, which the comment in the file notes.
