### PR TITLE
fix: imported mailboxes never sync and never ask for a password

### DIFF
--- a/frontend/src/components/settings/ImportThunderbirdModal.svelte
+++ b/frontend/src/components/settings/ImportThunderbirdModal.svelte
@@ -30,6 +30,7 @@
   } from '../../lib/api'
   import { onImportProgress, type ImportProgressEvent } from '../../lib/events'
   import { loadSidebar } from '../../stores/accounts'
+  import { promptForMissingPasswords } from '../../stores/passwordprompt'
   import { toastError, toastSuccess, errorMessage } from '../../stores/toast'
   import { formatBytes } from '../../lib/format'
   import type { ThunderbirdProfile } from '../../lib/types'
@@ -180,6 +181,13 @@
       chosen = profiles.find((p) => p.path === chosen?.path) ?? chosen
       await loadSidebar()
       toastSuccess(`${created} ${get(t)('import.accountsAdded')}`)
+      // Thunderbird keeps its own passwords, so an imported mailbox arrives
+      // without one and cannot sync until it has one. Asking here, while the
+      // user is still setting up, is the difference between a mailbox that
+      // works and one that quietly never receives anything.
+      if (created > 0) {
+        await promptForMissingPasswords()
+      }
     } catch (err) {
       toastError(errorMessage(err))
     }

--- a/internal/desktop/app.go
+++ b/internal/desktop/app.go
@@ -66,6 +66,11 @@ type App struct {
 	// learn it is to try, and a restart tries again. See bind_account_manage.go.
 	rejectedLogins   map[int64]struct{}
 	rejectedLoginsMu sync.Mutex
+	// startAccount runs an account's first sync and parks it on idle. It is a
+	// field only so a test can watch which accounts an import starts without
+	// the call reaching a real server or the os keyring. nil means
+	// StartAccountSync, which is what the app always uses.
+	startAccount func(accountID int64) error
 	// startedAt is when the process came up, for the process overlay's uptime.
 	startedAt time.Time
 	// runtimeReady is set once wails has handed us its context in startup.

--- a/internal/desktop/bind_import.go
+++ b/internal/desktop/bind_import.go
@@ -148,6 +148,11 @@ func (a *App) toProfileDTOs(profiles []mailimport.Profile) ([]ThunderbirdProfile
 // already configured are skipped. Passwords are not importable, so each new
 // account needs its password entered once before it can sync; the returned
 // count is how many were created.
+//
+// Each account is started the same way the wizard starts one. Without that an
+// imported account was inert: it never opened an idle connection, and nothing
+// recorded that it could not log in, so it carried no marker and the mailbox
+// looked healthy while no mail ever arrived in it.
 func (a *App) ImportThunderbirdAccounts(profilePath string, emails []string) (int, error) {
 	if err := a.ready(); err != nil {
 		return 0, err
@@ -168,6 +173,7 @@ func (a *App) ImportThunderbirdAccounts(profilePath string, emails []string) (in
 	}
 
 	created := 0
+	var started []int64
 	for _, acc := range profile.Accounts {
 		key := strings.ToLower(acc.Email)
 		if !want[key] || have[key] || acc.Kind != "imap" {
@@ -182,13 +188,32 @@ func (a *App) ImportThunderbirdAccounts(profilePath string, emails []string) (in
 			SMTPHost:    acc.SMTPHost,
 			SMTPPort:    acc.SMTPPort,
 		}
-		if _, err := a.store.CreateAccount(a.ctx, &account); err != nil {
+		id, err := a.store.CreateAccount(a.ctx, &account)
+		if err != nil {
 			return created, err
 		}
 		have[key] = true
+		started = append(started, id)
 		created++
 	}
+	// started after the loop rather than inside it, so a failure halfway through
+	// does not leave half the accounts syncing while the error says nothing was
+	// imported.
+	for _, id := range started {
+		if err := a.startImportedAccount(id); err != nil {
+			a.log.Error("start imported mailbox", "account", id, "err", err)
+		}
+	}
 	return created, nil
+}
+
+// startImportedAccount starts one freshly imported account, through the
+// App.startAccount seam so a test can see which accounts were started.
+func (a *App) startImportedAccount(accountID int64) error {
+	if a.startAccount != nil {
+		return a.startAccount(accountID)
+	}
+	return a.StartAccountSync(accountID)
 }
 
 // ChooseMailFiles opens a file picker for messages and archives to import and

--- a/internal/desktop/bind_import_accounts_test.go
+++ b/internal/desktop/bind_import_accounts_test.go
@@ -1,0 +1,182 @@
+package desktop
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// prefsWithTwoImapAndOnePop3 is a minimal Thunderbird prefs.js: two imap
+// accounts that can be imported and a pop3 one that cannot.
+const prefsWithTwoImapAndOnePop3 = `// Mozilla User Preferences
+user_pref("mail.accountmanager.accounts", "account1,account2,account3");
+
+user_pref("mail.account.account1.server", "server1");
+user_pref("mail.account.account1.identities", "id1");
+user_pref("mail.server.server1.type", "imap");
+user_pref("mail.server.server1.hostname", "imap.one.test");
+user_pref("mail.server.server1.port", 993);
+user_pref("mail.server.server1.userName", "one-login");
+user_pref("mail.identity.id1.useremail", "one@example.test");
+user_pref("mail.identity.id1.fullName", "Account One");
+user_pref("mail.identity.id1.smtpServer", "smtp1");
+user_pref("mail.smtpserver.smtp1.hostname", "smtp.one.test");
+user_pref("mail.smtpserver.smtp1.port", 587);
+
+user_pref("mail.account.account2.server", "server2");
+user_pref("mail.account.account2.identities", "id2");
+user_pref("mail.server.server2.type", "imap");
+user_pref("mail.server.server2.hostname", "imap.two.test");
+user_pref("mail.server.server2.port", 993);
+user_pref("mail.identity.id2.useremail", "two@example.test");
+user_pref("mail.identity.id2.fullName", "Account Two");
+
+user_pref("mail.account.account3.server", "server3");
+user_pref("mail.account.account3.identities", "id3");
+user_pref("mail.server.server3.type", "pop3");
+user_pref("mail.server.server3.hostname", "pop.three.test");
+user_pref("mail.server.server3.port", 995);
+user_pref("mail.identity.id3.useremail", "three@example.test");
+`
+
+// importTestApp is an app with a real store and a stubbed account start, so an
+// import can be run without opening a connection or touching the os keyring.
+func importTestApp(t *testing.T) (*App, *[]int64) {
+	t.Helper()
+	a := newAccountTestApp(t)
+	var started []int64
+	a.startAccount = func(id int64) error {
+		started = append(started, id)
+		return nil
+	}
+	return a, &started
+}
+
+// thunderbirdProfile writes a profile directory holding the given prefs.js.
+func thunderbirdProfile(t *testing.T, prefs string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "prefs.js"), []byte(prefs), 0o600); err != nil {
+		t.Fatalf("write prefs.js: %v", err)
+	}
+	return dir
+}
+
+func accountIDsByEmail(t *testing.T, a *App) map[string]int64 {
+	t.Helper()
+	accounts, err := a.store.ListAccounts(a.ctx)
+	if err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	out := make(map[string]int64, len(accounts))
+	for _, acc := range accounts {
+		out[acc.Email] = acc.ID
+	}
+	return out
+}
+
+// The bug this guards: the import created the account rows and stopped there.
+// Nothing synced them and nothing parked them on idle, so they never recorded
+// that they could not log in, carried no warning marker, and received no mail
+// while looking perfectly healthy.
+func TestImportStartsEveryAccountItCreates(t *testing.T) {
+	a, started := importTestApp(t)
+	profile := thunderbirdProfile(t, prefsWithTwoImapAndOnePop3)
+
+	created, err := a.ImportThunderbirdAccounts(profile, []string{"one@example.test", "two@example.test"})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if created != 2 {
+		t.Fatalf("created = %d, want 2", created)
+	}
+
+	ids := accountIDsByEmail(t, a)
+	want := []int64{ids["one@example.test"], ids["two@example.test"]}
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+	got := append([]int64(nil), *started...)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+
+	if len(got) != len(want) {
+		t.Fatalf("started %v, want the %d imported accounts %v", got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("started %v, want %v", got, want)
+		}
+	}
+}
+
+// A pop3 account cannot be imported, so it must not be created and must not be
+// started either.
+func TestImportSkipsPop3(t *testing.T) {
+	a, started := importTestApp(t)
+	profile := thunderbirdProfile(t, prefsWithTwoImapAndOnePop3)
+
+	created, err := a.ImportThunderbirdAccounts(profile, []string{"three@example.test"})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("created = %d, want 0 for a pop3 account", created)
+	}
+	if len(*started) != 0 {
+		t.Fatalf("started %v, want nothing", *started)
+	}
+}
+
+// Importing the same profile twice must not start the accounts a second time:
+// they are already running, and a duplicate start would open a second login for
+// a mailbox that already has one.
+func TestImportDoesNotRestartAccountsItAlreadyHas(t *testing.T) {
+	a, started := importTestApp(t)
+	profile := thunderbirdProfile(t, prefsWithTwoImapAndOnePop3)
+	emails := []string{"one@example.test", "two@example.test"}
+
+	if _, err := a.ImportThunderbirdAccounts(profile, emails); err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	first := len(*started)
+
+	created, err := a.ImportThunderbirdAccounts(profile, emails)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if created != 0 {
+		t.Fatalf("second import created = %d, want 0", created)
+	}
+	if len(*started) != first {
+		t.Fatalf("second import started %d more accounts, want 0", len(*started)-first)
+	}
+}
+
+// The server settings have to survive the import, since not retyping six
+// servers is the point of it.
+func TestImportKeepsTheServerSettings(t *testing.T) {
+	a, _ := importTestApp(t)
+	profile := thunderbirdProfile(t, prefsWithTwoImapAndOnePop3)
+
+	if _, err := a.ImportThunderbirdAccounts(profile, []string{"one@example.test"}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	accounts, err := a.store.ListAccounts(a.ctx)
+	if err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("got %d accounts, want 1", len(accounts))
+	}
+	acc := accounts[0]
+	if acc.IMAPHost != "imap.one.test" || acc.IMAPPort != 993 {
+		t.Errorf("imap = %s:%d, want imap.one.test:993", acc.IMAPHost, acc.IMAPPort)
+	}
+	if acc.SMTPHost != "smtp.one.test" || acc.SMTPPort != 587 {
+		t.Errorf("smtp = %s:%d, want smtp.one.test:587", acc.SMTPHost, acc.SMTPPort)
+	}
+	// the login name differs from the address here, and logging in as the
+	// address would fail.
+	if acc.Username != "one-login" {
+		t.Errorf("username = %q, want one-login", acc.Username)
+	}
+}

--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -20,6 +20,29 @@ import (
 // not open competing logins for the same account at once.
 var syncMu sync.Mutex
 
+const (
+	// idleRetry is how long an idle loop waits after a connection it did not
+	// expect to lose.
+	idleRetry = 15 * time.Second
+	// idleNoCredentialsRetry is how long it waits when the account has no
+	// password. Longer, because nothing changes until the user types one.
+	idleNoCredentialsRetry = 60 * time.Second
+)
+
+// idleRetryWait says how long to wait before opening an account's idle
+// connection again.
+//
+// A missing password used to end the loop for good. That made a mailbox
+// unfixable without a restart: the user typed the password, the account still
+// received nothing, and only the next launch brought it back. Waiting is the
+// whole point, since a password can arrive at any moment.
+func idleRetryWait(err error) time.Duration {
+	if errors.Is(err, errNoCredentials) {
+		return idleNoCredentialsRetry
+	}
+	return idleRetry
+}
+
 // startBackgroundServices launches the outbox worker and the initial sync plus
 // per-account idle loops. Credentials come from the keyring (added by the
 // wizard) with an environment fallback for the legacy cli account.
@@ -116,11 +139,22 @@ func (a *App) runInitialSyncAndIdle() {
 		if account.Local {
 			continue
 		}
-		if err := a.syncAccount(account); err != nil && !errors.Is(err, errNoCredentials) {
-			a.log.Error("initial sync", "account", account.Email, "err", err)
+		if err := a.syncAccount(account); err != nil {
+			// a missing password is not an error to shout about, but dropping it
+			// without a word left the one case that needs explaining with no
+			// trace at all, even with file logging on.
+			if errors.Is(err, errNoCredentials) {
+				a.log.Warn("mailbox has no password, not syncing", "account", account.Email)
+			} else {
+				a.log.Error("initial sync", "account", account.Email, "err", err)
+			}
 		}
 		goSafe("waiting for new mail", func() { a.idleLoop(account) })
 	}
+	// the marks from this pass are pushed like any other run's. without it a
+	// mailbox that failed its first sync stayed unmarked until some later run
+	// happened to end, which for a mailbox with no password is never.
+	a.emitAccountSyncStates()
 	// contacts ride along with the mail sync (#168). It is one cheap request
 	// per address book when nothing changed, and it runs after the mail so a
 	// slow contacts server never delays the inbox.
@@ -341,14 +375,13 @@ func (a *App) idleLoop(account storage.Account) {
 	ctx := a.sessionCtx()
 	for ctx.Err() == nil {
 		if err := a.idleSession(ctx, account); err != nil && ctx.Err() == nil {
-			if errors.Is(err, errNoCredentials) {
-				return
+			if !errors.Is(err, errNoCredentials) {
+				a.log.Error("idle session", "account", account.Email, "err", err)
 			}
-			a.log.Error("idle session", "account", account.Email, "err", err)
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(15 * time.Second):
+			case <-time.After(idleRetryWait(err)):
 			}
 		}
 	}

--- a/internal/desktop/bind_sync_idle_test.go
+++ b/internal/desktop/bind_sync_idle_test.go
@@ -1,0 +1,40 @@
+package desktop
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+// The bug this guards: a missing password ended the idle loop for good. The
+// user typed the password, the mailbox still received nothing, and only the
+// next launch brought it back. Every error has to leave a wait behind, because
+// a password can arrive at any moment.
+func TestIdleRetryWaitAlwaysWaits(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"no password", errNoCredentials, "long"},
+		{"no password, wrapped", fmt.Errorf("idle: %w", errNoCredentials), "long"},
+		{"connection dropped", &net.OpError{Op: "read", Err: errors.New("reset by peer")}, "short"},
+		{"anything else", errors.New("imap: unexpected response"), "short"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := idleRetryWait(tt.err)
+			if got <= 0 {
+				t.Fatalf("idleRetryWait(%v) = %v, want a wait rather than giving up", tt.err, got)
+			}
+			// a missing password waits longer, since nothing changes until the
+			// user types one and each try reads the keyring.
+			if tt.want == "long" && got != idleNoCredentialsRetry {
+				t.Fatalf("idleRetryWait(%v) = %v, want %v", tt.err, got, idleNoCredentialsRetry)
+			}
+			if tt.want == "short" && got != idleRetry {
+				t.Fatalf("idleRetryWait(%v) = %v, want %v", tt.err, got, idleRetry)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A mailbox imported from Thunderbird received no mail, and nothing said why.

Thunderbird keeps its own passwords, so an imported mailbox arrives without
one and cannot log in until it has one. Pelton never asked for it. The import
finished with a "mailboxes added" message and stopped there, so the mailboxes
were never synced, never opened a connection, and never recorded that they
could not log in. Without a recorded failure they carried no warning marker
either, which left them looking healthy while nothing arrived in them. The only
mail on screen was the archive the import had copied across, ending on the day
the import was made.

Importing now starts each new mailbox the same way the setup wizard does, and
asks for the missing passwords right after the import while the mailboxes are
still being set up.

Two things had kept this from correcting itself. A mailbox with no password
gave up on its push connection for good, so entering the password did nothing
until the app was restarted; it now waits and picks the password up on its own.
And a mailbox that failed its very first sync stayed unmarked until some later
sync run happened to end, which for a mailbox with no password never came; the
marker is now placed from the first sync onward.
