### PR TITLE
ci: build and test every pull request

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,10 @@ name: Checks
 # frontend type check went in with a green tick and only surfaced when someone
 # built by hand or when release.yml failed.
 #
+# main.go embeds all:frontend/dist, so nothing in Go compiles until the frontend
+# has been built. The frontend job therefore runs first and hands its dist to
+# the three Go jobs as an artifact, rather than each of them running vite again.
+#
 # Deliberately not here:
 #   * gofmt. Several files carry pre-existing drift (internal/desktop/bind_pgp.go,
 #     internal/desktop/bind_settings.go, internal/desktop/run.go,
@@ -42,75 +46,11 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Linux build, vet and the whole test suite. webkit2_41 matches what the
-  # release and nightly workflows build Linux with, so this compiles the same
-  # code path they do.
-  # ---------------------------------------------------------------------------
-  backend:
-    name: Go build, vet and test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      # the desktop package links against gtk and webkit through cgo, so the
-      # headers have to be present even to type-check it.
-      - name: Install system build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
-
-      - name: Build
-        run: go build -tags webkit2_41 ./...
-
-      - name: Vet
-        run: go vet -tags webkit2_41 ./...
-
-      - name: Test
-        run: go test -tags webkit2_41 ./internal/...
-
-  # ---------------------------------------------------------------------------
-  # Windows compiles from Linux because the Windows backend is pure Go
-  # (go-webview2), no cgo and no toolchain needed. macOS does need cgo and a
-  # real SDK, so it gets its own runner.
-  # ---------------------------------------------------------------------------
-  cross-windows:
-    name: Windows compile
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build for windows
-        env:
-          GOOS: windows
-          GOARCH: amd64
-          CGO_ENABLED: "0"
-        run: go build ./...
-
-  cross-darwin:
-    name: macOS compile
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Build for darwin
-        run: go build ./...
-
-  # ---------------------------------------------------------------------------
   # svelte-check has to come out clean. The type check is the only thing that
   # catches a broken hand-maintained wails binding, since those files are
   # written by hand and nothing generates or verifies them.
+  #
+  # This job also produces the dist the Go jobs embed.
   # ---------------------------------------------------------------------------
   frontend:
     name: Svelte check and build
@@ -136,3 +76,94 @@ jobs:
 
       - name: Build
         run: pnpm --dir frontend run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Linux build, vet and the whole test suite. webkit2_41 matches what the
+  # release and nightly workflows build Linux with, so this compiles the same
+  # code path they do.
+  # ---------------------------------------------------------------------------
+  backend:
+    name: Go build, vet and test
+    runs-on: ubuntu-latest
+    needs: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      # the desktop package links against gtk and webkit through cgo, so the
+      # headers have to be present even to type-check it.
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+
+      - name: Build
+        run: go build -tags webkit2_41 ./...
+
+      - name: Vet
+        run: go vet -tags webkit2_41 ./...
+
+      - name: Test
+        run: go test -tags webkit2_41 ./internal/...
+
+  # ---------------------------------------------------------------------------
+  # Windows compiles from Linux because the Windows backend is pure Go
+  # (go-webview2), no cgo and no toolchain needed. macOS does need cgo and a
+  # real SDK, so it gets its own runner.
+  # ---------------------------------------------------------------------------
+  cross-windows:
+    name: Windows compile
+    runs-on: ubuntu-latest
+    needs: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Build for windows
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+        run: go build ./...
+
+  cross-darwin:
+    name: macOS compile
+    runs-on: macos-latest
+    needs: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Build for darwin
+        run: go build ./...

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,138 @@
+name: Checks
+
+# Builds and tests every pull request, so a break is caught before it reaches
+# dev rather than at release time.
+#
+# Until this existed the only thing running on a pull request was CodeQL, which
+# scans but never compiles: nothing ran `go build`, `go test` or `svelte-check`
+# before a merge. A pull request that broke the Windows cross-compile or the
+# frontend type check went in with a green tick and only surfaced when someone
+# built by hand or when release.yml failed.
+#
+# Deliberately not here:
+#   * gofmt. Several files carry pre-existing drift (internal/desktop/bind_pgp.go,
+#     internal/desktop/bind_settings.go, internal/desktop/run.go,
+#     internal/storage/messages.go), so a formatting gate would fail on day one
+#     for reasons unrelated to whatever is being reviewed. Worth adding after a
+#     one-off `gofmt -w` pass.
+#   * `wails build`. The CLI rewrites go.mod when its version does not match the
+#     pinned one, and the three release workflows already cover the real
+#     packaged builds. `go build` with the same tags proves the code compiles,
+#     which is what a pull request needs to know.
+
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+# A second push to the same pull request cancels the previous run rather than
+# queueing behind it.
+concurrency:
+  group: checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.25"
+  NODE_VERSION: "20"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Linux build, vet and the whole test suite. webkit2_41 matches what the
+  # release and nightly workflows build Linux with, so this compiles the same
+  # code path they do.
+  # ---------------------------------------------------------------------------
+  backend:
+    name: Go build, vet and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # the desktop package links against gtk and webkit through cgo, so the
+      # headers have to be present even to type-check it.
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev build-essential pkg-config
+
+      - name: Build
+        run: go build -tags webkit2_41 ./...
+
+      - name: Vet
+        run: go vet -tags webkit2_41 ./...
+
+      - name: Test
+        run: go test -tags webkit2_41 ./internal/...
+
+  # ---------------------------------------------------------------------------
+  # Windows compiles from Linux because the Windows backend is pure Go
+  # (go-webview2), no cgo and no toolchain needed. macOS does need cgo and a
+  # real SDK, so it gets its own runner.
+  # ---------------------------------------------------------------------------
+  cross-windows:
+    name: Windows compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build for windows
+        env:
+          GOOS: windows
+          GOARCH: amd64
+          CGO_ENABLED: "0"
+        run: go build ./...
+
+  cross-darwin:
+    name: macOS compile
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build for darwin
+        run: go build ./...
+
+  # ---------------------------------------------------------------------------
+  # svelte-check has to come out clean. The type check is the only thing that
+  # catches a broken hand-maintained wails binding, since those files are
+  # written by hand and nothing generates or verifies them.
+  # ---------------------------------------------------------------------------
+  frontend:
+    name: Svelte check and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm --dir frontend run check
+
+      - name: Build
+        run: pnpm --dir frontend run build


### PR DESCRIPTION
Adds a Checks workflow that builds and tests every pull request.

Until now the only thing running on a pull request was CodeQL, which scans but never compiles. Nothing ran `go build`, `go test` or `svelte-check` before a merge, so a change that broke the Windows cross-compile or the frontend type check could go in with a green tick and only surface at release time.

Four jobs: Go build, vet and the full test suite on Linux with the webkit2_41 tag the release builds use; a Windows compile, which works from Linux because the Windows backend is pure Go; a macOS compile, which needs its own runner for cgo; and svelte-check plus the frontend build.

Two things left out on purpose, both noted in the file. There is no gofmt gate, because several files carry pre-existing formatting drift and it would fail on day one for unrelated reasons. And it runs `go build` rather than `wails build`, since the CLI rewrites go.mod when its version does not match the pinned one, and the release workflows already cover the packaged builds.

Verified locally before opening: build, vet, the test suite, the Windows cross-compile and svelte-check all pass clean.
