### PR TITLE
fix: a folder that fails to sync is reported as a clean sync

### DIFF
--- a/internal/desktop/bind_sync.go
+++ b/internal/desktop/bind_sync.go
@@ -244,7 +244,10 @@ func (a *App) syncFolders(client *pimap.Client, accountID int64) error {
 	// synced makes the bar lie (#173).
 	folders := make([]storage.Folder, 0, len(all))
 	for _, f := range all {
-		if !f.SyncExcluded {
+		// a container the server marks \Noselect holds no mail and cannot be
+		// selected, so syncing one fails every single time. It is kept as a row
+		// because the tree needs it as a parent, but it is not synced.
+		if !f.SyncExcluded && folderSelectable(f) {
 			folders = append(folders, f)
 		}
 	}
@@ -253,12 +256,22 @@ func (a *App) syncFolders(client *pimap.Client, accountID int64) error {
 	a.syncTally.begin(len(folders))
 
 	newTotal := 0
+	// a folder that fails does not stop the others: mail the rest of the account
+	// can still fetch is worth having. But the failure is carried out of here,
+	// because reporting the account as synced when a folder did not sync is what
+	// makes a mailbox go quiet with nothing to show for it.
+	var failedFolders []string
+	var firstFolderErr error
 	for i, f := range folders {
 		a.syncTally.enterFolder(i, f.Name)
 		a.emitSyncProgress(accountID, email, client.Addr(), a.syncTally.counts())
 		res, err := engine.SyncFolder(a.ctx, f)
 		if err != nil {
 			a.log.Error("sync folder", "folder", f.Name, "err", err)
+			failedFolders = append(failedFolders, f.Name)
+			if firstFolderErr == nil {
+				firstFolderErr = err
+			}
 			continue
 		}
 		if res.New > 0 {
@@ -285,7 +298,24 @@ func (a *App) syncFolders(client *pimap.Client, accountID int64) error {
 			goSafe("collecting addresses", a.harvestAddressBook)
 		}
 	}
-	return nil
+	return folderSyncError(failedFolders, len(folders), firstFolderErr)
+}
+
+// folderSyncError turns the folders that failed in one run into the error the
+// account's sync outcome records, or nil when they all got through.
+//
+// The first failure is wrapped rather than described, so the reason survives:
+// the ui classifies a sync failure by what the error is, and the detail dialog
+// shows the server's own words.
+func folderSyncError(failed []string, total int, first error) error {
+	if first == nil {
+		return nil
+	}
+	if len(failed) == 1 {
+		return fmt.Errorf("sync folder %q: %w", failed[0], first)
+	}
+	return fmt.Errorf("%d of %d folders failed to sync, starting with %q: %w",
+		len(failed), total, failed[0], first)
 }
 
 // findInboxFolder returns the account's INBOX folder row. IMAP's INBOX is a

--- a/internal/desktop/bind_sync_folders_test.go
+++ b/internal/desktop/bind_sync_folders_test.go
@@ -1,0 +1,89 @@
+package desktop
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	pimap "github.com/TRC-Loop/Pelton/internal/imap"
+	"github.com/TRC-Loop/Pelton/internal/storage"
+)
+
+// The bug this guards: a folder that failed to sync was logged and skipped, and
+// the account was then recorded as a clean sync. The mailbox stopped receiving
+// mail, no marker appeared, and the refresh button reported success, so there
+// was nothing anywhere to say what had gone wrong.
+func TestFolderSyncErrorCarriesTheFailureOut(t *testing.T) {
+	if err := folderSyncError(nil, 4, nil); err != nil {
+		t.Fatalf("folderSyncError with no failures = %v, want nil", err)
+	}
+
+	one := folderSyncError([]string{"INBOX"}, 4, errors.New("no mailbox selected"))
+	if one == nil {
+		t.Fatal("a failed folder produced no error, so the account would be recorded as synced")
+	}
+
+	many := folderSyncError([]string{"INBOX", "Sent"}, 4, errors.New("no mailbox selected"))
+	if many == nil {
+		t.Fatal("two failed folders produced no error")
+	}
+}
+
+// The reason has to survive being wrapped, since the ui classifies a failure by
+// what the error is and shows the server's own words in the detail dialog.
+func TestFolderSyncErrorKeepsTheReason(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		failed []string
+		err    error
+		want   string
+	}{
+		{"one folder", []string{"INBOX"}, pimap.ErrAuthFailed, syncFailAuth},
+		{"several folders", []string{"INBOX", "Sent"}, pimap.ErrAuthFailed, syncFailAuth},
+		{"wrapped further down", []string{"INBOX"}, fmt.Errorf("select: %w", pimap.ErrAuthFailed), syncFailAuth},
+		{"anything else", []string{"INBOX"}, errors.New("no mailbox selected"), syncFailOther},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := folderSyncError(tt.failed, 4, tt.err)
+			if got := syncFailureReason(err); got != tt.want {
+				t.Fatalf("syncFailureReason(%v) = %q, want %q", err, got, tt.want)
+			}
+		})
+	}
+}
+
+// The folder that failed has to be named, otherwise the detail dialog says a
+// sync failed without saying where.
+func TestFolderSyncErrorNamesTheFolder(t *testing.T) {
+	err := folderSyncError([]string{"Archive"}, 4, errors.New("select refused"))
+	got := err.Error()
+	if !strings.Contains(got, "Archive") || !strings.Contains(got, "select refused") {
+		t.Fatalf("error = %q, want it to name the folder and the reason", got)
+	}
+}
+
+// A \Noselect folder is a container in the hierarchy, not a mailbox. Syncing
+// one fails every time, so with failures now reported it would mark a perfectly
+// healthy account as broken on every run.
+func TestFolderSelectable(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		attrs []string
+		want  bool
+	}{
+		{"an ordinary folder", nil, true},
+		{"a folder with a role", []string{"\\Sent"}, true},
+		{"a container", []string{"\\Noselect"}, false},
+		{"a container, other case", []string{"\\NoSelect"}, false},
+		{"gone from the server", []string{"\\NonExistent"}, false},
+		{"a container that also has children", []string{"\\HasChildren", "\\Noselect"}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := storage.Folder{Name: "x", Attributes: tt.attrs}
+			if got := folderSelectable(f); got != tt.want {
+				t.Fatalf("folderSelectable(%v) = %v, want %v", tt.attrs, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/desktop/dto.go
+++ b/internal/desktop/dto.go
@@ -303,6 +303,19 @@ func toFolderDTO(f storage.Folder) FolderDTO {
 // mail cached but invisible to the unified views, and no list of localized or
 // provider-specific names would ever be complete. The manual override is the
 // escape hatch that does not depend on guessing (#186).
+// folderSelectable reports whether a folder can be opened on the server. A
+// \Noselect (or \NonExistent) folder is a container in the hierarchy, not a
+// mailbox: SELECT on one is refused, so sync has to leave it alone.
+func folderSelectable(f storage.Folder) bool {
+	for _, attr := range f.Attributes {
+		switch strings.ToLower(strings.TrimPrefix(attr, "\\")) {
+		case "noselect", "nonexistent":
+			return false
+		}
+	}
+	return true
+}
+
 func folderRole(f storage.Folder) string {
 	if role := f.RoleOverride; role != "" && validFolderRole(role) {
 		return role


### PR DESCRIPTION
A mailbox could stop receiving mail while Pelton reported everything as fine.

A folder that failed to sync was logged and skipped, and the account was then
recorded as a successful sync. No warning marker appeared next to the mailbox,
the refresh button reported success, and the only trace was a line in a log
file that is not written unless logging has been turned on. A mailbox whose
inbox failed on every run therefore went quiet with nothing anywhere to say
why.

A folder that fails still does not stop the others, so mail the rest of the
account can fetch still arrives. The failure is now carried out to the account,
which puts the warning marker in the sidebar and names the folder and the
server's reason in the failure dialog.

Folders the server marks as containers rather than mailboxes are no longer
synced. They cannot be opened, so syncing one failed on every run; it cost a
round trip per sync and, with failures now reported, would have marked a
healthy account as broken.
