### PR TITLE
fix: search paging can repeat and skip messages

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -173,6 +173,13 @@ func (i *Index) Search(q Query) (Results, error) {
 	}
 
 	req := bleve.NewSearchRequestOptions(i.build(q), limit, offset, false)
+	// Score alone is not a total order. Equal scores are the normal case, not an
+	// edge case: every message in a thread shares a subject, and a newsletter
+	// scores the same every month. Bleve's order among equal scores is not
+	// stable between queries, so paging by offset could return one message on
+	// two pages and never return another at all. Date breaks the tie the way a
+	// mail client should, and the document id makes the order total.
+	req.SortBy([]string{"-_score", "-date", "_id"})
 	res, err := i.idx.Search(req)
 	if err != nil {
 		return Results{}, fmt.Errorf("search: query %q: %w", q.Text, err)


### PR DESCRIPTION
Search ranked by relevance score alone, which is not a total order. Equal scores are the normal case rather than an edge case: every message in a thread shares a subject, and a newsletter scores the same every month.

Bleve's order among equally scored hits is not stable between queries, so paging by offset could return the same message on page one and page two while never returning another one at all. On a mailbox with a lot of similar mail that means a search result you scroll through is quietly wrong.

The fix is a total order: score first, then date so the tie breaks the way a mail client should, then the document id so there is always a deterministic last resort.

This is what made TestOffsetPagesThroughResults flaky. It builds thirty messages with identical subjects, so every score ties and the missing tiebreaker shows up directly. Ran it 25 times in a row clean after the change, and the rest of the search suite three times over to confirm the new ordering did not move anything else.
