### PR TITLE
fix: opening a folder or a crash report does nothing

### DIFF
--- a/internal/desktop/bind_locales.go
+++ b/internal/desktop/bind_locales.go
@@ -186,8 +186,7 @@ func (a *App) OpenLocalesFolder() error {
 	if err != nil {
 		return err
 	}
-	wailsruntime.BrowserOpenURL(a.ctx, "file://"+dir)
-	return nil
+	return openPath(dir)
 }
 
 // SaveLocaleTemplate writes a translation template (built by the frontend

--- a/internal/desktop/bind_logs.go
+++ b/internal/desktop/bind_logs.go
@@ -7,8 +7,6 @@ import (
 	"runtime"
 	"strings"
 
-	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
-
 	"github.com/TRC-Loop/Pelton/internal/logging"
 )
 
@@ -71,8 +69,7 @@ func (a *App) OpenLogFolder() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	wailsruntime.BrowserOpenURL(a.ctx, "file://"+dir)
-	return nil
+	return openPath(dir)
 }
 
 // OpenCrashReport opens the pending crash file in whatever the system opens
@@ -83,7 +80,9 @@ func (a *App) OpenCrashReport() error {
 	if !ok {
 		return errNoCrashReport
 	}
-	wailsruntime.BrowserOpenURL(a.ctx, "file://"+crash.Path)
+	if err := openPath(crash.Path); err != nil {
+		return err
+	}
 	return logging.AcknowledgeCrashes(dir)
 }
 

--- a/internal/desktop/bind_pdf.go
+++ b/internal/desktop/bind_pdf.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 // Exporting a message as a pdf. Wails v2 exposes no print or pdf api, and the
@@ -55,8 +53,7 @@ func (a *App) ExportMessagePrintView(id int64) error {
 	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
 		return fmt.Errorf("pelton: write print view: %w", err)
 	}
-	runtime.BrowserOpenURL(a.ctx, "file://"+path)
-	return nil
+	return openPath(path)
 }
 
 // printMeta is the header block shown above the body in the print view.

--- a/internal/desktop/bind_themes.go
+++ b/internal/desktop/bind_themes.go
@@ -330,6 +330,5 @@ func (a *App) OpenThemesFolder() error {
 	if err != nil {
 		return err
 	}
-	wailsruntime.BrowserOpenURL(a.ctx, "file://"+dir)
-	return nil
+	return openPath(dir)
 }

--- a/internal/desktop/openpath.go
+++ b/internal/desktop/openpath.go
@@ -1,0 +1,49 @@
+package desktop
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// errNothingToOpen means no path was resolved, so there is nothing to hand the
+// desktop.
+var errNothingToOpen = errors.New("pelton: there is nothing to open")
+
+// openPath asks the desktop to open a file or folder: a folder lands in the
+// file manager, a file in whatever application handles its type. The
+// invocation itself is built per platform in openpath_<os>.go, and arguments go
+// through argv rather than a shell, so a path with spaces needs no escaping.
+//
+// wailsruntime.BrowserOpenURL cannot do this. Wails runs every url it is handed
+// through a validator that rejects the file scheme outright, so a
+// "file://"+path call logs "Invalid URL" to Wails' own logger and returns,
+// leaving the button dead with nothing for Pelton to report. Every platform
+// takes that path, so it is not one desktop misbehaving.
+func openPath(path string) error {
+	if path == "" {
+		return errNothingToOpen
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("pelton: open %q: %w", path, err)
+	}
+	// checked here rather than left to the launcher, which reports a missing
+	// path as a bare exit code long after this call has returned.
+	if _, err := os.Stat(abs); err != nil {
+		return fmt.Errorf("pelton: open %q: %w", abs, err)
+	}
+	cmd, err := openCommand(abs)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("pelton: open %q: %w", abs, err)
+	}
+	// the launcher hands the path to the real application and exits. reap it in
+	// the background so it leaves no zombie and the caller is not left waiting
+	// on a file manager that may take a moment to appear.
+	go func() { _ = cmd.Wait() }()
+	return nil
+}

--- a/internal/desktop/openpath_darwin.go
+++ b/internal/desktop/openpath_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package desktop
+
+import "os/exec"
+
+// open is macOS's launcher: a folder opens in Finder, a file in the
+// application registered for its type.
+func openCommand(path string) (*exec.Cmd, error) {
+	return exec.Command("open", path), nil
+}

--- a/internal/desktop/openpath_linux.go
+++ b/internal/desktop/openpath_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package desktop
+
+import "os/exec"
+
+// xdg-open is the desktop-agnostic launcher, and inside a flatpak sandbox it is
+// the portal shim, so the packaged build opens the same folders as the plain
+// binary without a separate path.
+func openCommand(path string) (*exec.Cmd, error) {
+	return exec.Command("xdg-open", path), nil
+}

--- a/internal/desktop/openpath_other.go
+++ b/internal/desktop/openpath_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin && !linux && !windows
+
+package desktop
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// Any other platform has no launcher Pelton knows how to call, so the buttons
+// that reveal a folder report that instead of appearing to work.
+func openCommand(string) (*exec.Cmd, error) {
+	return nil, errors.New("pelton: opening a folder is not supported on this platform")
+}

--- a/internal/desktop/openpath_test.go
+++ b/internal/desktop/openpath_test.go
@@ -1,0 +1,25 @@
+package desktop
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenPathRejectsAnEmptyPath(t *testing.T) {
+	if err := openPath(""); !errors.Is(err, errNothingToOpen) {
+		t.Fatalf("openPath(%q) = %v, want errNothingToOpen", "", err)
+	}
+}
+
+// A path that is not there has to come back as an error the ui can show. The
+// call this replaced could not fail at all: wails dropped the url and the
+// button simply went dead.
+func TestOpenPathReportsAPathThatIsNotThere(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "gone")
+	err := openPath(missing)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("openPath(%q) = %v, want a not-exist error", missing, err)
+	}
+}

--- a/internal/desktop/openpath_windows.go
+++ b/internal/desktop/openpath_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package desktop
+
+import "os/exec"
+
+// explorer is the shell's own launcher and takes both folders and files. It is
+// run directly rather than through "cmd /c start", which would put the path
+// through the command interpreter.
+func openCommand(path string) (*exec.Cmd, error) {
+	return exec.Command("explorer", path), nil
+}


### PR DESCRIPTION
Buttons that reveal a folder or open a file did nothing. Opening the log
folder, opening a crash report, opening the themes or locales folder, and
exporting a message as a PDF all failed silently, with no error and no window.

The cause is the same in every case. Wails validates every URL it is handed and
refuses the `file` scheme outright, so passing it a `file://` path is dropped
before it reaches the desktop. Nothing came back to Pelton to report, which is
why the buttons looked dead rather than broken. This affects Linux, macOS and
Windows alike.

Pelton now asks the desktop directly, using the launcher each platform provides:
`open` on macOS, `xdg-open` on Linux, `explorer` on Windows. On Linux that is
the portal shim inside a Flatpak sandbox, so the packaged build behaves the same
as the plain binary.

A path that is missing or cannot be opened now reports the reason instead of
leaving the button silent.
