### PR TITLE
fix: select can be followed by no mailbox selected

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/emersion/go-imap/v2"
@@ -94,6 +95,32 @@ type Client struct {
 	raw     *imapclient.Client
 	cfg     Config
 	updates chan MailboxUpdate
+
+	// selected is the mailbox Select last opened, guarded because the caller
+	// and go-imap's reader goroutine both touch it.
+	//
+	// go-imap's own Client.Mailbox() cannot be used for this. completeCommand
+	// closes the channel that unblocks Wait() before it assigns the client's
+	// mailbox, so Select().Wait() can return while Mailbox() is still nil and
+	// the very next call reports "no mailbox selected". The window is small but
+	// a sync selects a mailbox and fetches from it immediately, which is
+	// exactly the pattern that loses the race.
+	selectedMu sync.Mutex
+	selected   *Mailbox
+}
+
+// selectedMailbox returns the mailbox Select opened, or nil when none is open.
+func (c *Client) selectedMailbox() *Mailbox {
+	c.selectedMu.Lock()
+	defer c.selectedMu.Unlock()
+	return c.selected
+}
+
+// setSelectedMailbox records what Select opened.
+func (c *Client) setSelectedMailbox(m *Mailbox) {
+	c.selectedMu.Lock()
+	defer c.selectedMu.Unlock()
+	c.selected = m
 }
 
 // Addr is the server this client is connected to, as host:port. Sync puts it in

--- a/internal/imap/expunge.go
+++ b/internal/imap/expunge.go
@@ -98,7 +98,7 @@ func (c *Client) expungeAll() error {
 // searchDeleted returns the uids currently carrying \Deleted in the selected
 // mailbox.
 func (c *Client) searchDeleted() ([]imap.UID, error) {
-	if c.raw.Mailbox() == nil {
+	if c.selectedMailbox() == nil {
 		return nil, fmt.Errorf("imap: no mailbox selected")
 	}
 	criteria := &imap.SearchCriteria{Flag: []imap.Flag{imap.FlagDeleted}}

--- a/internal/imap/fetch.go
+++ b/internal/imap/fetch.go
@@ -78,20 +78,25 @@ func (c *Client) Select(mailbox string) (*Mailbox, error) {
 	// go-imap encodes non-ASCII names as modified UTF-7 when needed
 	data, err := c.raw.Select(mailbox, nil).Wait()
 	if err != nil {
+		c.setSelectedMailbox(nil)
 		return nil, fmt.Errorf("imap: select %q: %w", mailbox, err)
 	}
-	return &Mailbox{
+	m := &Mailbox{
 		Name:        mailbox,
 		NumMessages: data.NumMessages,
 		UIDNext:     data.UIDNext,
 		UIDValidity: data.UIDValidity,
-	}, nil
+	}
+	// recorded from the response we already hold rather than read back off the
+	// client afterwards, which is racy. See Client.selected.
+	c.setSelectedMailbox(m)
+	return m, nil
 }
 
 // FetchRecentHeaders returns up to limit recent messages, newest first. No
 // bodies are fetched, so it stays cheap on large mailboxes.
 func (c *Client) FetchRecentHeaders(limit int) ([]MessageHeader, error) {
-	mbox := c.raw.Mailbox()
+	mbox := c.selectedMailbox()
 	if mbox == nil {
 		return nil, fmt.Errorf("imap: no mailbox selected")
 	}
@@ -260,7 +265,7 @@ func (c *Client) FetchRawMessage(uid imap.UID) ([]byte, error) {
 // mailboxes CONDSTORE would let us ask only for what changed since last sync,
 // but a full compare is correct and is enough for now.
 func (c *Client) FetchAllFlags() ([]MessageHeader, error) {
-	mbox := c.raw.Mailbox()
+	mbox := c.selectedMailbox()
 	if mbox == nil {
 		return nil, fmt.Errorf("imap: no mailbox selected")
 	}

--- a/internal/imap/move.go
+++ b/internal/imap/move.go
@@ -25,7 +25,7 @@ func (c *Client) MoveMessages(uids []imap.UID, mailbox string) error {
 	if len(uids) == 0 {
 		return nil
 	}
-	if c.raw.Mailbox() == nil {
+	if c.selectedMailbox() == nil {
 		return fmt.Errorf("imap: no mailbox selected for move")
 	}
 	if c.raw.Caps().Has(imap.CapMove) {

--- a/internal/imap/search.go
+++ b/internal/imap/search.go
@@ -11,7 +11,7 @@ import (
 // header matches messageID. It backs undo-archive: after a move the message has a
 // new UID in the destination, so we relocate it by its stable rfc Message-ID.
 func (c *Client) SearchByMessageID(messageID string) ([]imap.UID, error) {
-	if c.raw.Mailbox() == nil {
+	if c.selectedMailbox() == nil {
 		return nil, fmt.Errorf("imap: no mailbox selected for search")
 	}
 	if messageID == "" {
@@ -32,7 +32,7 @@ func (c *Client) SearchByMessageID(messageID string) ([]imap.UID, error) {
 // walks a date range and fetches whatever is not cached yet. A mailbox must be
 // selected first.
 func (c *Client) SearchSince(since time.Time) ([]imap.UID, error) {
-	if c.raw.Mailbox() == nil {
+	if c.selectedMailbox() == nil {
 		return nil, fmt.Errorf("imap: no mailbox selected for search")
 	}
 	criteria := &imap.SearchCriteria{Since: since}


### PR DESCRIPTION
Selecting a mailbox and then using it could fail with "imap: no mailbox selected", even though the select had just succeeded.

The cause is in go-imap. Its `completeCommand` sends and closes the channel that unblocks `Wait()` before the switch further down assigns `c.mailbox` and moves the connection to the selected state. So `Select(...).Wait()` can return while `Client.Mailbox()` is still nil, and whatever runs next loses the race. Six places read that value: both fetch paths, expunge, move and the two search entry points.

The window is small, but a sync selects a folder and immediately fetches from it, which is exactly the pattern that hits it. It showed up as a flaky test, `TestDeleteMessagesLargeMixedBatch`, which selects and fetches sixty times in a row and so hits the window far more often than normal use does.

Select already receives everything it needs in the response it waits on, so the fix is to record the mailbox from that rather than reading it back off the client afterwards. A failed select clears it. The six readers use the recorded value.

Verified with the package at -count=60 and under -race, plus the full internal suite.
