### PR TITLE
fix: saving a keyword search as a view leaves the name blank

### DIFF
--- a/frontend/src/components/list/SearchBar.svelte
+++ b/frontend/src/components/list/SearchBar.svelte
@@ -220,13 +220,28 @@
 
   $: hasContent = text !== '' || chips.length > 0
 
+  // viewName is what the new view is called before the user renames it.
+  //
+  // A keyword token becomes a chip as soon as it is typed, which leaves the text
+  // box empty: searching "from:bob" and pressing save gave the editor a blank
+  // name, and a view cannot be saved without one. The save button was then
+  // greyed out with nothing on screen saying why. The chips describe the search
+  // just as well, so they name it.
+  function viewName(): string {
+    const typed = text.trim()
+    if (typed !== '') {
+      return typed
+    }
+    return chips.map(chipText).join(' ')
+  }
+
   // saveAsView opens the view editor seeded from the current query and chips, so
   // a search the user just ran becomes a saved View. The relative date window is
   // left for the editor since the chips carry absolute dates.
   function saveAsView(): void {
     const f = buildFilter()
     openViewEditor({
-      name: text.trim(),
+      name: viewName(),
       queryText: text.trim(),
       queryFrom: f.from ? [f.from] : [],
       queryTo: f.to ? [f.to] : [],


### PR DESCRIPTION
Saving a keyword search as a View opened the editor with an empty name and the
save button greyed out, with nothing on screen saying why.

A keyword token becomes a chip as soon as it is typed, which empties the search
box. Searching for `from:bob` therefore left no text to name the view with, and
a view cannot be saved without a name. A plain text search was unaffected,
since its text became the name, so the button appeared to work only sometimes.

The chips describe the search just as well, so a search made only of them now
names its view: `from:bob` becomes a view called "From: bob", ready to rename.

Relates to #370.
